### PR TITLE
feat(traces): add HALO-style span tracing for harness optimization

### DIFF
--- a/agent/llm/router.py
+++ b/agent/llm/router.py
@@ -13,6 +13,7 @@ import os
 from openai import OpenAI
 
 from ..config import agent_config
+from ..traces import SpanKind, tracer
 
 
 class ModelTier(str, Enum):
@@ -104,6 +105,8 @@ class LLMRouter:
         system: Optional[str] = None,
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        prompt_name: Optional[str] = None,
+        prompt_version: Optional[str] = None,
         **kwargs
     ) -> str:
         """
@@ -116,6 +119,8 @@ class LLMRouter:
             system: System prompt
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
+            prompt_name: Identifier for the prompt template (for HALO).
+            prompt_version: Optional version tag for the prompt template.
 
         Returns:
             Generated text response
@@ -134,15 +139,41 @@ class LLMRouter:
             messages.append({"role": "system", "content": system})
         messages.append({"role": "user", "content": prompt})
 
-        # Make API call via OpenRouter
-        response = self.client.chat.completions.create(
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            messages=messages
-        )
+        async with tracer.span(
+            f"llm.complete:{prompt_name or task_type or 'unnamed'}",
+            kind=SpanKind.LLM,
+            inputs={
+                "model": model,
+                "task_type": task_type,
+                "prompt_name": prompt_name,
+                "prompt_version": prompt_version,
+                "prompt_chars": len(prompt),
+                "system_chars": len(system) if system else 0,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            },
+        ) as span:
+            response = self.client.chat.completions.create(
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                messages=messages,
+            )
 
-        return response.choices[0].message.content
+            content = response.choices[0].message.content
+            usage = getattr(response, "usage", None)
+            input_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
+            output_tokens = getattr(usage, "completion_tokens", 0) if usage else 0
+
+            span.add_attributes(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=getattr(usage, "total_tokens", input_tokens + output_tokens) if usage else None,
+                estimated_cost_usd=self.estimate_cost(input_tokens, output_tokens, model=model),
+                finish_reason=getattr(response.choices[0], "finish_reason", None),
+            )
+            span.set_output(content)
+            return content
 
     async def chat(
         self,
@@ -152,6 +183,8 @@ class LLMRouter:
         system: Optional[str] = None,
         max_tokens: int = 4096,
         temperature: float = 0.7,
+        prompt_name: Optional[str] = None,
+        prompt_version: Optional[str] = None,
         **kwargs
     ) -> str:
         """
@@ -164,6 +197,8 @@ class LLMRouter:
             system: System prompt
             max_tokens: Maximum tokens to generate
             temperature: Sampling temperature
+            prompt_name: Identifier for the prompt template (for HALO).
+            prompt_version: Optional version tag for the prompt template.
 
         Returns:
             Assistant's response
@@ -182,15 +217,40 @@ class LLMRouter:
             full_messages.append({"role": "system", "content": system})
         full_messages.extend(messages)
 
-        # Make API call
-        response = self.client.chat.completions.create(
-            model=model,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            messages=full_messages
-        )
+        async with tracer.span(
+            f"llm.chat:{prompt_name or task_type or 'unnamed'}",
+            kind=SpanKind.LLM,
+            inputs={
+                "model": model,
+                "task_type": task_type,
+                "prompt_name": prompt_name,
+                "prompt_version": prompt_version,
+                "message_count": len(messages),
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            },
+        ) as span:
+            response = self.client.chat.completions.create(
+                model=model,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                messages=full_messages,
+            )
 
-        return response.choices[0].message.content
+            content = response.choices[0].message.content
+            usage = getattr(response, "usage", None)
+            input_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
+            output_tokens = getattr(usage, "completion_tokens", 0) if usage else 0
+
+            span.add_attributes(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=getattr(usage, "total_tokens", input_tokens + output_tokens) if usage else None,
+                estimated_cost_usd=self.estimate_cost(input_tokens, output_tokens, model=model),
+                finish_reason=getattr(response.choices[0], "finish_reason", None),
+            )
+            span.set_output(content)
+            return content
 
     def estimate_cost(
         self,

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -17,6 +17,7 @@ from .config import agent_config
 from .models import TaskExecution, TaskStatus, agent_db
 from .scheduler import scheduler
 from .state import state_manager
+from .traces import SpanKind, SpanStatus, tracer
 
 
 class AgentLoop:
@@ -112,14 +113,21 @@ class AgentLoop:
             return
 
         # Check for due tasks
-        due_tasks = scheduler.get_due_tasks()
+        async with tracer.span(
+            "scheduler.tick",
+            kind=SpanKind.SCHEDULER,
+        ) as scheduler_span:
+            due_tasks = scheduler.get_due_tasks()
+            running_count = len(state_manager.get_running_tasks())
+            available_slots = agent_config.max_concurrent_tasks - running_count
+            scheduler_span.add_attributes(
+                due_count=len(due_tasks),
+                running_count=running_count,
+                available_slots=max(available_slots, 0),
+            )
+
         if not due_tasks:
             return
-
-        # Get currently running task count
-        running_count = len(state_manager.get_running_tasks())
-        available_slots = agent_config.max_concurrent_tasks - running_count
-
         if available_slots <= 0:
             return
 
@@ -153,47 +161,80 @@ class AgentLoop:
         )
         agent_db.create_execution(execution)
 
-        try:
-            # Get the task handler
-            handler = get_task_handler(task.task_type)
-            if handler is None:
-                raise ValueError(f"Unknown task type: {task.task_type}")
+        async with tracer.trace(
+            task_id=task.task_type,
+            execution_id=execution_id,
+            client=task.client,
+            root_span_name=f"task:{task.task_type}",
+            root_span_kind=SpanKind.TASK,
+            inputs={
+                "scheduled_task_id": task.id,
+                "name": task.name,
+                "cron": task.cron_expression,
+                "config_extra": task.config.extra,
+            },
+        ) as trace_handle:
+            try:
+                # Get the task handler
+                handler = get_task_handler(task.task_type)
+                if handler is None:
+                    raise ValueError(f"Unknown task type: {task.task_type}")
 
-            # Execute with timeout
-            timeout = task.config.timeout or agent_config.task_timeout
-            result = await asyncio.wait_for(
-                handler.execute(task),
-                timeout=timeout
-            )
+                # Execute with timeout
+                timeout = task.config.timeout or agent_config.task_timeout
+                async with tracer.span(
+                    "task.execute",
+                    kind=SpanKind.TASK,
+                    inputs={"timeout_s": timeout},
+                ) as exec_span:
+                    result = await asyncio.wait_for(
+                        handler.execute(task),
+                        timeout=timeout,
+                    )
+                    exec_span.set_output(result)
+                    exec_span.add_attributes(
+                        success=bool(result and result.get("success", True)),
+                    )
 
-            # Success
-            agent_db.update_execution(
-                execution_id,
-                status=TaskStatus.COMPLETED,
-                completed_at=datetime.utcnow(),
-                result=result or {}
-            )
-            state_manager.increment_stat("tasks_completed")
+                # Success
+                agent_db.update_execution(
+                    execution_id,
+                    status=TaskStatus.COMPLETED,
+                    completed_at=datetime.utcnow(),
+                    result=result or {}
+                )
+                state_manager.increment_stat("tasks_completed")
 
-            print(f"[{datetime.now()}] Task completed: {task.name}")
+                print(f"[{datetime.now()}] Task completed: {task.name}")
 
-            # Send notification if configured
-            if task.config.notify_on_complete:
-                await self._notify_completion(task, result)
+                # Send notification if configured
+                if task.config.notify_on_complete:
+                    async with tracer.span(
+                        "notification.send",
+                        kind=SpanKind.NOTIFICATION,
+                        inputs={"reason": "complete"},
+                    ):
+                        await self._notify_completion(task, result)
 
-        except asyncio.TimeoutError:
-            error = f"Task timed out after {timeout}s"
-            print(f"[{datetime.now()}] Task timeout: {task.name}")
-            await self._handle_task_failure(task, execution_id, error)
+            except asyncio.TimeoutError:
+                error = f"Task timed out after {timeout}s"
+                print(f"[{datetime.now()}] Task timeout: {task.name}")
+                async with tracer.span(
+                    "task.timeout",
+                    kind=SpanKind.RETRY,
+                    attributes={"timeout_s": timeout},
+                ) as timeout_span:
+                    timeout_span.set_status(SpanStatus.TIMEOUT)
+                await self._handle_task_failure(task, execution_id, error)
 
-        except Exception as e:
-            error = str(e)
-            print(f"[{datetime.now()}] Task failed: {task.name} - {error}")
-            traceback.print_exc()
-            await self._handle_task_failure(task, execution_id, error)
+            except Exception as e:
+                error = str(e)
+                print(f"[{datetime.now()}] Task failed: {task.name} - {error}")
+                traceback.print_exc()
+                await self._handle_task_failure(task, execution_id, error)
 
-        finally:
-            state_manager.remove_running_task(task.id)
+            finally:
+                state_manager.remove_running_task(task.id)
 
     async def _handle_task_failure(self, task, execution_id: str, error: str):
         """Handle a task failure with retry logic."""

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -379,6 +379,17 @@ class Scheduler:
                 "task_type": "connector_health_check",
                 "config": {"notify_on_complete": True}
             },
+            # HALO-style weekly harness review
+            {
+                "name": "Weekly Harness Review",
+                "cron_expression": "0 10 * * 1",  # 10 AM Mondays
+                "task_type": "harness_review",
+                "config": {
+                    "model": "opus",
+                    "notify_on_complete": True,
+                    "extra": {"window_days": 7},
+                },
+            },
         ]
 
         existing_tasks = {t.name for t in self.db.list_scheduled_tasks(enabled_only=False)}

--- a/agent/tasks/__init__.py
+++ b/agent/tasks/__init__.py
@@ -23,6 +23,7 @@ from .weekly_report import WeeklyReportTask
 from .creative_assets import CreativeAssetsTask
 from .social_staleness import SocialStalenessTask
 from .claude_agent import ClaudeAgentTask
+from .harness_review import HarnessReviewTask
 
 # Task type to handler mapping (generic handlers only)
 TASK_HANDLERS: dict[str, type[BaseTask]] = {
@@ -43,6 +44,8 @@ TASK_HANDLERS: dict[str, type[BaseTask]] = {
     "claude_seo": ClaudeAgentTask,
     "claude_ads": ClaudeAgentTask,
     "claude_competitors": ClaudeAgentTask,
+    # HALO-style harness review
+    "harness_review": HarnessReviewTask,
 }
 
 
@@ -86,6 +89,7 @@ __all__ = [
     "CreativeAssetsTask",
     "SocialStalenessTask",
     "ClaudeAgentTask",
+    "HarnessReviewTask",
     "register_task",
     "get_task_handler",
 ]

--- a/agent/tasks/harness_review.py
+++ b/agent/tasks/harness_review.py
@@ -1,0 +1,84 @@
+"""
+Weekly HALO-style harness review.
+
+Aggregates trace data from the last 7 days, asks an LLM to propose
+concrete harness improvements, and writes the result to
+`workspace/harness-reviews/` so changes can be cherry-picked.
+
+Add to the scheduler with task_type="harness_review".
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ..models import ScheduledTask
+from ..traces.diagnose import diagnose
+from .base import BaseTask
+
+
+class HarnessReviewTask(BaseTask):
+    """Recurring harness review task driven by the trace store."""
+
+    @property
+    def task_type(self) -> str:
+        return "harness_review"
+
+    @property
+    def description(self) -> str:
+        return "Diagnose recent trace activity and propose harness improvements"
+
+    async def execute(
+        self,
+        task: ScheduledTask,
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        days = int(task.config.extra.get("window_days", 7))
+        since = datetime.utcnow() - timedelta(days=days)
+        prompt = task.config.extra.get("prompt") or (
+            "Find recurring task failures, weak prompt/tool boundaries, missing "
+            "context, notification spam, and scheduler issues. Suggest concrete "
+            "harness changes. Cite the task or span by name."
+        )
+
+        report = await diagnose(
+            since=since,
+            until=None,
+            task_id=task.config.extra.get("task_id"),
+            client=task.client,
+            prompt=prompt,
+            use_llm=True,
+        )
+
+        review_dir = Path(__file__).parent.parent.parent / "workspace" / "harness-reviews"
+        review_dir.mkdir(parents=True, exist_ok=True)
+        date_str = datetime.utcnow().strftime("%Y-%m-%d")
+        suffix = f"-{task.client}" if task.client else ""
+        review_path = review_dir / f"harness-review-{date_str}{suffix}.md"
+        review_path.write_text(
+            f"# Harness review — {date_str} (last {days}d)\n\n{report}"
+        )
+
+        # Build a short summary for notifications.
+        summary_lines = []
+        for line in report.splitlines():
+            if line.startswith("## HALO suggestions"):
+                continue
+            if line.strip().startswith(("- ", "* ", "1.", "2.", "3.")):
+                summary_lines.append(line.strip())
+            if len(summary_lines) >= 5:
+                break
+
+        return {
+            "success": True,
+            "summary": (
+                f"Harness review ({days}d) saved to {review_path.name}.\n"
+                + "\n".join(summary_lines[:5])
+            ),
+            "data": {
+                "report_path": str(review_path),
+                "window_days": days,
+            },
+        }

--- a/agent/traces/__init__.py
+++ b/agent/traces/__init__.py
@@ -1,0 +1,43 @@
+"""
+HALO-style structured tracing for the CMO harness.
+
+Provides span-level capture across scheduler decisions, task execution,
+LLM calls, external API fetches, transforms, synthesis, and notifications.
+The resulting trace store powers HALO-style diagnosis loops that surface
+recurring failures, weak prompt/tool boundaries, low-signal outputs, and
+noisy alerts so the harness can be improved over time.
+
+Usage:
+
+    from agent.traces import tracer, SpanKind
+
+    async with tracer.trace(task_id="weekly_report", client="kaicalls") as t:
+        async with t.span("fetch_metrics", kind=SpanKind.EXTERNAL_API):
+            ...
+
+Trace data is persisted to the agent SQLite database in `task_spans` and
+can be exported as HALO-compatible JSONL with:
+
+    python -m agent.traces.export --since 7d > traces/cmo_traces.jsonl
+"""
+
+from .models import (
+    QualityLabel,
+    SpanKind,
+    SpanStatus,
+    TraceSpan,
+    trace_store,
+)
+from .tracer import Span, Tracer, current_trace_id, tracer
+
+__all__ = [
+    "QualityLabel",
+    "Span",
+    "SpanKind",
+    "SpanStatus",
+    "TraceSpan",
+    "Tracer",
+    "current_trace_id",
+    "trace_store",
+    "tracer",
+]

--- a/agent/traces/diagnose.py
+++ b/agent/traces/diagnose.py
@@ -1,0 +1,270 @@
+"""
+HALO-style trace diagnosis runner.
+
+Builds a structured digest of recent trace activity (failures, retries,
+LLM token usage, scheduler health, notification volume) and asks an
+LLM to surface concrete harness improvements.
+
+Usage:
+
+    python -m agent.traces.diagnose --since 7d
+    python -m agent.traces.diagnose --since 7d --task-id weekly_report \\
+        --prompt "Analyze why weekly business reports are low-signal."
+
+Output is markdown-formatted: digest first, then LLM-suggested actions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+
+from .export import parse_since
+from .models import QualityLabel, SpanKind, SpanStatus, TraceSpan, trace_store
+
+
+DEFAULT_PROMPT = (
+    "Find recurring task failures, weak prompt/tool boundaries, missing context, "
+    "notification spam, and scheduler issues. Suggest concrete harness changes."
+)
+
+
+def build_digest(spans: List[TraceSpan]) -> Dict[str, Any]:
+    """
+    Aggregate spans into a compact digest suitable for an LLM prompt.
+
+    Keeps cardinality bounded so the digest stays small even over wide
+    windows (e.g. 7d of every-5-min tasks).
+    """
+    if not spans:
+        return {"window": "empty", "span_count": 0}
+
+    # Group spans by trace.
+    traces: Dict[str, List[TraceSpan]] = defaultdict(list)
+    for span in spans:
+        traces[span.trace_id].append(span)
+
+    # Per-task aggregates.
+    task_stats: Dict[str, Dict[str, Any]] = defaultdict(lambda: {
+        "executions": 0,
+        "errors": 0,
+        "timeouts": 0,
+        "total_duration_ms": 0,
+        "llm_calls": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "estimated_cost_usd": 0.0,
+        "notifications": 0,
+        "external_errors": Counter(),
+        "error_signatures": Counter(),
+    })
+
+    notification_volume = 0
+    scheduler_decisions = 0
+
+    for trace_id, group in traces.items():
+        # Find the root span for the trace (kind=task, no parent).
+        root = next(
+            (s for s in group if s.kind == SpanKind.TASK and not s.parent_span_id),
+            group[0],
+        )
+        task_id = root.task_id or root.name
+        stats = task_stats[task_id]
+        stats["executions"] += 1
+        if root.status == SpanStatus.ERROR:
+            stats["errors"] += 1
+            sig = (root.error or "").split("\n", 1)[0][:160]
+            if sig:
+                stats["error_signatures"][sig] += 1
+
+        for span in group:
+            if span.duration_ms:
+                stats["total_duration_ms"] += span.duration_ms
+
+            if span.kind == SpanKind.LLM:
+                stats["llm_calls"] += 1
+                stats["input_tokens"] += int(span.attributes.get("input_tokens") or 0)
+                stats["output_tokens"] += int(span.attributes.get("output_tokens") or 0)
+                cost = span.attributes.get("estimated_cost_usd")
+                if isinstance(cost, (int, float)):
+                    stats["estimated_cost_usd"] += float(cost)
+
+            if span.kind == SpanKind.NOTIFICATION:
+                stats["notifications"] += 1
+                notification_volume += 1
+
+            if span.kind == SpanKind.SCHEDULER:
+                scheduler_decisions += 1
+
+            if span.kind == SpanKind.EXTERNAL_API and span.status == SpanStatus.ERROR:
+                endpoint = span.inputs.get("endpoint") or span.name
+                stats["external_errors"][str(endpoint)] += 1
+
+            if span.status == SpanStatus.TIMEOUT:
+                stats["timeouts"] += 1
+
+    # Convert counters to top-N lists for compact serialization.
+    digest_tasks: Dict[str, Any] = {}
+    for task_id, stats in task_stats.items():
+        digest_tasks[task_id] = {
+            "executions": stats["executions"],
+            "errors": stats["errors"],
+            "timeouts": stats["timeouts"],
+            "error_rate": (
+                round(stats["errors"] / stats["executions"], 3)
+                if stats["executions"]
+                else 0.0
+            ),
+            "avg_duration_ms": (
+                int(stats["total_duration_ms"] / stats["executions"])
+                if stats["executions"]
+                else 0
+            ),
+            "llm_calls": stats["llm_calls"],
+            "input_tokens": stats["input_tokens"],
+            "output_tokens": stats["output_tokens"],
+            "estimated_cost_usd": round(stats["estimated_cost_usd"], 4),
+            "notifications": stats["notifications"],
+            "top_external_errors": stats["external_errors"].most_common(5),
+            "top_error_signatures": stats["error_signatures"].most_common(5),
+        }
+
+    # Quality-label rollup so HALO can prefer "useful" patterns.
+    quality_rollup: Counter = Counter()
+    for trace_id in traces.keys():
+        for q in trace_store.get_quality(trace_id):
+            quality_rollup[q["label"]] += 1
+
+    return {
+        "span_count": len(spans),
+        "trace_count": len(traces),
+        "scheduler_decisions": scheduler_decisions,
+        "notification_volume": notification_volume,
+        "tasks": digest_tasks,
+        "quality_labels": dict(quality_rollup),
+    }
+
+
+def render_digest_markdown(digest: Dict[str, Any]) -> str:
+    if digest.get("span_count", 0) == 0:
+        return "_No spans found in the requested window._\n"
+
+    lines: List[str] = []
+    lines.append(f"- spans: **{digest['span_count']}**, traces: **{digest['trace_count']}**")
+    lines.append(f"- scheduler decisions: {digest['scheduler_decisions']}")
+    lines.append(f"- notifications sent: {digest['notification_volume']}")
+    if digest.get("quality_labels"):
+        labels = ", ".join(f"{k}: {v}" for k, v in digest["quality_labels"].items())
+        lines.append(f"- quality labels: {labels}")
+    lines.append("")
+    lines.append("| task | runs | errors | timeouts | err_rate | avg_ms | llm_calls | tokens (in/out) | cost $ |")
+    lines.append("| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: |")
+    for task_id, t in sorted(digest["tasks"].items()):
+        lines.append(
+            f"| {task_id} | {t['executions']} | {t['errors']} | {t['timeouts']} | "
+            f"{t['error_rate']} | {t['avg_duration_ms']} | {t['llm_calls']} | "
+            f"{t['input_tokens']}/{t['output_tokens']} | {t['estimated_cost_usd']} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+async def diagnose(
+    *,
+    since: Optional[datetime],
+    until: Optional[datetime],
+    task_id: Optional[str],
+    client: Optional[str],
+    prompt: str,
+    use_llm: bool,
+) -> str:
+    spans = trace_store.list_spans(
+        since=since, until=until, task_id=task_id, client=client
+    )
+    digest = build_digest(spans)
+    digest_md = render_digest_markdown(digest)
+
+    if not use_llm or digest.get("span_count", 0) == 0:
+        return f"## Trace digest\n{digest_md}"
+
+    # Lazy import to avoid pulling OpenRouter into pure-export usage.
+    from ..llm import llm_router
+
+    system = (
+        "You are HALO, a harness optimization assistant. You read trace digests "
+        "from the CMO marketing agent and produce a punch list of concrete harness "
+        "changes. Each suggestion must be actionable: name the task, span, or "
+        "prompt; say what to change; and explain why. Do not speculate beyond what "
+        "the digest supports."
+    )
+
+    body = (
+        f"{prompt}\n\n"
+        f"## Trace digest\n{digest_md}\n"
+        f"## Raw digest JSON (for reference)\n```json\n"
+        f"{json.dumps(digest, default=str, indent=2)}\n```"
+    )
+
+    suggestions = await llm_router.complete(
+        prompt=body,
+        system=system,
+        task_type="weekly_report",
+        prompt_name="halo_diagnose",
+        prompt_version="v1",
+        max_tokens=2048,
+        temperature=0.2,
+    )
+
+    return (
+        f"## Trace digest\n{digest_md}\n"
+        f"## HALO suggestions\n{suggestions}\n"
+    )
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="agent.traces.diagnose",
+        description="Run HALO-style diagnosis over recent trace spans.",
+    )
+    parser.add_argument("--since", default="7d", help="Window start (e.g. 7d).")
+    parser.add_argument("--until", default=None)
+    parser.add_argument("--task-id", default=None)
+    parser.add_argument("--client", default=None)
+    parser.add_argument(
+        "--prompt",
+        default=DEFAULT_PROMPT,
+        help="Diagnosis prompt to send to HALO.",
+    )
+    parser.add_argument(
+        "--no-llm",
+        action="store_true",
+        help="Print the digest only, skip the LLM step.",
+    )
+
+    args = parser.parse_args(argv)
+
+    since = parse_since(args.since)
+    until = parse_since(args.until) if args.until else None
+
+    output = asyncio.run(
+        diagnose(
+            since=since,
+            until=until,
+            task_id=args.task_id,
+            client=args.client,
+            prompt=args.prompt,
+            use_llm=not args.no_llm,
+        )
+    )
+    sys.stdout.write(output)
+    if not output.endswith("\n"):
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent/traces/export.py
+++ b/agent/traces/export.py
@@ -1,0 +1,133 @@
+"""
+Export trace spans as HALO-compatible JSONL.
+
+Usage:
+
+    python -m agent.traces.export --since 7d > traces/cmo_traces.jsonl
+    python -m agent.traces.export --since 24h --task-id weekly_report
+    python -m agent.traces.export --client kai-calls --status error
+
+The output is one JSON object per line: each row is a single span,
+fully self-describing with trace_id/parent_span_id so HALO can
+reconstruct the trace tree without an additional schema.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from .models import SpanStatus, trace_store
+
+
+_DURATION_RE = re.compile(r"^(?P<num>\d+)(?P<unit>[smhd])$")
+
+
+def parse_since(value: Optional[str]) -> Optional[datetime]:
+    """
+    Accept "7d", "24h", "30m", "120s", or an ISO timestamp.
+    """
+    if not value:
+        return None
+    m = _DURATION_RE.match(value.strip())
+    if m:
+        num = int(m.group("num"))
+        unit = m.group("unit")
+        delta = {
+            "s": timedelta(seconds=num),
+            "m": timedelta(minutes=num),
+            "h": timedelta(hours=num),
+            "d": timedelta(days=num),
+        }[unit]
+        return datetime.utcnow() - delta
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise SystemExit(f"Invalid --since value: {value!r} ({exc})")
+
+
+def _emit(rows, out) -> int:
+    count = 0
+    for span in rows:
+        out.write(json.dumps(span.to_halo_dict(), default=str))
+        out.write("\n")
+        count += 1
+    return count
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="agent.traces.export",
+        description="Export CMO harness trace spans as HALO-compatible JSONL.",
+    )
+    parser.add_argument(
+        "--since",
+        default="7d",
+        help="Window start. Duration like 7d/24h/30m/120s, or ISO timestamp. Default: 7d.",
+    )
+    parser.add_argument(
+        "--until",
+        default=None,
+        help="Optional window end (ISO timestamp). Default: now.",
+    )
+    parser.add_argument(
+        "--task-id",
+        default=None,
+        help="Filter by task_id (e.g. weekly_report).",
+    )
+    parser.add_argument(
+        "--client",
+        default=None,
+        help="Filter by client (e.g. kai-calls).",
+    )
+    parser.add_argument(
+        "--status",
+        default=None,
+        choices=[s.value for s in SpanStatus],
+        help="Filter by span status.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Limit total spans emitted.",
+    )
+    parser.add_argument(
+        "--out",
+        default="-",
+        help="Output path. Default: stdout (-).",
+    )
+
+    args = parser.parse_args(argv)
+
+    since = parse_since(args.since)
+    until = parse_since(args.until) if args.until else None
+
+    spans = trace_store.list_spans(
+        since=since,
+        until=until,
+        task_id=args.task_id,
+        client=args.client,
+        status=SpanStatus(args.status) if args.status else None,
+        limit=args.limit,
+    )
+
+    if args.out == "-":
+        count = _emit(spans, sys.stdout)
+    else:
+        path = Path(args.out)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w") as out:
+            count = _emit(spans, out)
+
+    print(f"[traces] exported {count} spans", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent/traces/models.py
+++ b/agent/traces/models.py
@@ -1,0 +1,345 @@
+"""
+Trace span model and SQLite-backed trace store.
+
+A trace is the full execution of one scheduled task; spans are the
+individual operations inside it (scheduler decisions, external API
+fetches, LLM calls, transforms, synthesis, notifications, retries).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timedelta
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from pydantic import BaseModel, Field
+
+from ..config import agent_config
+
+
+class SpanKind(str, Enum):
+    """The kind of operation a span represents."""
+
+    SCHEDULER = "scheduler"
+    TASK = "task"
+    EXTERNAL_API = "external_api"
+    LLM = "llm"
+    TRANSFORM = "transform"
+    SYNTHESIS = "synthesis"
+    NOTIFICATION = "notification"
+    RETRY = "retry"
+    OTHER = "other"
+
+
+class SpanStatus(str, Enum):
+    """Final status of a span."""
+
+    OK = "ok"
+    ERROR = "error"
+    TIMEOUT = "timeout"
+    SKIPPED = "skipped"
+
+
+class QualityLabel(str, Enum):
+    """
+    Downstream usefulness signals for a trace.
+
+    These are recorded after the fact (e.g. by Connor reacting to a
+    Discord report, or by an automated useful/noisy classifier) and let
+    HALO optimize for business value, not just successful execution.
+    """
+
+    SENT = "sent"
+    IGNORED = "ignored"
+    USEFUL = "useful"
+    NOISY = "noisy"
+    WRONG = "wrong"
+    ACTION_TAKEN = "action_taken"
+
+
+class TraceSpan(BaseModel):
+    """A single span inside a trace."""
+
+    span_id: str
+    trace_id: str
+    parent_span_id: Optional[str] = None
+    task_id: Optional[str] = None
+    execution_id: Optional[str] = None
+    client: Optional[str] = None
+    name: str
+    kind: SpanKind = SpanKind.OTHER
+    status: SpanStatus = SpanStatus.OK
+    started_at: datetime
+    completed_at: Optional[datetime] = None
+    duration_ms: Optional[int] = None
+    inputs: Dict[str, Any] = Field(default_factory=dict)
+    outputs_summary: Optional[str] = None
+    attributes: Dict[str, Any] = Field(default_factory=dict)
+    error: Optional[str] = None
+
+    def to_halo_dict(self) -> Dict[str, Any]:
+        """Render as HALO-compatible JSONL row."""
+        return {
+            "trace_id": self.trace_id,
+            "span_id": self.span_id,
+            "parent_span_id": self.parent_span_id,
+            "task_id": self.task_id,
+            "execution_id": self.execution_id,
+            "client": self.client,
+            "name": self.name,
+            "kind": self.kind.value,
+            "status": self.status.value,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "duration_ms": self.duration_ms,
+            "inputs": self.inputs,
+            "outputs_summary": self.outputs_summary,
+            "attributes": self.attributes,
+            "error": self.error,
+        }
+
+
+class TraceStore:
+    """
+    SQLite-backed store for trace spans and quality labels.
+
+    Reuses the agent database file so that traces, executions, and
+    scheduled tasks live alongside each other and can be cross-joined
+    during diagnosis.
+    """
+
+    def __init__(self, db_path: Optional[Path] = None):
+        self.db_path = db_path or agent_config.db_path
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS task_spans (
+                    span_id TEXT PRIMARY KEY,
+                    trace_id TEXT NOT NULL,
+                    parent_span_id TEXT,
+                    task_id TEXT,
+                    execution_id TEXT,
+                    client TEXT,
+                    name TEXT NOT NULL,
+                    kind TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    started_at TEXT NOT NULL,
+                    completed_at TEXT,
+                    duration_ms INTEGER,
+                    inputs TEXT,
+                    outputs_summary TEXT,
+                    attributes TEXT,
+                    error TEXT
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trace_quality (
+                    trace_id TEXT NOT NULL,
+                    label TEXT NOT NULL,
+                    note TEXT,
+                    source TEXT,
+                    recorded_at TEXT NOT NULL,
+                    PRIMARY KEY (trace_id, label)
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_spans_trace ON task_spans(trace_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_spans_task ON task_spans(task_id)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_spans_started ON task_spans(started_at)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_spans_status ON task_spans(status)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_spans_kind ON task_spans(kind)"
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Span persistence
+    # ------------------------------------------------------------------
+    def save_span(self, span: TraceSpan) -> None:
+        """Insert or replace a span (idempotent on span_id)."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO task_spans
+                (span_id, trace_id, parent_span_id, task_id, execution_id, client,
+                 name, kind, status, started_at, completed_at, duration_ms,
+                 inputs, outputs_summary, attributes, error)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    span.span_id,
+                    span.trace_id,
+                    span.parent_span_id,
+                    span.task_id,
+                    span.execution_id,
+                    span.client,
+                    span.name,
+                    span.kind.value,
+                    span.status.value,
+                    span.started_at.isoformat(),
+                    span.completed_at.isoformat() if span.completed_at else None,
+                    span.duration_ms,
+                    json.dumps(span.inputs, default=str),
+                    span.outputs_summary,
+                    json.dumps(span.attributes, default=str),
+                    span.error,
+                ),
+            )
+            conn.commit()
+
+    # ------------------------------------------------------------------
+    # Querying
+    # ------------------------------------------------------------------
+    def list_spans(
+        self,
+        *,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+        task_id: Optional[str] = None,
+        client: Optional[str] = None,
+        status: Optional[SpanStatus] = None,
+        limit: Optional[int] = None,
+    ) -> List[TraceSpan]:
+        clauses: List[str] = []
+        params: List[Any] = []
+
+        if since is not None:
+            clauses.append("started_at >= ?")
+            params.append(since.isoformat())
+        if until is not None:
+            clauses.append("started_at <= ?")
+            params.append(until.isoformat())
+        if task_id is not None:
+            clauses.append("task_id = ?")
+            params.append(task_id)
+        if client is not None:
+            clauses.append("client = ?")
+            params.append(client)
+        if status is not None:
+            clauses.append("status = ?")
+            params.append(status.value)
+
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        sql = f"SELECT * FROM task_spans {where} ORDER BY started_at ASC"
+        if limit is not None:
+            sql += f" LIMIT {int(limit)}"
+
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(sql, params).fetchall()
+
+        return [_row_to_span(row) for row in rows]
+
+    def iter_spans(
+        self,
+        *,
+        since: Optional[datetime] = None,
+        until: Optional[datetime] = None,
+    ) -> Iterable[TraceSpan]:
+        # Streamed read for export over large windows.
+        for span in self.list_spans(since=since, until=until):
+            yield span
+
+    def get_trace(self, trace_id: str) -> List[TraceSpan]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM task_spans WHERE trace_id = ? ORDER BY started_at ASC",
+                (trace_id,),
+            ).fetchall()
+        return [_row_to_span(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Quality labels
+    # ------------------------------------------------------------------
+    def record_quality(
+        self,
+        trace_id: str,
+        label: QualityLabel,
+        *,
+        note: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO trace_quality
+                (trace_id, label, note, source, recorded_at)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    trace_id,
+                    label.value,
+                    note,
+                    source,
+                    datetime.utcnow().isoformat(),
+                ),
+            )
+            conn.commit()
+
+    def get_quality(self, trace_id: str) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT label, note, source, recorded_at FROM trace_quality WHERE trace_id = ?",
+                (trace_id,),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    # ------------------------------------------------------------------
+    # Maintenance
+    # ------------------------------------------------------------------
+    def cleanup(self, *, older_than_days: int = 60) -> int:
+        cutoff = (datetime.utcnow() - timedelta(days=older_than_days)).isoformat()
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute(
+                "DELETE FROM task_spans WHERE started_at < ?", (cutoff,)
+            )
+            conn.execute(
+                "DELETE FROM trace_quality WHERE recorded_at < ?", (cutoff,)
+            )
+            conn.commit()
+            return cur.rowcount or 0
+
+
+def _row_to_span(row: sqlite3.Row) -> TraceSpan:
+    return TraceSpan(
+        span_id=row["span_id"],
+        trace_id=row["trace_id"],
+        parent_span_id=row["parent_span_id"],
+        task_id=row["task_id"],
+        execution_id=row["execution_id"],
+        client=row["client"],
+        name=row["name"],
+        kind=SpanKind(row["kind"]),
+        status=SpanStatus(row["status"]),
+        started_at=datetime.fromisoformat(row["started_at"]),
+        completed_at=(
+            datetime.fromisoformat(row["completed_at"]) if row["completed_at"] else None
+        ),
+        duration_ms=row["duration_ms"],
+        inputs=json.loads(row["inputs"]) if row["inputs"] else {},
+        outputs_summary=row["outputs_summary"],
+        attributes=json.loads(row["attributes"]) if row["attributes"] else {},
+        error=row["error"],
+    )
+
+
+# Global trace store instance.
+trace_store = TraceStore()

--- a/agent/traces/quality.py
+++ b/agent/traces/quality.py
@@ -1,0 +1,71 @@
+"""
+CLI for recording downstream quality labels on traces.
+
+These labels feed HALO's optimization loop: a `useful` weekly_report
+trace is something to amplify; an `ignored` daily_analytics trace is
+something to compress or drop.
+
+Usage:
+
+    python -m agent.traces.quality <trace_id> useful --note "Connor reacted 👍"
+    python -m agent.traces.quality <trace_id> noisy --source discord
+    python -m agent.traces.quality --list <trace_id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Optional
+
+from .models import QualityLabel, trace_store
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="agent.traces.quality",
+        description="Record downstream quality labels on a trace.",
+    )
+    parser.add_argument("trace_id")
+    parser.add_argument(
+        "label",
+        nargs="?",
+        choices=[q.value for q in QualityLabel],
+        help="Quality label to record. Omit with --list to inspect existing labels.",
+    )
+    parser.add_argument("--note", default=None)
+    parser.add_argument(
+        "--source",
+        default=None,
+        help="Origin of the label (e.g. discord, manual, classifier).",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List existing labels for the trace and exit.",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.list:
+        rows = trace_store.get_quality(args.trace_id)
+        json.dump(rows, sys.stdout, default=str, indent=2)
+        sys.stdout.write("\n")
+        return 0
+
+    if not args.label:
+        parser.error("label is required unless --list is passed")
+
+    trace_store.record_quality(
+        args.trace_id,
+        QualityLabel(args.label),
+        note=args.note,
+        source=args.source,
+    )
+    print(f"[traces] recorded label={args.label} on trace_id={args.trace_id}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/agent/traces/redact.py
+++ b/agent/traces/redact.py
@@ -1,0 +1,124 @@
+"""
+Redaction helpers for trace inputs/outputs/errors.
+
+The trace store may be exported off-host for HALO diagnosis, so any
+secret-shaped values (tokens, API keys, phone numbers, emails, customer
+identifiers passed as headers/auth) must be scrubbed before they hit
+disk or JSONL exports.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Field names that are always redacted regardless of value shape.
+SENSITIVE_KEYS = {
+    "api_key",
+    "apikey",
+    "access_token",
+    "auth_token",
+    "authorization",
+    "bearer",
+    "client_secret",
+    "cookie",
+    "credentials",
+    "key",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+    "session",
+    "set-cookie",
+    "token",
+    "twilio_auth_token",
+    "x-api-key",
+}
+
+# Value patterns that look secret-shaped even in non-sensitive keys.
+_REDACT_PATTERNS = [
+    # Long opaque tokens (Twilio, OpenAI, Anthropic, Discord, etc.)
+    re.compile(r"\b(sk-[A-Za-z0-9]{16,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{16})\b"),
+    re.compile(r"\b[A-Za-z0-9_-]{40,}\b"),
+    # Email addresses (PII for outbound contacts)
+    re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b"),
+    # E.164-ish phone numbers
+    re.compile(r"\+?\d[\d\s\-().]{8,}\d"),
+]
+
+REDACTED = "[REDACTED]"
+_MAX_STR = 2000
+
+
+def _redact_str(value: str) -> str:
+    """Apply value-shape redaction to a string."""
+    redacted = value
+    for pat in _REDACT_PATTERNS:
+        redacted = pat.sub(REDACTED, redacted)
+    if len(redacted) > _MAX_STR:
+        redacted = redacted[:_MAX_STR] + f"... [truncated {len(value) - _MAX_STR} chars]"
+    return redacted
+
+
+def redact(value: Any, *, _depth: int = 0) -> Any:
+    """
+    Recursively redact sensitive values from arbitrary structures.
+
+    - Dict keys matching SENSITIVE_KEYS (case-insensitive) are replaced.
+    - Long opaque tokens, emails, and phone numbers are pattern-redacted.
+    - Strings longer than 2000 chars are truncated with a marker.
+    - Recursion is depth-limited to avoid pathological structures.
+    """
+    if _depth > 6:
+        return REDACTED
+
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+
+    if isinstance(value, str):
+        return _redact_str(value)
+
+    if isinstance(value, dict):
+        out: dict = {}
+        for k, v in value.items():
+            key = str(k)
+            if key.lower() in SENSITIVE_KEYS:
+                out[key] = REDACTED
+            else:
+                out[key] = redact(v, _depth=_depth + 1)
+        return out
+
+    if isinstance(value, (list, tuple)):
+        return [redact(v, _depth=_depth + 1) for v in value]
+
+    # Fallback: stringify and redact.
+    return _redact_str(repr(value))
+
+
+def summarize_output(value: Any, *, max_len: int = 400) -> str:
+    """
+    Build a short, redaction-safe summary of a span's output for storage.
+
+    HALO consumes summaries (not full bodies) to keep traces lean and to
+    avoid leaking high-cardinality content into diagnosis prompts.
+    """
+    if value is None:
+        return ""
+
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, dict):
+        # Prefer explicit summary fields if the task already produced one.
+        for field in ("summary", "headline", "title", "message"):
+            if isinstance(value.get(field), str) and value[field].strip():
+                text = value[field]
+                break
+        else:
+            text = repr(redact(value))
+    else:
+        text = repr(redact(value))
+
+    text = _redact_str(text)
+    if len(text) > max_len:
+        text = text[: max_len - 3] + "..."
+    return text

--- a/agent/traces/tracer.py
+++ b/agent/traces/tracer.py
@@ -1,0 +1,300 @@
+"""
+Tracer: ergonomic span context managers with implicit propagation.
+
+The tracer captures structured span data via async context managers,
+propagates the current trace through `contextvars` so deeply-nested
+helpers can attach LLM/external/transform spans without threading a
+tracer argument through every call, and writes spans to the trace
+store at span exit.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from datetime import datetime
+from typing import Any, AsyncIterator, Dict, Iterator, Optional
+from uuid import uuid4
+
+from .models import (
+    QualityLabel,
+    SpanKind,
+    SpanStatus,
+    TraceSpan,
+    trace_store,
+)
+from .redact import redact, summarize_output
+
+
+# Active trace + parent span context. Used so handlers/helpers can open
+# child spans without explicitly being passed a tracer instance.
+_current_trace_id: ContextVar[Optional[str]] = ContextVar(
+    "_current_trace_id", default=None
+)
+_current_parent_span_id: ContextVar[Optional[str]] = ContextVar(
+    "_current_parent_span_id", default=None
+)
+_current_task_id: ContextVar[Optional[str]] = ContextVar(
+    "_current_task_id", default=None
+)
+_current_execution_id: ContextVar[Optional[str]] = ContextVar(
+    "_current_execution_id", default=None
+)
+_current_client: ContextVar[Optional[str]] = ContextVar(
+    "_current_client", default=None
+)
+
+
+def current_trace_id() -> Optional[str]:
+    """Return the active trace ID, or None outside a trace."""
+    return _current_trace_id.get()
+
+
+class Span:
+    """
+    A live span. Use as an async context manager:
+
+        async with tracer.span("fetch_metrics", kind=SpanKind.EXTERNAL_API) as s:
+            data = await api.get(...)
+            s.add_attributes(rows=len(data))
+            s.set_output(data)
+
+    Attributes accumulate freely; output summary is short-form by
+    default and is run through redaction before persistence.
+    """
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        kind: SpanKind = SpanKind.OTHER,
+        trace_id: str,
+        parent_span_id: Optional[str],
+        task_id: Optional[str],
+        execution_id: Optional[str],
+        client: Optional[str],
+        inputs: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Dict[str, Any]] = None,
+    ):
+        self.span_id = uuid4().hex[:16]
+        self.trace_id = trace_id
+        self.parent_span_id = parent_span_id
+        self.task_id = task_id
+        self.execution_id = execution_id
+        self.client = client
+        self.name = name
+        self.kind = kind
+        self.inputs: Dict[str, Any] = redact(inputs or {})
+        self.attributes: Dict[str, Any] = dict(attributes or {})
+        self.outputs_summary: Optional[str] = None
+        self.status: SpanStatus = SpanStatus.OK
+        self.error: Optional[str] = None
+        self.started_at: datetime = datetime.utcnow()
+        self.completed_at: Optional[datetime] = None
+        self._t0 = time.monotonic()
+        self._closed = False
+
+    # -- mutation API used inside the `with` block ---------------------
+    def add_attributes(self, **kwargs: Any) -> None:
+        """Add structured metadata (e.g. row counts, status codes)."""
+        self.attributes.update(redact(kwargs))
+
+    def set_output(self, value: Any) -> None:
+        """Record a redaction-safe summary of the span's output."""
+        self.outputs_summary = summarize_output(value)
+
+    def set_status(self, status: SpanStatus) -> None:
+        self.status = status
+
+    # -- finalization --------------------------------------------------
+    def _finalize(self, *, error: Optional[BaseException] = None) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
+        self.completed_at = datetime.utcnow()
+        duration_ms = int((time.monotonic() - self._t0) * 1000)
+
+        if error is not None:
+            self.status = SpanStatus.ERROR
+            self.error = redact(f"{type(error).__name__}: {error}")
+
+        span = TraceSpan(
+            span_id=self.span_id,
+            trace_id=self.trace_id,
+            parent_span_id=self.parent_span_id,
+            task_id=self.task_id,
+            execution_id=self.execution_id,
+            client=self.client,
+            name=self.name,
+            kind=self.kind,
+            status=self.status,
+            started_at=self.started_at,
+            completed_at=self.completed_at,
+            duration_ms=duration_ms,
+            inputs=self.inputs,
+            outputs_summary=self.outputs_summary,
+            attributes=self.attributes,
+            error=self.error,
+        )
+        try:
+            trace_store.save_span(span)
+        except Exception as exc:  # pragma: no cover - storage best-effort
+            # Tracing must never take down the agent loop.
+            print(f"[traces] failed to persist span {self.name}: {exc}")
+
+
+class _TraceHandle:
+    """
+    Returned by `tracer.trace(...)`. Exposes `.span()` so handlers can
+    open child spans that inherit task/client metadata automatically.
+    """
+
+    def __init__(self, trace_id: str):
+        self.trace_id = trace_id
+
+    def span(self, name: str, *, kind: SpanKind = SpanKind.OTHER, **kwargs: Any):
+        return tracer.span(name, kind=kind, **kwargs)
+
+    def label(
+        self,
+        label: QualityLabel,
+        *,
+        note: Optional[str] = None,
+        source: Optional[str] = None,
+    ) -> None:
+        """Attach a downstream usefulness label to this trace."""
+        trace_store.record_quality(self.trace_id, label, note=note, source=source)
+
+
+class Tracer:
+    """
+    Front-end facade that opens traces and child spans against the
+    process-global trace store.
+    """
+
+    @asynccontextmanager
+    async def trace(
+        self,
+        *,
+        task_id: Optional[str] = None,
+        execution_id: Optional[str] = None,
+        client: Optional[str] = None,
+        trace_id: Optional[str] = None,
+        root_span_name: str = "task",
+        root_span_kind: SpanKind = SpanKind.TASK,
+        inputs: Optional[Dict[str, Any]] = None,
+    ) -> AsyncIterator[_TraceHandle]:
+        """
+        Open a new trace with a root span.
+
+        The root span captures the task-level start/end so HALO has a
+        single record per execution to cluster against.
+        """
+        tid = trace_id or uuid4().hex
+        token_trace = _current_trace_id.set(tid)
+        token_task = _current_task_id.set(task_id)
+        token_exec = _current_execution_id.set(execution_id)
+        token_client = _current_client.set(client)
+
+        root = Span(
+            name=root_span_name,
+            kind=root_span_kind,
+            trace_id=tid,
+            parent_span_id=None,
+            task_id=task_id,
+            execution_id=execution_id,
+            client=client,
+            inputs=inputs,
+        )
+        token_parent = _current_parent_span_id.set(root.span_id)
+
+        try:
+            yield _TraceHandle(tid)
+            root._finalize()
+        except BaseException as exc:
+            root._finalize(error=exc)
+            raise
+        finally:
+            _current_parent_span_id.reset(token_parent)
+            _current_client.reset(token_client)
+            _current_execution_id.reset(token_exec)
+            _current_task_id.reset(token_task)
+            _current_trace_id.reset(token_trace)
+
+    @asynccontextmanager
+    async def span(
+        self,
+        name: str,
+        *,
+        kind: SpanKind = SpanKind.OTHER,
+        inputs: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> AsyncIterator[Span]:
+        """
+        Open a child span under the active trace. If no trace is active
+        the span is created with a synthetic trace ID so callers don't
+        need conditional code paths during partial rollouts.
+        """
+        trace_id = _current_trace_id.get() or uuid4().hex
+        parent = _current_parent_span_id.get()
+
+        s = Span(
+            name=name,
+            kind=kind,
+            trace_id=trace_id,
+            parent_span_id=parent,
+            task_id=_current_task_id.get(),
+            execution_id=_current_execution_id.get(),
+            client=_current_client.get(),
+            inputs=inputs,
+            attributes=attributes,
+        )
+        token_parent = _current_parent_span_id.set(s.span_id)
+        try:
+            yield s
+            s._finalize()
+        except BaseException as exc:
+            s._finalize(error=exc)
+            raise
+        finally:
+            _current_parent_span_id.reset(token_parent)
+
+    @contextmanager
+    def sync_span(
+        self,
+        name: str,
+        *,
+        kind: SpanKind = SpanKind.OTHER,
+        inputs: Optional[Dict[str, Any]] = None,
+        attributes: Optional[Dict[str, Any]] = None,
+    ) -> Iterator[Span]:
+        """Sync variant for non-async code paths (CLI tools, scripts)."""
+        trace_id = _current_trace_id.get() or uuid4().hex
+        parent = _current_parent_span_id.get()
+
+        s = Span(
+            name=name,
+            kind=kind,
+            trace_id=trace_id,
+            parent_span_id=parent,
+            task_id=_current_task_id.get(),
+            execution_id=_current_execution_id.get(),
+            client=_current_client.get(),
+            inputs=inputs,
+            attributes=attributes,
+        )
+        token_parent = _current_parent_span_id.set(s.span_id)
+        try:
+            yield s
+            s._finalize()
+        except BaseException as exc:
+            s._finalize(error=exc)
+            raise
+        finally:
+            _current_parent_span_id.reset(token_parent)
+
+
+# Global tracer instance.
+tracer = Tracer()

--- a/tests/test_traces.py
+++ b/tests/test_traces.py
@@ -1,0 +1,253 @@
+"""Tests for the HALO-style trace store and tracer."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+# Force the trace store to use a fresh sqlite file for the test session.
+import os
+import tempfile
+
+_tmp_db = Path(tempfile.mkdtemp(prefix="cmo-traces-")) / "agent.db"
+
+import agent.config as agent_config_mod  # noqa: E402
+
+agent_config_mod.agent_config._db_path = _tmp_db
+
+# Re-import models to bind to the test DB.
+import agent.traces.models as traces_models  # noqa: E402
+
+traces_models.trace_store = traces_models.TraceStore(db_path=_tmp_db)
+
+import agent.traces.tracer as tracer_mod  # noqa: E402
+
+# Rebind the tracer module to the freshly-pathed store.
+tracer_mod.trace_store = traces_models.trace_store
+
+from agent.traces import (  # noqa: E402
+    QualityLabel,
+    SpanKind,
+    SpanStatus,
+    tracer,
+)
+from agent.traces.diagnose import build_digest, render_digest_markdown  # noqa: E402
+from agent.traces.export import parse_since  # noqa: E402
+from agent.traces.redact import redact, summarize_output  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+def test_redact_removes_sensitive_keys():
+    payload = {
+        "api_key": "abc123",
+        "Authorization": "Bearer xyz",
+        "user": "Connor",
+        "nested": {"password": "hunter2", "ok": "value"},
+    }
+    out = redact(payload)
+    assert out["api_key"] == "[REDACTED]"
+    assert out["Authorization"] == "[REDACTED]"
+    assert out["user"] == "Connor"
+    assert out["nested"]["password"] == "[REDACTED]"
+    assert out["nested"]["ok"] == "value"
+
+
+def test_redact_pattern_matches_long_tokens_and_emails():
+    text = (
+        "key=AKIAABCDEFGHIJKLMNOP "
+        "email=connor@example.com "
+        "phone=+1 415 555 0199 "
+        "ok=hi"
+    )
+    out = redact(text)
+    assert "AKIAABCDEFGHIJKLMNOP" not in out
+    assert "connor@example.com" not in out
+    assert "+1 415 555 0199" not in out
+    assert "ok=hi" in out
+
+
+def test_summarize_output_prefers_summary_field():
+    value = {"summary": "All good", "raw": "x" * 5000}
+    assert summarize_output(value).startswith("All good")
+
+
+def test_summarize_output_truncates_long_strings():
+    # Use varied content so the opaque-token redaction regex doesn't fire
+    # before truncation has a chance to apply.
+    text = "Lorem ipsum dolor sit amet, " * 100
+    out = summarize_output(text, max_len=200)
+    assert len(out) <= 200
+    assert out.endswith("...")
+
+
+# ---------------------------------------------------------------------------
+# Tracer + store
+# ---------------------------------------------------------------------------
+
+
+def test_trace_root_and_child_spans_persist():
+    async def run():
+        async with tracer.trace(
+            task_id="weekly_report",
+            execution_id="exec1",
+            client="kai-calls",
+            root_span_name="task:weekly_report",
+        ) as t:
+            async with tracer.span(
+                "fetch_metrics", kind=SpanKind.EXTERNAL_API
+            ) as s:
+                s.add_attributes(rows=42)
+                s.set_output({"summary": "Sessions: 100"})
+            return t.trace_id
+
+    trace_id = asyncio.run(run())
+    spans = traces_models.trace_store.get_trace(trace_id)
+    assert len(spans) == 2
+    by_name = {s.name: s for s in spans}
+    assert "task:weekly_report" in by_name
+    assert "fetch_metrics" in by_name
+
+    fetch = by_name["fetch_metrics"]
+    assert fetch.kind == SpanKind.EXTERNAL_API
+    assert fetch.status == SpanStatus.OK
+    assert fetch.outputs_summary.startswith("Sessions: 100")
+    assert fetch.attributes["rows"] == 42
+    assert fetch.parent_span_id == by_name["task:weekly_report"].span_id
+
+
+def test_trace_captures_errors_with_redaction():
+    async def run():
+        try:
+            async with tracer.trace(
+                task_id="daily_analytics",
+                execution_id="exec2",
+                root_span_name="task:daily_analytics",
+            ) as t:
+                async with tracer.span("call_api", kind=SpanKind.EXTERNAL_API):
+                    # 50-char opaque token triggers the long-token regex.
+                    raise RuntimeError(
+                        "auth failed token=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMN"
+                    )
+        except RuntimeError:
+            pass
+        return t.trace_id
+
+    trace_id = asyncio.run(run())
+    spans = traces_models.trace_store.get_trace(trace_id)
+    statuses = {s.name: s.status for s in spans}
+    assert statuses["call_api"] == SpanStatus.ERROR
+    assert statuses["task:daily_analytics"] == SpanStatus.ERROR
+
+    errored = next(s for s in spans if s.name == "call_api")
+    assert "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMN" not in (
+        errored.error or ""
+    )
+    assert "[REDACTED]" in (errored.error or "")
+
+
+def test_trace_handles_concurrent_traces():
+    """Two concurrent traces must not share trace_id or parent_span_id."""
+
+    async def run_one(task_id: str):
+        async with tracer.trace(
+            task_id=task_id,
+            execution_id=f"exec-{task_id}",
+            root_span_name=f"task:{task_id}",
+        ) as t:
+            await asyncio.sleep(0)
+            async with tracer.span("step", kind=SpanKind.TRANSFORM):
+                await asyncio.sleep(0)
+            return t.trace_id
+
+    async def run_both():
+        return await asyncio.gather(run_one("a"), run_one("b"))
+
+    trace_a, trace_b = asyncio.run(run_both())
+    assert trace_a != trace_b
+    spans_a = traces_models.trace_store.get_trace(trace_a)
+    spans_b = traces_models.trace_store.get_trace(trace_b)
+    assert {s.task_id for s in spans_a} == {"a"}
+    assert {s.task_id for s in spans_b} == {"b"}
+
+
+# ---------------------------------------------------------------------------
+# Quality labels
+# ---------------------------------------------------------------------------
+
+
+def test_record_and_read_quality_labels():
+    traces_models.trace_store.record_quality(
+        "trace-q1",
+        QualityLabel.USEFUL,
+        note="Connor reacted",
+        source="discord",
+    )
+    rows = traces_models.trace_store.get_quality("trace-q1")
+    assert len(rows) == 1
+    assert rows[0]["label"] == "useful"
+    assert rows[0]["source"] == "discord"
+
+
+# ---------------------------------------------------------------------------
+# Digest + export
+# ---------------------------------------------------------------------------
+
+
+def test_build_digest_aggregates_by_task():
+    async def run():
+        async with tracer.trace(
+            task_id="weekly_report",
+            execution_id="d1",
+            root_span_name="task:weekly_report",
+        ):
+            async with tracer.span("llm.complete:weekly", kind=SpanKind.LLM) as s:
+                s.add_attributes(
+                    input_tokens=100,
+                    output_tokens=200,
+                    estimated_cost_usd=0.0123,
+                )
+
+    asyncio.run(run())
+
+    spans = traces_models.trace_store.list_spans(
+        since=datetime.utcnow() - timedelta(hours=1)
+    )
+    digest = build_digest(spans)
+    assert digest["span_count"] >= 2
+    assert "weekly_report" in digest["tasks"]
+    md = render_digest_markdown(digest)
+    assert "weekly_report" in md
+
+
+def test_parse_since_handles_durations_and_iso():
+    now = datetime.utcnow()
+    out = parse_since("1h")
+    assert (now - out) < timedelta(hours=1, minutes=1)
+    iso = parse_since("2026-05-01T00:00:00")
+    assert iso.year == 2026
+
+
+def test_export_emits_jsonl(tmp_path):
+    from agent.traces.export import main
+
+    out = tmp_path / "traces.jsonl"
+    rc = main(["--since", "1d", "--out", str(out)])
+    assert rc == 0
+    # File may be empty if no spans matched, but it must be valid JSONL.
+    if out.exists() and out.stat().st_size > 0:
+        for line in out.read_text().splitlines():
+            row = json.loads(line)
+            assert "trace_id" in row
+            assert "span_id" in row
+            assert "kind" in row


### PR DESCRIPTION
Adds structured span-level tracing across the CMO agent so the harness can be analyzed by HALO and surface concrete improvements to prompts, task inputs, alert thresholds, and reporting structure based on production trace outcomes.

- agent/traces/: SQLite-backed trace store, contextvar-based tracer, redaction (sensitive keys + opaque tokens + emails/phones), HALO- compatible JSONL exporter, digest/diagnose CLI, quality-label CLI.
- agent/loop.py: wraps each task execution in a trace with spans for scheduler decisions, task execution, timeouts, and notifications.
- agent/llm/router.py: emits llm.* spans with model, prompt name/version, token usage, finish reason, and estimated cost.
- agent/tasks/harness_review.py + scheduler entry: weekly Mon 10am harness review that diagnoses the last 7d of traces and writes workspace/harness-reviews/<date>.md.
- tests/test_traces.py: 11 tests covering redaction, span lifecycle, concurrent traces, error capture, quality labels, digest, export.

Closes #8.

https://claude.ai/code/session_011exQ1WDqitQviJzoJw8zh1