### PR TITLE
[codex] Add system architecture docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you searched for **AI marketing agent**, **Claude Code marketing skills**, **
 - [KaiCalls](https://kaicalls.com) — AI voice agents for small-business phone answering and lead capture.
 - [Connor Gallic](https://connorgallic.com) — founder building Kai, KaiCalls, and AI automation systems.
 - [How Kai runs paid ads](docs/AI_POWERED_ADS_SYSTEM.md) — plain-English explanation of the paid media workflow.
+- [System guide](docs/system/README.md) — architecture pages, Mermaid diagrams, and runtime schemas.
 
 ## Start here
 

--- a/docs/system/README.md
+++ b/docs/system/README.md
@@ -1,0 +1,121 @@
+# Kai System Guide
+
+This folder is the reader-facing map of the Kai CMO Harness. It explains how the runtime, skills, content engine, quality gates, approvals, gateway, connectors, and background work fit together.
+
+Use this guide when you want to understand the product without reading every Python module first.
+
+## One-Screen Map
+
+```mermaid
+flowchart TB
+    Operator["Operator, agent, or remote client"]
+    Local["Local surface<br/>Claude Code skills in harness/skills"]
+    Remote["Remote surface<br/>FastAPI gateway"]
+    Runtime["Kai Runtime<br/>workspace, brand, modules, runs, artifacts"]
+    Workflows["Workflow registry<br/>kai/runtime/workflows.py"]
+    Content["Content outcome engine<br/>scripts/content/engine.py"]
+    Audit["Audit and proposal system<br/>kai/audits + kai/proposals"]
+    Quality["Quality and policy gates<br/>scripts/quality_gates + kai/runtime/policy.py"]
+    Approval["Approval lifecycle<br/>runs and action proposals"]
+    Store["Runtime store<br/>data/runtime JSON records"]
+    Actions["Execution arms<br/>connectors, CMS, ads, email, analytics"]
+    Learning["Memory and learning loop<br/>patterns, snapshots, writeback"]
+
+    Operator --> Local
+    Operator --> Remote
+    Local --> Runtime
+    Remote --> Runtime
+    Runtime --> Workflows
+    Workflows --> Content
+    Workflows --> Audit
+    Content --> Quality
+    Audit --> Quality
+    Quality --> Approval
+    Approval --> Store
+    Approval --> Actions
+    Actions --> Store
+    Store --> Learning
+    Learning --> Runtime
+```
+
+## Start Here
+
+| Reader | Best first page | Why |
+|---|---|---|
+| New repo reader | [Runtime Map](runtime-map.md) | Names the main nouns and where they live. |
+| Engineer adding a workflow | [Schema Catalog](schema-catalog.md) | Shows the contracts workflows must preserve. |
+| Engineer debugging a run | [Execution Lifecycle](execution-lifecycle.md) | Follows a run from request to artifact to approval. |
+| Operator reviewing safety | [Governance and Quality](governance-and-quality.md) | Explains quality gates, provenance, policy, and holds. |
+| Engineer wiring remote work | [Remote and Connectors](remote-and-connectors.md) | Shows gateway, jobs, connectors, and background tasks. |
+
+## System Pages
+
+- [Runtime Map](runtime-map.md): product layers, runtime nouns, module activation, and code map.
+- [Execution Lifecycle](execution-lifecycle.md): local generation, audit/proposal flow, run states, and action states.
+- [Governance and Quality](governance-and-quality.md): quality gate pipeline, audit provenance, approval policy, and memory writeback.
+- [Remote and Connectors](remote-and-connectors.md): FastAPI gateway, job queue, connector maturity, scheduled tasks, and integration shape.
+- [Schema Catalog](schema-catalog.md): JSON Schema contracts and example payloads.
+
+## Machine-Readable Schemas
+
+The JSON Schema files live in [schemas/](schemas/). They document the runtime contracts already represented in code:
+
+- `KaiWorkspaceProfile`
+- `KaiBrandProfile`
+- `KaiModuleManifest`
+- `WorkflowDefinition`
+- `KaiRunRequest`
+- `KaiRunRecord`
+- `KaiArtifactRecord`
+- `KaiRuntimeState`
+- `ActionProposal`
+
+The schemas are documentation-first. They are meant to help API clients, docs tooling, dashboards, and future tests align on the same contract.
+
+## Maturity Legend
+
+| Status | Meaning |
+|---|---|
+| Built | Code exists and is part of the working path. |
+| Partial | The shape is present, but some providers, transports, or product wiring are incomplete. |
+| Planned | Described by docs or manifests, but not a complete runtime path yet. |
+
+## Current Product Shape
+
+```mermaid
+flowchart LR
+    subgraph Built["Built core"]
+        Models["Runtime models"]
+        Store["File-backed runtime store"]
+        Skills["Local Kai skills"]
+        Content["Content engine"]
+        Gates["Quality gates"]
+        Audits["Audit engines"]
+        Approval["Approval lifecycle"]
+    end
+
+    subgraph Partial["Partial product layer"]
+        Gateway["Remote gateway"]
+        Connectors["Connector business logic"]
+        Watchers["Watchers and scheduled tasks"]
+        Dashboard["Dashboard-oriented endpoints"]
+    end
+
+    subgraph Planned["Planned expansion"]
+        AgentLoop["Full agent loop"]
+        RemoteAutos["Remote automations from module manifests"]
+        ProviderCoverage["Provider-complete execution arms"]
+    end
+
+    Models --> Store
+    Skills --> Content
+    Content --> Gates
+    Audits --> Approval
+    Gateway --> Store
+    Connectors --> Gateway
+    Watchers --> Gateway
+    Gateway --> Dashboard
+    Watchers --> AgentLoop
+    RemoteAutos --> ProviderCoverage
+```
+

--- a/docs/system/execution-lifecycle.md
+++ b/docs/system/execution-lifecycle.md
@@ -1,0 +1,180 @@
+# Execution Lifecycle
+
+Kai has three major execution loops:
+
+1. Local content generation through skills and `scripts/content/engine.py`.
+2. Programmatic audits that produce findings, proposals, bundles, and action candidates.
+3. Remote jobs and operator actions through the FastAPI gateway.
+
+All three should preserve the same runtime contract: request, run record, artifacts, approval, state update, memory or result writeback.
+
+## Local Content Generation
+
+```mermaid
+sequenceDiagram
+    actor Operator
+    participant Skill as Kai skill
+    participant Runtime as Kai runtime
+    participant Engine as Content engine
+    participant Writer as Writer
+    participant Gates as Quality gates
+    participant Store as Runtime store
+    participant Approval as Approval policy
+    participant Memory as Memory
+
+    Operator->>Skill: Invoke /kai-write or workflow alias
+    Skill->>Runtime: Resolve workspace, brand, modules, workflow
+    Runtime->>Store: start_run(KaiRunRequest)
+    Runtime->>Engine: generate(format, site, keyword)
+    Engine->>Engine: Resolve persona and brief
+    Engine->>Writer: Assemble prompt and draft
+    Writer-->>Engine: Draft content
+    Engine->>Gates: Four U's, banned words, SEO or policy checks
+    Gates-->>Engine: Gate report
+    Engine->>Approval: Apply approval policy
+    Approval-->>Engine: approved, held, failed, or draft
+    Engine->>Store: Create artifacts and complete run
+    Store->>Memory: Write back approved learning
+```
+
+## Audit and Proposal Flow
+
+```mermaid
+flowchart TB
+    Profile["BusinessProfile"]
+    Normalize["Normalize channels, locations, offers, metadata"]
+    Audits["8 audit engines"]
+    Findings["Scored findings"]
+    Proposals["Proposal mapper and ranker"]
+    Bundle["Review bundle<br/>7-day, 30-day, campaign packs"]
+    Policy["PolicyEngine<br/>risk, claims, spend, channel rules"]
+    Action["ActionProposal"]
+    Human["Human approval or hold"]
+    Execute["Execution bridge"]
+    Verify["Verification result"]
+    Learn["Memory writeback"]
+
+    Profile --> Normalize
+    Normalize --> Audits
+    Audits --> Findings
+    Findings --> Proposals
+    Proposals --> Bundle
+    Bundle --> Policy
+    Policy --> Action
+    Action --> Human
+    Human --> Execute
+    Execute --> Verify
+    Verify --> Learn
+```
+
+## Remote Gateway Flow
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant API as FastAPI gateway
+    participant Jobs as SQLite job queue
+    participant Runtime as Runtime store
+    participant Worker as Background worker
+    participant Handler as Workflow handler
+    participant Artifacts as Artifact records
+
+    Client->>API: POST remote workflow or operator action
+    API->>Jobs: create_job(command, options, run_request)
+    Jobs->>Runtime: Seed canonical run record
+    API-->>Client: job_id
+    Worker->>Jobs: Pick pending job
+    Worker->>Runtime: Mark run started
+    Worker->>Handler: Execute workflow handler
+    Handler-->>Worker: Result payload
+    Worker->>Artifacts: Persist output artifacts
+    Worker->>Runtime: Complete or fail run
+    Client->>API: GET /jobs or /runtime/runs/{run_id}
+    API-->>Client: Status, artifacts, lineage
+```
+
+## Run State Machine
+
+`KaiRunRecord.status` is intentionally small. Workflows can add richer metadata, but the main state should stay readable.
+
+```mermaid
+stateDiagram-v2
+    [*] --> running
+    running --> draft: generated but needs revision
+    running --> held: gate or policy wants review
+    running --> approved: approved directly
+    running --> completed: finished without approval need
+    running --> failed: unrecoverable error
+    draft --> held: human or gate hold
+    draft --> approved: approved revision
+    held --> draft: revision requested
+    held --> approved: human approval
+    held --> failed: rejected
+    approved --> completed: executed or logged
+    completed --> approved: explicit approval after completion
+    completed --> failed: rejected after review
+    failed --> [*]
+    completed --> [*]
+```
+
+## Action Proposal State
+
+Action proposals are for real-world mutations: website edits, social posts, ad changes, email sends, analytics updates, and similar work. They track both approval and execution.
+
+```mermaid
+stateDiagram-v2
+    [*] --> drafted
+    drafted --> gated: policy_result attached
+    gated --> approved: approval_state approved
+    gated --> held: approval_state held
+    gated --> rejected: approval_state rejected
+    held --> approved: human approval
+    held --> rejected: human rejection
+    approved --> executed: execution_state completed
+    approved --> failed: execution_state failed
+    executed --> verified: verification_result attached
+    verified --> learned: memory_writeback_ids present
+    failed --> rolled_back: rollback applied
+    learned --> [*]
+    rejected --> [*]
+    rolled_back --> [*]
+```
+
+| Field | Values |
+|---|---|
+| `approval_state` | `pending`, `approved`, `rejected`, `auto_approved`, `held` |
+| `execution_state` | `pending`, `executing`, `completed`, `failed`, `rolled_back` |
+| Derived operating state | `drafted`, `gated`, `approved`, `executed`, `verified`, `learned` |
+
+## Lineage
+
+Each run and artifact keeps enough lineage to answer:
+
+- Which request created this output?
+- Which parent run or prior artifacts influenced it?
+- Which approval or hold decision happened?
+- Which artifact should be used as the latest result for a brand and workflow?
+
+```mermaid
+flowchart LR
+    Parent["Parent run"]
+    Run["Current run"]
+    Brief["Brief artifact"]
+    Draft["Draft artifact"]
+    Gate["Gate proposal artifact"]
+    Approved["Approved asset"]
+    Snapshot["Performance snapshot"]
+    Pattern["Learned pattern"]
+    State["Runtime state index"]
+
+    Parent --> Run
+    Run --> Brief
+    Brief --> Draft
+    Draft --> Gate
+    Gate --> Approved
+    Approved --> Snapshot
+    Snapshot --> Pattern
+    Run --> State
+    Approved --> State
+```
+

--- a/docs/system/governance-and-quality.md
+++ b/docs/system/governance-and-quality.md
@@ -1,0 +1,144 @@
+# Governance and Quality
+
+Kai should be useful without being reckless. Governance is split into deterministic gates, platform policy references, provenance rules, approval state, and memory writeback.
+
+## Quality Gate Stack
+
+```mermaid
+flowchart TB
+    Draft["Draft or proposal"]
+    Contract["Skill contract<br/>harness/skill-contracts/*.yaml"]
+    Framework["Framework and channel rules<br/>knowledge + harness/references"]
+    FourUs["Four U's score"]
+    Banned["Banned word check"]
+    Seo["SEO lint when search-targeted"]
+    Policy["Platform and risk policy"]
+    Provenance["Audit provenance lint when claims are client-facing"]
+    Decision{"Ship, hold, revise, or fail?"}
+    Approved["Approved asset or action"]
+    Held["Held for human review"]
+    Revision["Revision loop"]
+    Failed["Failed after allowed retries"]
+
+    Draft --> Contract
+    Contract --> Framework
+    Framework --> FourUs
+    FourUs --> Banned
+    Banned --> Seo
+    Seo --> Policy
+    Policy --> Provenance
+    Provenance --> Decision
+    Decision --> Approved
+    Decision --> Held
+    Decision --> Revision
+    Decision --> Failed
+```
+
+## Gate Responsibilities
+
+| Gate | Code or source | Blocks on |
+|---|---|---|
+| Skill contract | `harness/skill-contracts/*.yaml` | Wrong structure, wrong format, missing required sections. |
+| Four U's | `scripts/quality_gates/four_us_score.py` | Content below the required usefulness and specificity threshold. |
+| Banned words | `scripts/quality_gates/banned_word_check.py` | Tier 1 filler, weak claims, and language that should not ship. |
+| SEO lint | `scripts/quality_gates/seo_lint.py` | Search content that breaks structural SEO and Algorithmic Authorship rules. |
+| Platform policy | `harness/references/*-ads-*.md`, `kai/runtime/policy.py` | Platform rule violations, regulated claims, personal attributes, unsafe spend changes. |
+| Audit provenance | `scripts/quality_gates/audit_provenance_lint.py` | Quantitative or client-facing claims without a source. |
+| Agent readiness | `scripts/quality_gates/agent_readiness_lint.py` | Site-level AEO work when robots, llms.txt, schema, or JS access block AI-readiness. |
+
+## Approval Decision Model
+
+```mermaid
+flowchart LR
+    Result["Gate or policy result"]
+    Risk{"Risk tier"}
+    Low["Low risk"]
+    Medium["Medium risk"]
+    High["High risk"]
+    Auto{"Auto eligible?"}
+    Human["Human review"]
+    Approve["Approve"]
+    Hold["Hold"]
+    Reject["Reject"]
+    Execute["Execute approved action"]
+
+    Result --> Risk
+    Risk --> Low
+    Risk --> Medium
+    Risk --> High
+    Low --> Auto
+    Auto -->|yes| Approve
+    Auto -->|no| Human
+    Medium --> Human
+    High --> Human
+    Human --> Approve
+    Human --> Hold
+    Human --> Reject
+    Approve --> Execute
+```
+
+## Provenance Rule
+
+For audits, reports, decks, competitor teardowns, CRO work, analytics plans, growth plans, and retrospectives:
+
+- Declare the data mode: `sales_external`, `onboarding_connected`, or `internal_demo`.
+- Collect data before writing with `python -m scripts.audit.collect --url <url> --mode <mode> --workflow <workflow> --out <data-folder>`.
+- Cite collector sources for client-facing numbers.
+- Put missing inputs in `_data-gaps.md`.
+- Run `python scripts/quality_gates/audit_provenance_lint.py <audit-folder> --audit-dir` before handoff.
+
+```mermaid
+flowchart TB
+    Request["Audit-style workflow"]
+    Mode["Declare data mode"]
+    Collect["Run data collector"]
+    Data["kai-data.json / audit-data.json"]
+    Gaps["_data-gaps.md"]
+    Draft["Write report or deck"]
+    Lint["audit_provenance_lint.py"]
+    Pass["Client-ready"]
+    Hold["Fix sources or label gaps"]
+
+    Request --> Mode
+    Mode --> Collect
+    Collect --> Data
+    Collect --> Gaps
+    Data --> Draft
+    Gaps --> Draft
+    Draft --> Lint
+    Lint -->|pass| Pass
+    Lint -->|fail| Hold
+    Hold --> Draft
+```
+
+## Memory Writeback
+
+Approved work can become future context. Rejected, held, and failed work should still be visible for observability, but should not silently become a learned pattern.
+
+```mermaid
+flowchart LR
+    Approved["Approved run or verified action"]
+    Extract["Extract decision, artifact, and outcome"]
+    Memory["Brand memory / learned patterns"]
+    Retrieval["Future prompt retrieval"]
+    Guard["Anti-pattern memory"]
+
+    Approved --> Extract
+    Extract --> Memory
+    Memory --> Retrieval
+    Retrieval --> Approved
+    Extract --> Guard
+```
+
+## Practical Rule
+
+Any workflow that can change a live channel should produce an `ActionProposal` first. The proposal should contain:
+
+- proposed changes
+- evidence
+- risk tier
+- policy result
+- preview artifact when possible
+- verification criteria
+- rollback reference when needed
+

--- a/docs/system/remote-and-connectors.md
+++ b/docs/system/remote-and-connectors.md
@@ -1,0 +1,134 @@
+# Remote and Connectors
+
+The remote surface lets dashboards, webhooks, scheduled tasks, and agents use the same runtime contracts as local skills.
+
+## Gateway Topology
+
+```mermaid
+flowchart TB
+    Client["Dashboard, webhook, or agent"]
+    Auth["API key or channel auth"]
+    Gateway["gateway/main.py<br/>FastAPI app"]
+    RuntimeRouter["/runtime<br/>workspace, modules, runs, artifacts, approvals"]
+    OpsRouter["/ops<br/>action proposals and integrations"]
+    JobsRouter["/jobs<br/>job status"]
+    Webhooks["/webhooks/*<br/>analytics, TikTok, cold email, tasks, creative"]
+    Queue["gateway/jobs.py<br/>SQLite queue"]
+    Store["kai/runtime/store.py<br/>JSON runtime records"]
+    ActionStore["kai/runtime/actions.py<br/>action JSON + audit log"]
+    Connectors["kai/connectors/*<br/>provider-specific arms"]
+
+    Client --> Auth
+    Auth --> Gateway
+    Gateway --> RuntimeRouter
+    Gateway --> OpsRouter
+    Gateway --> JobsRouter
+    Gateway --> Webhooks
+    RuntimeRouter --> Store
+    OpsRouter --> ActionStore
+    OpsRouter --> Connectors
+    Webhooks --> Queue
+    Queue --> Store
+```
+
+## Remote Endpoints
+
+| Prefix | Router | Role |
+|---|---|---|
+| `/runtime` | `gateway/routers/runtime.py` | Workspace, brands, modules, runs, artifacts, lineage, approvals. |
+| `/ops` | `gateway/routers/actions.py` | Action proposals, approvals, action history, integration registry. |
+| `/jobs` | `gateway/routers/jobs.py` | Async job status and result lookup. |
+| `/connections` | `gateway/routers/connections.py` | Connection-oriented remote state. |
+| `/daemon` | `gateway/routers/daemon.py` | Daemon and operator loop support. |
+| `/webhooks/analytics` | `gateway/routers/analytics.py` | Analytics webhook handling. |
+| `/webhooks/creative` | `gateway/routers/creative.py` | Creative webhook handling. |
+| `/webhooks/cold-email` | `gateway/routers/cold_email.py` | Cold email webhook handling. |
+| `/webhooks/tasks` | `gateway/routers/tasks.py` | Task integration hooks. |
+| `/webhooks/tiktok` | `gateway/routers/tiktok.py` | TikTok integration hooks. |
+| `/webhooks/whatsapp` | `gateway/routers/whatsapp.py` | WhatsApp/Twilio channel hooks. |
+
+## Connector Maturity
+
+```mermaid
+flowchart LR
+    subgraph Built["Built"]
+        Runtime["Runtime API"]
+        Queue["Job queue"]
+        ActionLifecycle["Action lifecycle"]
+        RealScripts["Standalone API scripts"]
+    end
+
+    subgraph Partial["Partial"]
+        Ads["Ads connectors"]
+        Analytics["Analytics connectors"]
+        CMS["CMS connectors"]
+        Lifecycle["Email and CRM connectors"]
+        Social["Social connectors"]
+    end
+
+    subgraph Needed["Needed for full remote execution"]
+        Transport["Provider HTTP transport"]
+        Auth["Account connection and token refresh"]
+        Coverage["Provider-complete actions"]
+        Verification["Post-execution verification"]
+    end
+
+    Runtime --> Queue
+    ActionLifecycle --> Ads
+    ActionLifecycle --> Analytics
+    ActionLifecycle --> CMS
+    ActionLifecycle --> Lifecycle
+    ActionLifecycle --> Social
+    RealScripts --> Transport
+    Ads --> Transport
+    Analytics --> Transport
+    CMS --> Transport
+    Lifecycle --> Auth
+    Social --> Coverage
+    Transport --> Verification
+```
+
+## Brain, Nervous System, Arms
+
+Kai follows a simple remote execution model:
+
+| Layer | Responsibility | Examples |
+|---|---|---|
+| Brain | Decides what should happen and why. | audits, proposals, ranking, campaign plans |
+| Nervous system | Carries state, risk, approval, and lineage. | run records, action proposals, policy results, audit logs |
+| Arms | Executes approved channel-specific actions. | WordPress, Shopify, Meta, Google Ads, email, social, analytics |
+
+Arms should observe, execute approved actions, and report results. They should not invent strategy outside the approved contract.
+
+## Scheduled and Background Work
+
+```mermaid
+flowchart TB
+    Schedule["agent/scheduler.py"]
+    Tasks["agent/tasks/*"]
+    Watchers["kai/watchers/*"]
+    Runtime["Runtime store"]
+    Actions["Approved actions"]
+    Connectors["Connectors and API clients"]
+    Reports["Reports, alerts, snapshots"]
+    Learning["Memory and learned patterns"]
+
+    Schedule --> Tasks
+    Tasks --> Watchers
+    Watchers --> Runtime
+    Runtime --> Actions
+    Actions --> Connectors
+    Connectors --> Reports
+    Reports --> Runtime
+    Runtime --> Learning
+```
+
+## Remote Contract Rules
+
+- Every remote invocation should create or reference a `KaiRunRequest`.
+- Every long-running unit should have a job id and a run id.
+- Every output should be an artifact, not only a raw API response.
+- Every live mutation should be represented as an `ActionProposal`.
+- Every action should carry a policy result before approval.
+- Every execution result should update state and keep enough evidence for verification.
+

--- a/docs/system/runtime-map.md
+++ b/docs/system/runtime-map.md
@@ -1,0 +1,160 @@
+# Runtime Map
+
+Kai is organized around a small set of runtime nouns. The docs and code should keep pointing back to these nouns so new workflows do not invent parallel contracts.
+
+## Layer Model
+
+```mermaid
+flowchart TB
+    subgraph Product["Kai Marketing OS"]
+        Skills["Skills<br/>operator workflows"]
+        Modules["Modules<br/>archetype defaults"]
+        Knowledge["Knowledge base<br/>frameworks, policies, checklists"]
+        Quality["Quality gates<br/>score, lint, policy"]
+        Approval["Approvals<br/>human or auto by risk"]
+    end
+
+    subgraph Runtime["Kai Runtime"]
+        Workspace["KaiWorkspaceProfile"]
+        Brand["KaiBrandProfile"]
+        Workflow["WorkflowDefinition"]
+        Run["KaiRunRequest + KaiRunRecord"]
+        Artifact["KaiArtifactRecord"]
+        State["KaiRuntimeState"]
+    end
+
+    subgraph Implementation["Implementation"]
+        Content["scripts/content/engine.py"]
+        Audits["kai/audits"]
+        Proposals["kai/proposals"]
+        Store["kai/runtime/store.py"]
+        Gateway["gateway"]
+        Actions["kai/runtime/actions.py"]
+    end
+
+    Skills --> Workspace
+    Modules --> Brand
+    Knowledge --> Workflow
+    Workspace --> Brand
+    Brand --> Workflow
+    Workflow --> Run
+    Run --> Artifact
+    Artifact --> State
+    Quality --> Run
+    Approval --> Run
+    Run --> Store
+    Content --> Artifact
+    Audits --> Proposals
+    Proposals --> Actions
+    Gateway --> Store
+```
+
+## Runtime Nouns
+
+| Noun | Code source | Purpose |
+|---|---|---|
+| Workspace profile | `kai/runtime/models.py` | Describes the workspace, available surfaces, enabled plugins, and brands. |
+| Brand profile | `kai/runtime/models.py` | Describes one business target: URL, archetype, channels, proof, personas, and metadata. |
+| Module manifest | `kai/runtime/modules/*.yaml` | Adds archetype defaults: trigger words, prompt hints, required memory, workflows, KPIs, subagents, and automation names. |
+| Workflow definition | `kai/runtime/workflows.py` | Maps product workflows to handlers, input contracts, output artifacts, quality policy, aliases, and risk. |
+| Run request | `kai/runtime/models.py` | The cross-surface invocation contract for local and remote execution. |
+| Run record | `kai/runtime/models.py` | The persisted lifecycle record for a run, including status, lineage, artifacts, inputs, outputs, and timestamps. |
+| Artifact record | `kai/runtime/models.py` | The persisted output contract for briefs, drafts, audits, plans, snapshots, and learned patterns. |
+| Runtime state | `kai/runtime/models.py` | A derived index of latest runs and artifacts by brand and workflow. |
+| Action proposal | `kai/runtime/actions.py` | The contract for real-world marketing mutations such as publishing, editing, or changing spend. |
+
+## Data Model
+
+```mermaid
+erDiagram
+    WORKSPACE ||--o{ BRAND : contains
+    BRAND ||--o{ MODULE : activates
+    BRAND ||--o{ RUN : owns
+    MODULE ||--o{ RUN : guides
+    WORKFLOW ||--o{ RUN : invokes
+    RUN ||--o{ ARTIFACT : creates
+    RUN ||--o{ ACTION : proposes
+    ACTION ||--o{ ACTION_LOG : records
+    ARTIFACT ||--o{ MEMORY_ENTRY : teaches
+    RUN ||--o{ RUNTIME_STATE : indexes
+
+    WORKSPACE {
+        string workspace_id
+        string name
+        string primary_user
+        string product_mode
+    }
+
+    BRAND {
+        string id
+        string name
+        string primary_archetype
+        array module_ids
+        array active_channels
+    }
+
+    RUN {
+        string run_id
+        string workflow
+        string brand_id
+        string surface
+        string status
+    }
+
+    ARTIFACT {
+        string artifact_id
+        string artifact_type
+        string workflow
+        string brand_id
+    }
+
+    ACTION {
+        string action_id
+        string channel
+        string action_type
+        string risk_tier
+        string approval_state
+        string execution_state
+    }
+```
+
+## Module Activation
+
+Module activation turns a business profile into operating defaults. A local-service brand gets call conversion, reviews, GBP, and speed-to-lead guidance; an ecommerce brand gets creative, product pages, retention, and paid social guidance.
+
+```mermaid
+flowchart LR
+    Input["Business or product context"]
+    Loader["kai/runtime/loader.py"]
+    Archetype["Primary archetype"]
+    Overlays["Optional overlays"]
+    Manifest["kai/runtime/modules/*.yaml"]
+    Brand["KaiBrandProfile.module_ids"]
+    Prompt["Prompt hints and workflow defaults"]
+    Gates["Checklist and KPI expectations"]
+
+    Input --> Loader
+    Loader --> Archetype
+    Loader --> Overlays
+    Archetype --> Manifest
+    Overlays --> Manifest
+    Manifest --> Brand
+    Brand --> Prompt
+    Brand --> Gates
+```
+
+## Code Map
+
+| Area | Files |
+|---|---|
+| Canonical models | `kai/runtime/models.py` |
+| Workspace and module loading | `kai/runtime/loader.py`, `kai/runtime/modules/*.yaml` |
+| Workflow registry | `kai/runtime/workflows.py` |
+| Persistence | `kai/runtime/store.py`, `kai/runtime/actions.py` |
+| Content generation | `scripts/content/engine.py`, `scripts/content/_writer.py`, `scripts/content/brief_generator.py` |
+| Quality gates | `scripts/quality_gates/*.py` |
+| Audit and proposals | `kai/audits/`, `kai/proposals/`, `kai/runtime/application_flow.py` |
+| Compliance and approval | `kai/compliance/`, `kai/runtime/policy.py`, `scripts/content/approval_policy.py` |
+| Remote API | `gateway/main.py`, `gateway/routers/runtime.py`, `gateway/routers/actions.py` |
+| Background work | `agent/scheduler.py`, `agent/tasks/` |
+

--- a/docs/system/schema-catalog.md
+++ b/docs/system/schema-catalog.md
@@ -1,0 +1,82 @@
+# Schema Catalog
+
+The schema files in [schemas/](schemas/) describe the contracts that tie the system together. They mirror the current dataclasses and registry shapes in `kai/runtime/`, plus the action proposal model in `kai/runtime/actions.py`.
+
+## Schema Index
+
+| Schema | Code shape | Use |
+|---|---|---|
+| [kai-workspace-profile.schema.json](schemas/kai-workspace-profile.schema.json) | `KaiWorkspaceProfile` | Workspace-level metadata, surfaces, plugins, and brands. |
+| [kai-brand-profile.schema.json](schemas/kai-brand-profile.schema.json) | `KaiBrandProfile` | Brand/business target loaded into a workspace. |
+| [kai-module-manifest.schema.json](schemas/kai-module-manifest.schema.json) | `KaiModuleManifest` | Archetype module manifest loaded from `kai/runtime/modules/*.yaml`. |
+| [workflow-definition.schema.json](schemas/workflow-definition.schema.json) | `WorkflowDefinition` | Product workflow registry entries from `kai/runtime/workflows.py`. |
+| [kai-run-request.schema.json](schemas/kai-run-request.schema.json) | `KaiRunRequest` | Local or remote run invocation. |
+| [kai-run-record.schema.json](schemas/kai-run-record.schema.json) | `KaiRunRecord` | Persisted run lifecycle record. |
+| [kai-artifact-record.schema.json](schemas/kai-artifact-record.schema.json) | `KaiArtifactRecord` | Persisted output artifact. |
+| [kai-runtime-state.schema.json](schemas/kai-runtime-state.schema.json) | `KaiRuntimeState` | Derived runtime index. |
+| [action-proposal.schema.json](schemas/action-proposal.schema.json) | `ActionProposal` | Proposed real-world marketing mutation. |
+| [system-documentation-bundle.schema.json](schemas/system-documentation-bundle.schema.json) | Documentation bundle | Optional manifest for this docs pack. |
+
+## Design Conventions
+
+- Schemas use JSON Schema draft 2020-12.
+- Dataclass dictionaries use `snake_case` keys.
+- `metadata`, `inputs`, `outputs`, and `data` are intentionally open objects.
+- Runtime status enums match the code at the time this guide was added.
+- Artifact types match `KaiArtifactRecord.artifact_type`.
+- Action approval and execution states match `kai/runtime/actions.py`.
+
+## Minimal Run Request
+
+```json
+{
+  "intent": "Write a local-service landing page for missed-call capture",
+  "workflow": "landing-page",
+  "brand_id": "kaicalls",
+  "surface": "local",
+  "module_set": ["local-service"],
+  "inputs": {
+    "keyword": "AI receptionist for plumbers",
+    "format": "landing-page"
+  },
+  "metadata": {
+    "requested_by": "operator"
+  }
+}
+```
+
+## Contract Chain
+
+```mermaid
+flowchart LR
+    Workspace["KaiWorkspaceProfile"]
+    Brand["KaiBrandProfile"]
+    Module["KaiModuleManifest"]
+    Workflow["WorkflowDefinition"]
+    Request["KaiRunRequest"]
+    Run["KaiRunRecord"]
+    Artifact["KaiArtifactRecord"]
+    Action["ActionProposal"]
+    State["KaiRuntimeState"]
+
+    Workspace --> Brand
+    Brand --> Module
+    Module --> Workflow
+    Workflow --> Request
+    Request --> Run
+    Run --> Artifact
+    Run --> Action
+    Artifact --> State
+    Action --> State
+```
+
+## Validation Example
+
+Use any draft 2020-12 JSON Schema validator. A dashboard or API client can validate before sending a remote request:
+
+```bash
+jsonschema -i request.json docs/system/schemas/kai-run-request.schema.json
+```
+
+The repo does not currently require these schemas at runtime. They are contract documentation that can be promoted into tests later.
+

--- a/docs/system/schemas/README.md
+++ b/docs/system/schemas/README.md
@@ -1,0 +1,19 @@
+# Runtime Schema Files
+
+These files are JSON Schema documents for the system contracts described in `docs/system/`.
+
+| File | Describes |
+|---|---|
+| `kai-workspace-profile.schema.json` | Workspace-level profile and embedded brands. |
+| `kai-brand-profile.schema.json` | Brand/business target profile. |
+| `kai-module-manifest.schema.json` | Archetype module manifest. |
+| `workflow-definition.schema.json` | Workflow registry entry. |
+| `kai-run-request.schema.json` | Local or remote run invocation. |
+| `kai-run-record.schema.json` | Persisted run lifecycle record. |
+| `kai-artifact-record.schema.json` | Persisted runtime artifact. |
+| `kai-runtime-state.schema.json` | Derived runtime state index. |
+| `action-proposal.schema.json` | Proposed live-channel action. |
+| `system-documentation-bundle.schema.json` | Optional manifest for docs packs like this one. |
+
+The schemas are intentionally permissive for `metadata`, `inputs`, `outputs`, and artifact `data` because each workflow can add specialized payloads.
+

--- a/docs/system/schemas/action-proposal.schema.json
+++ b/docs/system/schemas/action-proposal.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/action-proposal.schema.json",
+  "title": "ActionProposal",
+  "description": "A proposed real-world marketing mutation against a live channel.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["brand_id", "channel", "action_type", "intent"],
+  "properties": {
+    "action_id": {
+      "type": "string",
+      "default": ""
+    },
+    "brand_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "channel": {
+      "type": "string",
+      "description": "Marketing channel such as website, social, paid_media, email, analytics, or calls."
+    },
+    "action_type": {
+      "type": "string",
+      "description": "Provider-neutral action type such as update_page_copy or create_paused_campaign."
+    },
+    "intent": {
+      "type": "string",
+      "minLength": 1
+    },
+    "proposed_changes": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "default": []
+    },
+    "source_run_id": {
+      "type": ["string", "null"]
+    },
+    "risk_tier": {
+      "type": "string",
+      "enum": ["low", "medium", "high"],
+      "default": "low"
+    },
+    "policy_result": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {
+        "passed": true,
+        "checks": [],
+        "violations": []
+      }
+    },
+    "preview_artifact": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "approval_state": {
+      "type": "string",
+      "enum": ["pending", "approved", "rejected", "auto_approved", "held"],
+      "default": "pending"
+    },
+    "execution_state": {
+      "type": "string",
+      "enum": ["pending", "executing", "completed", "failed", "rolled_back"],
+      "default": "pending"
+    },
+    "verification_criteria": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      },
+      "default": []
+    },
+    "verification_result": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "rollback_reference": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "result_summary": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "memory_writeback_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    },
+    "created_at": {
+      "type": "string",
+      "default": ""
+    },
+    "updated_at": {
+      "type": "string",
+      "default": ""
+    },
+    "executed_at": {
+      "type": ["string", "null"]
+    }
+  }
+}
+

--- a/docs/system/schemas/kai-artifact-record.schema.json
+++ b/docs/system/schemas/kai-artifact-record.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/kai-artifact-record.schema.json",
+  "title": "KaiArtifactRecord",
+  "description": "Canonical artifact contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["artifact_id", "artifact_type", "brand_id", "workflow"],
+  "properties": {
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "artifact_type": {
+      "type": "string",
+      "enum": [
+        "brief",
+        "draft",
+        "audit_findings",
+        "campaign_plan",
+        "gate_proposal",
+        "approved_asset",
+        "published_asset",
+        "performance_snapshot",
+        "learned_pattern"
+      ]
+    },
+    "brand_id": {
+      "type": "string"
+    },
+    "workflow": {
+      "type": "string"
+    },
+    "module_set": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "source_run": {
+      "type": ["string", "null"]
+    },
+    "parent_artifact_id": {
+      "type": ["string", "null"]
+    },
+    "lineage_run_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "created_at": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string"
+    },
+    "data": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    }
+  }
+}
+

--- a/docs/system/schemas/kai-brand-profile.schema.json
+++ b/docs/system/schemas/kai-brand-profile.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/kai-brand-profile.schema.json",
+  "title": "KaiBrandProfile",
+  "description": "A brand or business target that runs inside the Kai runtime.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "name"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string",
+      "default": ""
+    },
+    "url": {
+      "type": ["string", "null"],
+      "format": "uri"
+    },
+    "primary_archetype": {
+      "type": ["string", "null"]
+    },
+    "archetype_overlays": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "module_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "active_channels": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "proof_points": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "persona_defaults": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "default": {}
+    },
+    "ga_property": {
+      "type": ["string", "null"]
+    },
+    "gsc_site": {
+      "type": ["string", "null"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    }
+  }
+}
+

--- a/docs/system/schemas/kai-module-manifest.schema.json
+++ b/docs/system/schemas/kai-module-manifest.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/kai-module-manifest.schema.json",
+  "title": "KaiModuleManifest",
+  "description": "Opinionated module manifest for a business archetype.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["id", "name", "description"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable module id, for example local-service."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "trigger_keywords": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "prompt_hints": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "required_memory_fields": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "default_workflows": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "checklist_paths": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "default_kpis": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "subagents": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "remote_automations": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    }
+  }
+}
+

--- a/docs/system/schemas/kai-run-record.schema.json
+++ b/docs/system/schemas/kai-run-record.schema.json
@@ -1,0 +1,77 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/kai-run-record.schema.json",
+  "title": "KaiRunRecord",
+  "description": "Persisted run record with lineage and lifecycle state.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["run_id", "intent", "workflow", "brand_id"],
+  "properties": {
+    "run_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "intent": {
+      "type": "string"
+    },
+    "workflow": {
+      "type": "string"
+    },
+    "brand_id": {
+      "type": "string"
+    },
+    "surface": {
+      "type": "string",
+      "enum": ["local", "remote"],
+      "default": "local"
+    },
+    "module_set": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "status": {
+      "type": "string",
+      "enum": ["running", "draft", "held", "approved", "completed", "failed"],
+      "default": "running"
+    },
+    "parent_run_id": {
+      "type": ["string", "null"]
+    },
+    "ancestor_run_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    },
+    "outputs": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    },
+    "artifact_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "started_at": {
+      "type": "string"
+    },
+    "updated_at": {
+      "type": "string"
+    },
+    "completed_at": {
+      "type": ["string", "null"]
+    }
+  }
+}
+

--- a/docs/system/schemas/kai-run-request.schema.json
+++ b/docs/system/schemas/kai-run-request.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/kai-run-request.schema.json",
+  "title": "KaiRunRequest",
+  "description": "Canonical run contract shared by local and remote surfaces.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["intent", "workflow", "brand_id"],
+  "properties": {
+    "intent": {
+      "type": "string",
+      "minLength": 1
+    },
+    "workflow": {
+      "type": "string",
+      "minLength": 1
+    },
+    "brand_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "surface": {
+      "type": "string",
+      "enum": ["local", "remote"],
+      "default": "local"
+    },
+    "module_set": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "inputs": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    }
+  }
+}
+

--- a/docs/system/schemas/kai-runtime-state.schema.json
+++ b/docs/system/schemas/kai-runtime-state.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/kai-runtime-state.schema.json",
+  "title": "KaiRuntimeState",
+  "description": "Mutable workspace state snapshot derived from runs and artifacts.",
+  "type": "object",
+  "additionalProperties": true,
+  "required": ["workspace_id", "updated_at"],
+  "properties": {
+    "workspace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "updated_at": {
+      "type": "string"
+    },
+    "latest_run_ids_by_brand": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "default": {}
+    },
+    "latest_run_ids_by_brand_workflow": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "default": {}
+    },
+    "latest_artifact_ids_by_brand": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "default": {}
+    },
+    "latest_artifact_ids_by_brand_workflow": {
+      "type": "object",
+      "additionalProperties": { "type": "string" },
+      "default": {}
+    },
+    "active_run_ids": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    }
+  }
+}
+

--- a/docs/system/schemas/kai-workspace-profile.schema.json
+++ b/docs/system/schemas/kai-workspace-profile.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/kai-workspace-profile.schema.json",
+  "title": "KaiWorkspaceProfile",
+  "description": "Canonical workspace profile for local and remote execution.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["workspace_id", "name"],
+  "properties": {
+    "workspace_id": {
+      "type": "string",
+      "minLength": 1,
+      "default": "kai-marketing-os"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "default": "Kai Marketing OS"
+    },
+    "description": {
+      "type": "string",
+      "default": "Marketing-native Claude Code-style runtime"
+    },
+    "primary_user": {
+      "type": "string",
+      "default": "operator_saas"
+    },
+    "product_mode": {
+      "type": "string",
+      "default": "clone"
+    },
+    "surfaces": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["local", "remote", "dashboard"]
+      },
+      "default": ["local", "remote"]
+    },
+    "brands": {
+      "type": "array",
+      "items": { "$ref": "kai-brand-profile.schema.json" },
+      "default": []
+    },
+    "enabled_plugins": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": ["kai-marketing"]
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    }
+  }
+}
+

--- a/docs/system/schemas/system-documentation-bundle.schema.json
+++ b/docs/system/schemas/system-documentation-bundle.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/system-documentation-bundle.schema.json",
+  "title": "SystemDocumentationBundle",
+  "description": "Optional manifest for a Kai system documentation pack.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["title", "version", "pages", "schemas"],
+  "properties": {
+    "title": {
+      "type": "string",
+      "minLength": 1
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "summary": {
+      "type": "string"
+    },
+    "pages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "path"],
+        "properties": {
+          "title": { "type": "string" },
+          "path": { "type": "string" },
+          "audience": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": []
+          },
+          "diagrams": {
+            "type": "array",
+            "items": { "type": "string" },
+            "default": []
+          }
+        }
+      }
+    },
+    "schemas": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["title", "path"],
+        "properties": {
+          "title": { "type": "string" },
+          "path": { "type": "string" },
+          "code_shape": { "type": "string" }
+        }
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": {}
+    }
+  }
+}
+

--- a/docs/system/schemas/workflow-definition.schema.json
+++ b/docs/system/schemas/workflow-definition.schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://kai-cmo-harness.local/schemas/workflow-definition.schema.json",
+  "title": "WorkflowDefinition",
+  "description": "A product workflow that can be invoked from Kai surfaces.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["workflow_id", "handler", "input_schema"],
+  "properties": {
+    "workflow_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "handler": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Python import path or handler id."
+    },
+    "input_schema": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the workflow input contract."
+    },
+    "output_artifacts": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "quality_policy": {
+      "type": "string",
+      "default": "default"
+    },
+    "supported_surfaces": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["local", "remote", "dashboard"]
+      },
+      "default": ["local", "remote", "dashboard"]
+    },
+    "content_format": {
+      "type": ["string", "null"]
+    },
+    "aliases": {
+      "type": "array",
+      "items": { "type": "string" },
+      "default": []
+    },
+    "local_service_asset": {
+      "type": ["string", "null"]
+    },
+    "risk_tier": {
+      "type": "string",
+      "enum": ["low", "medium", "high"],
+      "default": "medium"
+    },
+    "auto_run_allowed": {
+      "type": "boolean",
+      "default": false
+    }
+  }
+}
+


### PR DESCRIPTION
## What changed

- Added `docs/system/` as a reader-facing system guide for Kai CMO Harness.
- Added Mermaid diagrams for runtime structure, execution lifecycle, governance, remote gateway, connectors, lineage, and state flows.
- Added JSON Schema contracts for runtime profiles, workflow definitions, run records, artifacts, state, and action proposals.
- Added a root `README.md` link so the system guide is easy to discover from the main GitHub page.

## Why

New readers need a clear path into the repo without reverse-engineering the runtime from scattered implementation files. The system guide gives operators, contributors, and API clients a single docs entry point.

## Validation

- Parsed every new JSON schema with PowerShell `ConvertFrom-Json`.
- Checked all local links in `docs/system` resolve.

## Scope note

This PR intentionally includes only the new system docs, schema files, and README discoverability link. The working tree contains other pre-existing local changes that are not part of this PR.