### PR TITLE
fix(deps): declare missing runtime packages

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -21,6 +21,8 @@ searchconsole>=0.2.0
 # Data
 supabase>=2.0.0
 stripe>=7.0.0
+aiohttp>=3.9.0             # Async lead pipeline HTTP client
+feedparser>=6.0.0          # Reddit monitor and knowledge cloner RSS parsing
 
 # Statistical analysis
 scipy>=1.11.0

--- a/workspace/github-issue-triage/runs/2026-06-19/github-issue-22.md
+++ b/workspace/github-issue-triage/runs/2026-06-19/github-issue-22.md
@@ -1,0 +1,65 @@
+# GitHub Issue Triage Run: 2026-06-19
+
+## Inventory
+
+- needs_triage: 2 at intake (#21, #22)
+- actionable_now: 1 (#22)
+- needs_info: 0
+- duplicate_candidate: 0
+- blocked: 0
+- stale_or_low_value: 1 (#21)
+- security_or_private_disclosure_needed: 0
+- already_fixed_or_has_pr: 0
+- open_prs_at_intake: 0
+
+## Metadata And Comments Applied
+
+- Created/confirmed compact labels: `type/bug`, `type/chore`, `area/runtime`, `area/deps`.
+- Labeled #22 with `type/bug`, `priority/p2`, `area/runtime`, `area/deps`, and moved status from `status/ready` to `status/in-progress`.
+- Commented on #21 explaining it appeared to be a tracker test issue with no actionable Kai CMO Harness work.
+- Closed #21 as not planned after the cleanup comment.
+
+## Selected Issue
+
+- Issue: #22, "deps: openai (OpenRouter client) is required but undeclared - agent loop crashes on clean install"
+- Why actionable: the issue named concrete imports and a single dependency manifest target. Fresh `origin/main` already declared `openai`, but scoped import inspection confirmed `aiohttp` and `feedparser` were still imported by repo scripts and missing from `scripts/requirements.txt`.
+
+## Files Inspected
+
+- `AGENTS.md`
+- `memory/MEMORY.md`
+- `scripts/requirements.txt`
+- `agent/llm/router.py`
+- `scripts/leads/lead_pipeline.py`
+- `scripts/reddit_monitor/reddit_digest.py`
+- `scripts/knowledge_cloner/discovery.py`
+
+## Files Changed
+
+- `scripts/requirements.txt`
+  - Added `aiohttp>=3.9.0` for the async lead pipeline.
+  - Added `feedparser>=6.0.0` for Reddit monitor and knowledge cloner RSS parsing.
+
+## Verification
+
+- `python -c "<requirements declaration check>"` verified `openai`, `aiohttp`, and `feedparser` are declared.
+- Focused clean temp virtualenv verification passed:
+  - Installed `openai>=1.0.0`, `aiohttp>=3.9.0`, and `feedparser>=6.0.0`.
+  - Ran `import openai, aiohttp, feedparser`.
+  - Result: `focused imports ok`.
+- `git diff --check` passed. It only warned that Git may normalize line endings from LF to CRLF on Windows.
+
+## Blockers / Notes
+
+- Full `pip install -r scripts/requirements.txt` was attempted in a disposable temp virtualenv but failed before reaching this slice because `searchconsole>=0.2.0` has no matching distribution available to pip in this environment. That appears unrelated to #22 and should be handled as the next dependency cleanup slice.
+- The primary workspace at `E:\Dev2\kai-cmo-harness` had pre-existing local changes on `main`, so implementation used a separate clean worktree at `E:\Dev2\kai-cmo-harness-issue-22`.
+
+## PR / Merge Status
+
+- Branch: `codex/issue-22-declare-agent-deps`
+- PR: pending at run-note creation time.
+- Merge: pending at run-note creation time.
+
+## Next Recommended Slice
+
+Fix or re-scope the `searchconsole>=0.2.0` requirement so a full clean `pip install -r scripts/requirements.txt` can complete.

--- a/workspace/github-issue-triage/runs/2026-06-19/github-issue-22.md
+++ b/workspace/github-issue-triage/runs/2026-06-19/github-issue-22.md
@@ -57,8 +57,10 @@
 ## PR / Merge Status
 
 - Branch: `codex/issue-22-declare-agent-deps`
-- PR: pending at run-note creation time.
-- Merge: pending at run-note creation time.
+- PR: #23, https://github.com/cgallic/kai-cmo-harness/pull/23
+- Merge: left open; auto-merge skipped because PR checks were unstable.
+- Blocker: GitHub Pages `build-and-deploy` failed because branch `codex/issue-22-declare-agent-deps` is not allowed to deploy to the protected `github-pages` environment. Vercel was still pending when checked.
+- Comments: posted status comments on issue #22 and PR #23 with verification and blocker details.
 
 ## Next Recommended Slice
 


### PR DESCRIPTION
## Summary
- declare `aiohttp` for the async lead pipeline
- declare `feedparser` for Reddit monitor and knowledge cloner RSS parsing
- add the daily triage run note for issue #22

Closes #22

## Verification
- `python -c "<requirements declaration check>"`
- disposable temp venv: `pip install "openai>=1.0.0" "aiohttp>=3.9.0" "feedparser>=6.0.0"`
- disposable temp venv: `python -c "import openai, aiohttp, feedparser"`
- `git diff --check`

## Note
A full `pip install -r scripts/requirements.txt` was attempted but is currently blocked by existing `searchconsole>=0.2.0`, which pip could not resolve in this environment. That is recorded as the next recommended dependency cleanup slice.