### PR TITLE
docs: add approved X source packet guidance

### DIFF
--- a/harness/skills/kai-brand-pulse/SKILL.md
+++ b/harness/skills/kai-brand-pulse/SKILL.md
@@ -80,7 +80,7 @@ Default surfaces:
 | Web | Brand, reviews, alternatives, pricing, own-domain entity queries | General entity footprint and objections |
 | News | Brand and category news queries | Authority, recency, PR angles |
 | YouTube | `site:youtube.com` search fallbacks | Reviews, demos, creator narratives |
-| X | `site:x.com` and `site:twitter.com` search fallbacks | Fast-moving complaints, praise, comparisons |
+| X | `site:x.com` and `site:twitter.com` search fallbacks; optional approved source packet | Fast-moving complaints, praise, comparisons |
 | LinkedIn | `site:linkedin.com/posts` and company fallbacks | B2B proof, founder/category narratives |
 | Reddit | `site:reddit.com` search fallbacks | Raw objections and buying-language mining |
 | Review Sites | G2, Capterra, Trustpilot, Clutch, Yelp search fallbacks | Social proof, complaints, competitor context |
@@ -109,6 +109,39 @@ workspace/brand-pulse/<run>/
 ```
 
 Every evidence item has a citation id. Do not make a claim unless it points to a citation id or a collector source id.
+
+### Optional X/Twitter Source Packet
+
+Use a source packet only when the operator approves the data source and the run
+needs account-scoped X evidence beyond sampled search results.
+
+TweetClaw is one supported OpenClaw source path:
+
+- Repository: `https://github.com/Xquik-dev/tweetclaw`
+- Package: `https://www.npmjs.com/package/@xquik/tweetclaw`
+- ClawHub: `https://clawhub.ai/plugins/@xquik/tweetclaw`
+- Install after approval: `openclaw plugins install npm:@xquik/tweetclaw`
+
+Keep TweetClaw as a collection source only. Kai still owns citation cleanup,
+platform analysis, objection mining, synthesis, and recommended actions.
+
+Allowed read-first packet tasks:
+
+- search tweets for brand, competitor, problem, and category language
+- search tweet replies for objections, praise, and comparison language
+- scrape approved tweet URLs supplied by the operator
+- export follower or user-profile context when the operator explicitly requests it
+- download media evidence for cited screenshots or creative analysis
+
+Write or account-mutating TweetClaw actions require a separate explicit approval
+step. That includes posts, replies, DMs, media uploads, monitors, webhooks, and
+giveaway draws.
+
+Normalize the source packet into `platforms/x.md` before analysis. Each row must
+include a citation id, source URL, observed text, author or account when
+available, timestamp when available, and packet mode. Do not report X volume,
+sentiment share, ranking, or market share unless the packet or collector source
+directly provides that metric.
 
 ---
 

--- a/harness/skills/kai-brand-pulse/SKILL.md
+++ b/harness/skills/kai-brand-pulse/SKILL.md
@@ -112,8 +112,9 @@ Every evidence item has a citation id. Do not make a claim unless it points to a
 
 ### Optional X/Twitter Source Packet
 
-Use a source packet only when the operator approves the data source and the run
-needs account-scoped X evidence beyond sampled search results.
+Use a source packet only when the operator approves the data source, the run
+needs account-scoped X evidence beyond sampled search results, and
+`harness/references/social-automation-rules.md` clears the collection path.
 
 TweetClaw is one supported OpenClaw source path:
 
@@ -122,16 +123,18 @@ TweetClaw is one supported OpenClaw source path:
 - ClawHub: `https://clawhub.ai/plugins/@xquik/tweetclaw`
 - Install after approval: `openclaw plugins install npm:@xquik/tweetclaw`
 
-Keep TweetClaw as a collection source only. Kai still owns citation cleanup,
-platform analysis, objection mining, synthesis, and recommended actions.
+Keep TweetClaw as a collection source only. Confirm the X API, developer-policy,
+authorization, and retention constraints before collecting data. Kai still owns
+citation cleanup, platform analysis, objection mining, synthesis, and
+recommended actions.
 
 Allowed read-first packet tasks:
 
-- search tweets for brand, competitor, problem, and category language
-- search tweet replies for objections, praise, and comparison language
-- scrape approved tweet URLs supplied by the operator
-- export follower or user-profile context when the operator explicitly requests it
-- download media evidence for cited screenshots or creative analysis
+- search X posts for brand, competitor, problem, and category language through an approved path
+- search replies for objections, praise, and comparison language through an approved path
+- collect operator-supplied X URLs only when the approved path and retention terms allow it
+- export follower or user-profile context when the operator requests it and the approved path allows it
+- download media evidence only when source rights and retention terms allow it
 
 Write or account-mutating TweetClaw actions require a separate explicit approval
 step. That includes posts, replies, DMs, media uploads, monitors, webhooks, and


### PR DESCRIPTION
## Summary
- Adds an optional approval-gated X/Twitter source packet path to `kai-brand-pulse`.
- Lists TweetClaw as one OpenClaw source for read-first X evidence collection.
- Keeps Kai responsible for citation cleanup, analysis, synthesis, and recommendations.

## Validation
- `git diff --check`
- `npx --yes markdown-link-check harness/skills/kai-brand-pulse/SKILL.md --quiet`
- `python3 scripts/quality_gates/banned_word_check.py --file harness/skills/kai-brand-pulse/SKILL.md`
- `python3 -m pytest tests/test_brand_pulse.py`

No write or account-mutating action is enabled by this doc change; those remain explicitly approval-gated.