### PR TITLE
docs(triage): record daily issue cleanup

### DIFF
--- a/workspace/github-issue-triage/runs/2026-06-21/github-issue-22.md
+++ b/workspace/github-issue-triage/runs/2026-06-21/github-issue-22.md
@@ -1,0 +1,66 @@
+# GitHub Issue Triage Run: 2026-06-21
+
+## Inventory
+
+- needs_triage: 0
+- actionable_now: 0
+- needs_info: 0
+- duplicate_candidate: 0
+- blocked: 0
+- stale_or_low_value: 0
+- security_or_private_disclosure_needed: 0
+- already_fixed_or_has_pr: 1 (#22, PR #23)
+- open_prs_at_intake: 2 (#23, #24)
+
+## Metadata And Comments Applied
+
+- Confirmed #22 already had compact triage metadata: `type/bug`, `priority/p2`, `area/runtime`, `area/deps`, and `status/in-progress`.
+- Merged PR #23, which closed #22 via `Closes #22`.
+- Updated #22 after closure by removing `status/in-progress` and adding `status/done`.
+- No new issue comments were needed; prior comments already documented the implementation, verification, and the earlier Pages check blocker.
+
+## Selected Issue
+
+- Issue: #22, "deps: openai (OpenRouter client) is required but undeclared - agent loop crashes on clean install"
+- Why actionable: the issue already had a focused implementation PR. The useful daily action was to re-check the merge blocker, merge the completed fix, and clean up issue status metadata.
+
+## Files Inspected
+
+- `AGENTS.md`
+- `memory/MEMORY.md`
+- `.github/workflows/deploy-dashboard.yml`
+- GitHub issue #22
+- GitHub PR #23
+- GitHub PR #24
+
+## Files Changed
+
+- `workspace/github-issue-triage/runs/2026-06-21/github-issue-22.md`
+  - Recorded the daily triage inventory, merge result, metadata cleanup, and remaining next slice.
+
+## Verification
+
+- `gh issue list --repo cgallic/kai-cmo-harness --state open --limit 100 --json number,title,labels,url`
+  - Result: `[]`
+- `gh pr view 23 --repo cgallic/kai-cmo-harness --json number,state,mergedAt,mergeCommit,statusCheckRollup,url,headRefName`
+  - Result: PR #23 is merged at `2026-06-21T03:03:04Z`; merge commit `e714b7e858671bb7a991fe2bd334dcdb8607fefb`.
+- `gh issue view 22 --repo cgallic/kai-cmo-harness --json number,state,closedAt,labels,url`
+  - Result: #22 is closed and labeled `status/done`.
+
+## Blockers / Notes
+
+- No open GitHub issues remain after this run.
+- PR #24 remains open and is not linked to an issue. Its Vercel status is failing with an authorization URL, so it was not treated as issue-clearing work.
+- The primary workspace at `E:\Dev2\kai-cmo-harness` still has pre-existing local edits in root instruction/context files. The run note was created from a clean temporary worktree at `C:\Users\cgall\AppData\Local\Temp\kai-cmo-triage-20260621`.
+
+## PR / Merge Status
+
+- Existing implementation branch: `codex/issue-22-declare-agent-deps`
+- Existing implementation PR: #23, https://github.com/cgallic/kai-cmo-harness/pull/23
+- Merge: succeeded via normal squash merge with branch deletion.
+- Auto-merge: succeeded after re-checking the earlier blocker; GitHub accepted the merge and closed #22.
+- Run-note branch: `codex/daily-issue-triage-2026-06-21`
+
+## Next Recommended Slice
+
+Fix or re-scope the `searchconsole>=0.2.0` requirement so a full clean `pip install -r scripts/requirements.txt` can complete.


### PR DESCRIPTION
## Summary
- records the 2026-06-21 GitHub issue triage run
- notes PR #23 merge, issue #22 closure, and status metadata cleanup
- records the remaining dependency cleanup slice

## Verification
- git diff --check
- gh issue list --repo cgallic/kai-cmo-harness --state open --limit 100 --json number,title,labels,url
- gh pr view 23 --repo cgallic/kai-cmo-harness --json number,state,mergedAt,mergeCommit,statusCheckRollup,url,headRefName

No product/runtime code changed.