### PR TITLE
docs(triage): record zero issue queue

### DIFF
--- a/workspace/github-issue-triage/runs/2026-06-22/github-issue-no-open-issues.md
+++ b/workspace/github-issue-triage/runs/2026-06-22/github-issue-no-open-issues.md
@@ -1,0 +1,76 @@
+# Daily GitHub Issue Triage - 2026-06-22
+
+## Scope
+
+- Automation: Daily Kai CMO GitHub Issue Triage
+- Repository: `cgallic/kai-cmo-harness`
+- Workspace used: `E:\Dev2\kai-cmo-harness`
+- Clean worktree used for this note: `E:\Dev2\kai-cmo-harness-triage-2026-06-22`
+- Primary workspace state: local `main` was behind origin and had pre-existing edits to `.gitignore`, `AGENTS.md`, `CLAUDE.md`, plus untracked backup/context files. Those changes were not touched.
+
+## Current GitHub State
+
+- Open issues: 0
+- Open PRs: 1
+- Open PR not tied to an issue: #24, `docs: add approved X source packet guidance`
+- PR #24 blocker: Vercel status check is failing with an authorization URL, so it remains open and unmerged.
+
+## Triage Inventory
+
+| Bucket | Count | Notes |
+| --- | ---: | --- |
+| `needs_triage` | 0 | No open issues. |
+| `actionable_now` | 0 | No open issues to select. |
+| `needs_info` | 0 | No missing-info issue present. |
+| `duplicate_candidate` | 0 | No open duplicate candidates. |
+| `blocked` | 0 | No open issue blockers. |
+| `stale_or_low_value` | 0 | No open issues to evaluate for stale handling. |
+| `security_or_private_disclosure_needed` | 0 | No open security-sensitive issue present. |
+| `already_fixed_or_has_pr` | 0 | No open issues with linked PRs. |
+
+## Metadata and Comments Applied
+
+- No issue metadata applied because the open issue queue is empty.
+- No issue comments added because there were no issues requiring status, duplicate, missing-info, stale, or closure comments.
+- No PR metadata changed. PR #24 is not issue-linked and remains blocked by the external Vercel authorization check.
+
+## Selected Issue
+
+- Selected issue: none.
+- Reason: `gh issue list --repo cgallic/kai-cmo-harness --state open --limit 100` returned an empty issue queue.
+- Implementation work: none selected because the daily issue-clearing queue had no actionable issue.
+
+## Files Inspected
+
+- `AGENTS.md`
+- `memory/MEMORY.md`
+- Automation memory at `C:\Users\cgall\.codex\automations\daily-kai-cmo-github-issue-triage\memory.md`
+- GitHub issue list for `cgallic/kai-cmo-harness`
+- GitHub PR list and PR #24 status details
+
+## Files Changed
+
+- `workspace/github-issue-triage/runs/2026-06-22/github-issue-no-open-issues.md`
+
+## Verification
+
+- `git fetch --prune origin`
+- `git status --short --branch`
+- `gh issue list --repo cgallic/kai-cmo-harness --state open --limit 100 --json number,title,labels,assignees,milestone,createdAt,updatedAt,author,url`
+- `gh pr list --repo cgallic/kai-cmo-harness --state open --limit 100 --json number,title,headRefName,baseRefName,isDraft,labels,assignees,createdAt,updatedAt,url`
+- `gh pr view 24 --repo cgallic/kai-cmo-harness --json number,title,state,mergeStateStatus,statusCheckRollup,reviewDecision,headRefName,baseRefName,url,closingIssuesReferences`
+
+## PR and Merge Status
+
+- Branch: `codex/daily-issue-triage-2026-06-22`
+- PR: #26, `docs(triage): record zero issue queue`
+- Auto-merge: blocked.
+- Blocker: the `build-and-deploy` GitHub Pages workflow failed because branch `codex/daily-issue-triage-2026-06-22` is not allowed to deploy to `github-pages` under environment protection rules.
+- Passing checks: `self-check`, `Vercel`, and `Vercel Preview Comments`.
+- Known separate blocker: unrelated PR #24 remains blocked by Vercel authorization.
+
+## Next Recommended Slice
+
+- Keep the issue queue at zero on the next run.
+- Separately resolve PR #24 by authorizing the Vercel GitHub integration or removing that deployment requirement for docs-only changes.
+- Carry forward the dependency cleanup suggestion from the previous automation memory: investigate `searchconsole>=0.2.0` so a clean `pip install -r scripts/requirements.txt` can complete.


### PR DESCRIPTION
## Summary
- records the 2026-06-22 daily GitHub issue triage pass
- documents that the open issue queue is empty
- notes existing PR #24 remains blocked by Vercel authorization

## Verification
- `gh issue list --repo cgallic/kai-cmo-harness --state open --limit 100 --json number,title,labels,assignees,milestone,createdAt,updatedAt,author,url`
- `gh pr view 24 --repo cgallic/kai-cmo-harness --json number,title,state,mergeStateStatus,statusCheckRollup,reviewDecision,headRefName,baseRefName,url,closingIssuesReferences`