### PR TITLE
feat(autonomy): control layer ledger, decision router, impact cards

### DIFF
--- a/data/autonomy/README.md
+++ b/data/autonomy/README.md
@@ -1,0 +1,33 @@
+# Autonomy ledger
+
+This folder holds `ledger.jsonl`, the append-only record of every autonomy run
+(GitHub issue #27). The file is runtime data and is gitignored; only this README
+is tracked so the location stays discoverable.
+
+## What writes here
+
+`scripts/autonomy/ledger.py` appends one JSON object per automation run. The
+social platform monitor (`scripts.social.platform_change_monitor`) is the first
+converted automation. Each record carries:
+
+`run_id`, `workflow`, `started_at`, `finished_at`, `inputs`, `sources_checked`,
+`findings`, `actions_taken`, `files_changed`, `validation`, `risk_level`,
+`requires_human`, `blockers`, `lessons`, `followups`.
+
+Every finding inside a record carries an explicit `decision` (one of
+`auto_fix`, `auto_pr`, `stage_for_approval`, `escalate`, `block`) and a
+`risk_level`, set by `scripts/autonomy/decisions.py`.
+
+## Reading it
+
+```python
+from scripts.autonomy.ledger import read_records, mine_repeated_lessons
+
+records = read_records()
+repeated = mine_repeated_lessons(records, min_count=2)  # promotion candidates
+```
+
+## Controls
+
+- `KAI_AUTONOMY_LEDGER=0` disables writes.
+- `KAI_AUTONOMY_DIR=/some/path` redirects the ledger location.

--- a/scripts/autonomy/__init__.py
+++ b/scripts/autonomy/__init__.py
@@ -1,0 +1,40 @@
+"""Kai autonomy control layer.
+
+The control layer is the part of Kai that decides what a finding means, what
+action is allowed, what must be verified, and what needs human approval. It sits
+between raw automations (monitors, patchers, publishers) and the systems they
+touch.
+
+Modules:
+  - ``ledger``    append-only, machine-readable record of every automation run
+  - ``decisions`` maps findings to a permitted action class (the policy router)
+  - ``impact``    turns raw change signals into practical impact cards
+
+See GitHub issue #27 for the full design and the broader roadmap.
+"""
+
+from scripts.autonomy.decisions import (
+    ACTION_CLASSES,
+    RISK_LEVELS,
+    DecisionResult,
+    route_decision,
+)
+from scripts.autonomy.ledger import (
+    LedgerRecord,
+    mine_repeated_lessons,
+    new_run_id,
+    read_records,
+    record_run,
+)
+
+__all__ = [
+    "ACTION_CLASSES",
+    "RISK_LEVELS",
+    "DecisionResult",
+    "route_decision",
+    "LedgerRecord",
+    "mine_repeated_lessons",
+    "new_run_id",
+    "read_records",
+    "record_run",
+]

--- a/scripts/autonomy/decisions.py
+++ b/scripts/autonomy/decisions.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Policy decision engine — maps a finding to a permitted action class.
+
+This is the rules layer that makes Kai's judgment explicit instead of implied by
+agent prose. Every finding gets routed to exactly one action class, and the
+chosen class is recorded in the autonomy ledger.
+
+Action classes (ordered least -> most restrictive):
+  auto_fix           safe docs, registries, snapshots, dead-link/lint-only changes
+  auto_pr            code or content changes that need review before merge
+  stage_for_approval emails, client-facing claims, publishing, paid spend, account changes
+  escalate           unclear business fit, missing source, ambiguous policy
+  block              deception, astroturfing, scraping outside terms, credential misuse, rule evasion
+
+The engine is deliberately conservative: when signals are ambiguous it routes up,
+never down. Guardrail matches (block) always win.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+# Risk vocabulary, ordered low -> high. Shared with the ledger.
+RISK_LEVELS: tuple[str, ...] = ("none", "low", "medium", "high", "critical")
+
+# Action classes, ordered least -> most restrictive.
+ACTION_CLASSES: tuple[str, ...] = (
+    "auto_fix",
+    "auto_pr",
+    "stage_for_approval",
+    "escalate",
+    "block",
+)
+
+# Substrings that force a hard block regardless of any other signal. These are
+# the activities the guardrails forbid Kai from ever automating.
+_BLOCK_SIGNALS: tuple[str, ...] = (
+    "deception",
+    "deceive",
+    "astroturf",
+    "fake engagement",
+    "fake review",
+    "bought account",
+    "buy followers",
+    "hidden ownership",
+    "undisclosed ownership",
+    "scrape outside",
+    "scraping outside",
+    "credential misuse",
+    "steal credential",
+    "rule evasion",
+    "evade detection",
+    "evade platform",
+    "duplicate-content evasion",
+    "cloaking",
+)
+
+# Action kinds that always need a human before they touch the outside world.
+_APPROVAL_ACTIONS: frozenset[str] = frozenset(
+    {
+        "send_email",
+        "outbound_email",
+        "cold_email",
+        "publish",
+        "live_publish",
+        "post",
+        "client_claim",
+        "client_report",
+        "paid_spend",
+        "paid_media",
+        "budget_change",
+        "account_change",
+        "credential_change",
+        "deploy",
+        "legal_content",
+        "compliance_content",
+    }
+)
+
+# Conditions that mean we cannot decide safely on our own.
+_ESCALATE_SIGNALS: tuple[str, ...] = (
+    "unclear business fit",
+    "missing source",
+    "no source",
+    "source missing",
+    "ambiguous policy",
+    "unresolved",
+    "needs manual review",
+    "manual review",
+)
+
+
+@dataclass
+class DecisionResult:
+    """The routed action class plus the reason and any rolled-up risk."""
+
+    action_class: str
+    reason: str
+    risk_level: str = "low"
+    requires_human: bool = field(default=False)
+
+    def __post_init__(self) -> None:
+        self.requires_human = self.action_class in {
+            "stage_for_approval",
+            "escalate",
+            "block",
+        }
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "decision": self.action_class,
+            "decision_reason": self.reason,
+            "risk_level": self.risk_level,
+            "requires_human": self.requires_human,
+        }
+
+
+def _haystack(finding: dict[str, Any]) -> str:
+    """Flatten the searchable text of a finding for signal matching."""
+    parts: list[str] = []
+    for key in ("title", "summary", "why_it_matters", "what_changed", "notes", "impact_area"):
+        value = finding.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    for tag in finding.get("tags", []) or []:
+        if isinstance(tag, str):
+            parts.append(tag)
+    return " ".join(parts).lower()
+
+
+def route_decision(finding: dict[str, Any]) -> DecisionResult:
+    """Route a single finding to one action class.
+
+    ``finding`` may carry: ``action_kind`` (what the automation would do),
+    ``risk_level``, ``change_type`` ("docs"|"registry"|"snapshot"|"dead_link"|
+    "lint"|"code"|"content"), ``source_status`` ("fixed"|"replaced"|
+    "unresolved"), and free text fields used for guardrail matching.
+    """
+    risk = finding.get("risk_level", "low")
+    if risk not in RISK_LEVELS:
+        risk = "low"
+    text = _haystack(finding)
+    action_kind = (finding.get("action_kind") or "").strip().lower()
+    change_type = (finding.get("change_type") or "").strip().lower()
+    source_status = (finding.get("source_status") or "").strip().lower()
+
+    # 1. Guardrails always win.
+    for signal in _BLOCK_SIGNALS:
+        if signal in text or signal in action_kind:
+            return DecisionResult("block", f"guardrail: matched '{signal}'", "critical")
+
+    # 2. Outside-world actions need a person.
+    if action_kind in _APPROVAL_ACTIONS:
+        return DecisionResult(
+            "stage_for_approval",
+            f"action '{action_kind}' touches a live/client surface",
+            _max_risk(risk, "high"),
+        )
+
+    # 3. Unresolved or ambiguous source/policy -> escalate to a human.
+    if source_status == "unresolved":
+        return DecisionResult("escalate", "source unresolved; needs manual review", _max_risk(risk, "medium"))
+    for signal in _ESCALATE_SIGNALS:
+        if signal in text:
+            return DecisionResult("escalate", f"ambiguous: matched '{signal}'", _max_risk(risk, "medium"))
+
+    # 4. Safe self-service edits the automation can make directly.
+    safe_changes = {"docs", "registry", "snapshot", "dead_link", "lint"}
+    if change_type in safe_changes and risk in ("none", "low"):
+        return DecisionResult("auto_fix", f"safe {change_type} change", risk if risk != "none" else "low")
+
+    # 5. Code/content changes that should go through review.
+    if change_type in {"code", "content"} or risk in ("medium", "high", "critical"):
+        return DecisionResult("auto_pr", f"{change_type or 'change'} needs review before merge", _max_risk(risk, "medium"))
+
+    # 6. Default: surface for review rather than acting silently.
+    return DecisionResult("auto_pr", "unclassified change; defaulting to review", _max_risk(risk, "low"))
+
+
+def _max_risk(a: str, b: str) -> str:
+    """Return the higher of two risk levels."""
+    if a not in RISK_LEVELS:
+        a = "low"
+    if b not in RISK_LEVELS:
+        b = "low"
+    return a if RISK_LEVELS.index(a) >= RISK_LEVELS.index(b) else b

--- a/scripts/autonomy/impact.py
+++ b/scripts/autonomy/impact.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Impact classifier — turn raw change signals into practical impact cards.
+
+Monitors used to report "hash changed" or "status 404". That is a log, not a
+decision. This module upgrades a change signal into an impact card answering the
+questions an operator actually has:
+
+  what changed · why it matters · action taken · remaining risk · confidence ·
+  source url · next recommended gate/registry/doc update
+
+It also classifies broken sources as ``fixed``, ``replaced``, or ``unresolved``
+manual-review items, so a dead link never silently rots in the registry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from scripts.autonomy.decisions import route_decision
+
+# Map a registry category to the operational area it affects and a plain-language
+# consequence. Categories come from
+# harness/references/social-platform-source-registry.json.
+_CATEGORY_IMPACT: dict[str, tuple[str, str]] = {
+    "policy": (
+        "allowed content",
+        "allowed-content rules may have shifted; recheck the owner doc and the pre-publish gate",
+    ),
+    "ai_policy": (
+        "AI/synthetic media labels",
+        "AI/synthetic media disclosure rules may have changed; the pre-publish gate may need an AI/synthetic-media question",
+    ),
+    "ads_policy": (
+        "paid amplification",
+        "ad eligibility or prohibited-content rules may have changed; recheck ad copy gates before the next paid run",
+    ),
+    "commercial_policy": (
+        "commercial disclosure",
+        "branded-content or disclosure requirements may have changed; recheck commercial-disclosure rules",
+    ),
+    "data_policy": (
+        "privacy/data use",
+        "data-use or privacy terms may have changed; recheck what data automations may collect or store",
+    ),
+    "automation": (
+        "API automation",
+        "automation rules may have changed; the scheduler or write actions may need updated guardrails",
+    ),
+    "developer": (
+        "API automation",
+        "developer terms may have changed; API usage limits or content-usage rules may affect automations",
+    ),
+    "changelog": (
+        "scheduling/rate limits",
+        "an API change may affect posting limits, required upload fields, or the scheduler",
+    ),
+    "recommendation": (
+        "recommendation eligibility",
+        "ranking or eligibility guidance may have changed; recheck distribution playbooks",
+    ),
+    "monetization": (
+        "paid amplification",
+        "monetization or eligibility rules may have changed; recheck program assumptions",
+    ),
+    "terms": (
+        "community-specific rules",
+        "platform terms may have changed; recheck the owner doc for new prohibited behavior",
+    ),
+}
+
+_DEFAULT_IMPACT = (
+    "allowed content",
+    "platform guidance may have changed; recheck the owner doc",
+)
+
+
+def classify_source_status(result: dict[str, Any]) -> str:
+    """Classify a broken/recovered source as fixed, replaced, or unresolved.
+
+    - ``fixed``      — source errored before but fetched cleanly this run
+    - ``replaced``   — source is still broken but the registry names a replacement
+    - ``unresolved`` — source is broken with no known replacement (manual review)
+    - ``ok``         — source fetched cleanly and was not previously broken
+    """
+    ok = result.get("ok") or result.get("monitor_status") not in {"error", None}
+    if result.get("monitor_status") == "error" or result.get("ok") is False:
+        ok = False
+    previous_error = bool(result.get("previous_error"))
+    if ok:
+        return "fixed" if previous_error else "ok"
+    if result.get("replacement_url"):
+        return "replaced"
+    return "unresolved"
+
+
+def _confidence(status: str, source_status: str) -> str:
+    """How sure are we that the impact assessment is right?"""
+    if source_status == "unresolved":
+        return "high"  # we are sure the source is broken
+    if status == "changed":
+        return "medium"  # we know it changed, not yet what changed
+    if status == "new":
+        return "medium"
+    return "high"
+
+
+def build_impact_card(result: dict[str, Any]) -> dict[str, Any]:
+    """Build one practical impact card from a monitor source result.
+
+    ``result`` is a registry source merged with fetch outcome, carrying at least
+    ``platform``, ``category``, ``title``, ``url``, ``monitor_status`` and the
+    optional ``owner_file`` / ``previous_error`` / ``replacement_url`` fields.
+    """
+    status = result.get("monitor_status", "unchanged")
+    category = result.get("category", "")
+    impact_area, consequence = _CATEGORY_IMPACT.get(category, _DEFAULT_IMPACT)
+    source_status = classify_source_status(result)
+    owner_file = result.get("owner_file", "")
+
+    # what changed
+    if status == "error" or source_status in {"unresolved", "replaced"}:
+        what = f"Source unreachable ({result.get('error') or result.get('status_code') or 'fetch failed'})"
+    elif status == "changed":
+        prev = (result.get("previous_hash") or "")[:12]
+        cur = (result.get("content_hash") or "")[:12]
+        what = f"Content hash changed ({prev} -> {cur})"
+    elif status == "new":
+        what = "New source added to monitoring; baseline captured"
+    elif source_status == "fixed":
+        what = "Previously broken source is reachable again"
+    else:
+        what = "No change since last run"
+
+    # action taken + remaining risk + next step, by situation
+    if source_status == "unresolved":
+        action_taken = "Flagged for manual review; registry entry left unchanged"
+        remaining_risk = "Guidance for this source cannot be verified until the link is fixed or replaced"
+        next_step = f"Find a canonical replacement URL for `{result.get('id')}` or mark the registry entry deprecated"
+        change_type = "dead_link"
+    elif source_status == "replaced":
+        action_taken = "Replacement URL recorded for review"
+        remaining_risk = "New URL must be confirmed canonical before the registry is updated"
+        next_step = f"Confirm replacement `{result.get('replacement_url')}` and update the registry entry"
+        change_type = "registry"
+    elif status == "changed":
+        action_taken = "Snapshot hash updated; change logged for owner-doc review"
+        remaining_risk = "The specific rule change is not yet read into the owner doc"
+        next_step = (
+            f"Review `{owner_file}` against the live page and update it" if owner_file else "Assign an owner doc for this source"
+        )
+        change_type = "docs"
+    elif status == "new":
+        action_taken = "Baseline snapshot captured"
+        remaining_risk = "No prior baseline to diff against yet"
+        next_step = "Confirm the owner doc reflects current guidance"
+        change_type = "snapshot"
+    elif source_status == "fixed":
+        action_taken = "Snapshot refreshed now that the source is reachable"
+        remaining_risk = "Confirm the recovered page still matches the owner doc"
+        next_step = f"Spot-check `{owner_file}`" if owner_file else "Assign an owner doc for this source"
+        change_type = "snapshot"
+    else:
+        action_taken = "Snapshot hash confirmed unchanged"
+        remaining_risk = "None"
+        next_step = "No action needed"
+        change_type = "snapshot"
+
+    why = consequence if status in {"changed", "new", "error"} or source_status in {"fixed", "unresolved", "replaced"} else "No operational impact this run"
+
+    finding = {
+        "id": result.get("id"),
+        "platform": result.get("platform"),
+        "category": category,
+        "title": result.get("title"),
+        "monitor_status": status,
+        "source_status": source_status,
+        "impact_area": impact_area,
+        "what_changed": what,
+        "why_it_matters": why,
+        "action_taken": action_taken,
+        "remaining_risk": remaining_risk,
+        "confidence": _confidence(status, source_status),
+        "source_url": result.get("url"),
+        "next_step": next_step,
+        "owner_file": owner_file,
+        "change_type": change_type,
+    }
+    decision = route_decision(finding)
+    finding.update(decision.as_dict())
+    return finding

--- a/scripts/autonomy/ledger.py
+++ b/scripts/autonomy/ledger.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Autonomy ledger — append-only, machine-readable record of every run.
+
+Each automation run writes one typed JSON line to ``data/autonomy/ledger.jsonl``.
+The ledger is the source of truth for mining repeated failures, successes, and
+stale guidance, and for promoting recurring lessons into checklists, gates, and
+evals.
+
+Design constraints (mirror ``scripts/quality_gates/gate_logger.py``):
+  - Never crash the caller. Logging failures are swallowed.
+  - Stdlib only; no new dependencies.
+  - Opt out with ``KAI_AUTONOMY_LEDGER=0``; redirect with ``KAI_AUTONOMY_DIR``.
+
+Schema (one object per line):
+  run_id          stable id for the run (workflow + UTC timestamp + short uuid)
+  workflow        dotted automation name, e.g. "scripts.social.platform_change_monitor"
+  started_at      ISO-8601 UTC
+  finished_at     ISO-8601 UTC
+  inputs          dict of run inputs (filters, flags)
+  sources_checked list of source ids / urls inspected
+  findings        list of finding dicts (each carries risk_level + decision)
+  actions_taken   list of strings describing what the run actually did
+  files_changed   list of repo-relative paths written
+  validation      dict describing how the run was verified
+  risk_level      highest risk across findings ("none"|"low"|"medium"|"high"|"critical")
+  requires_human  bool — true if any finding routed to approval/escalate/block
+  blockers        list of strings preventing completion
+  lessons         list of short, stable lesson signatures for mining
+  followups       list of recommended next steps (gate/registry/doc updates)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Ordered low -> high so callers can compare and roll up.
+from scripts.autonomy.decisions import RISK_LEVELS  # noqa: E402  (intentional: shared vocabulary)
+
+# Fields a ledger record always carries, in stable order, for readers/tests.
+LEDGER_FIELDS: tuple[str, ...] = (
+    "run_id",
+    "workflow",
+    "started_at",
+    "finished_at",
+    "inputs",
+    "sources_checked",
+    "findings",
+    "actions_taken",
+    "files_changed",
+    "validation",
+    "risk_level",
+    "requires_human",
+    "blockers",
+    "lessons",
+    "followups",
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def ledger_path() -> Path:
+    """Return the active ledger path, honoring ``KAI_AUTONOMY_DIR``."""
+    base = os.environ.get("KAI_AUTONOMY_DIR")
+    if base:
+        return Path(base) / "ledger.jsonl"
+    return REPO_ROOT / "data" / "autonomy" / "ledger.jsonl"
+
+
+def new_run_id(workflow: str) -> str:
+    """Build a sortable, unique run id from the workflow name and current time."""
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    short = uuid.uuid4().hex[:8]
+    leaf = workflow.rsplit(".", 1)[-1]
+    return f"{leaf}-{stamp}-{short}"
+
+
+def _rollup_risk(findings: list[dict[str, Any]]) -> str:
+    """Return the highest risk level present across findings."""
+    highest = "none"
+    for finding in findings:
+        level = finding.get("risk_level", "none")
+        if level not in RISK_LEVELS:
+            level = "none"
+        if RISK_LEVELS.index(level) > RISK_LEVELS.index(highest):
+            highest = level
+    return highest
+
+
+def _needs_human(findings: list[dict[str, Any]]) -> bool:
+    """True if any finding routed to an action class that requires a person."""
+    human_classes = {"stage_for_approval", "escalate", "block"}
+    return any(f.get("decision") in human_classes for f in findings)
+
+
+@dataclass
+class LedgerRecord:
+    """One automation run. Use :meth:`finish` then :func:`record_run`."""
+
+    workflow: str
+    run_id: str = ""
+    started_at: str = field(default_factory=_utc_now)
+    finished_at: str = ""
+    inputs: dict[str, Any] = field(default_factory=dict)
+    sources_checked: list[Any] = field(default_factory=list)
+    findings: list[dict[str, Any]] = field(default_factory=list)
+    actions_taken: list[str] = field(default_factory=list)
+    files_changed: list[str] = field(default_factory=list)
+    validation: dict[str, Any] = field(default_factory=dict)
+    risk_level: str = "none"
+    requires_human: bool = False
+    blockers: list[str] = field(default_factory=list)
+    lessons: list[str] = field(default_factory=list)
+    followups: list[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            self.run_id = new_run_id(self.workflow)
+
+    def finish(self) -> "LedgerRecord":
+        """Stamp completion time and derive ``risk_level`` / ``requires_human``.
+
+        Both derived fields are recomputed from ``findings`` so callers cannot
+        forget to set them; an explicit non-default value is preserved only when
+        it is stricter than the derived one.
+        """
+        if not self.finished_at:
+            self.finished_at = _utc_now()
+        derived_risk = _rollup_risk(self.findings)
+        if RISK_LEVELS.index(derived_risk) >= RISK_LEVELS.index(self.risk_level):
+            self.risk_level = derived_risk
+        self.requires_human = self.requires_human or _needs_human(self.findings)
+        return self
+
+    def to_record(self) -> dict[str, Any]:
+        data = asdict(self)
+        # Emit in stable field order for deterministic, diff-friendly lines.
+        return {key: data[key] for key in LEDGER_FIELDS}
+
+
+def record_run(record: LedgerRecord, path: Path | None = None) -> dict[str, Any] | None:
+    """Append a finished run to the ledger. Never raises.
+
+    Returns the written record (useful for tests), or ``None`` when logging is
+    disabled or fails.
+    """
+    if os.environ.get("KAI_AUTONOMY_LEDGER", "1") == "0":
+        return None
+    try:
+        record.finish()
+        payload = record.to_record()
+        target = path or ledger_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with open(target, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        return payload
+    except Exception:
+        return None
+
+
+def read_records(path: Path | None = None) -> list[dict[str, Any]]:
+    """Read every ledger record. Skips malformed lines rather than raising."""
+    target = path or ledger_path()
+    if not target.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for line in target.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return records
+
+
+def mine_repeated_lessons(
+    records: list[dict[str, Any]] | None = None,
+    *,
+    min_count: int = 2,
+    path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Group lesson signatures that recur across runs.
+
+    Returns a list of ``{"lesson", "count", "run_ids", "workflows"}`` sorted by
+    descending count. Lessons seen at least ``min_count`` times are candidates
+    for promotion (memory -> checklist -> gate/eval), per the issue's promotion
+    ladder.
+    """
+    if records is None:
+        records = read_records(path)
+    counts: dict[str, dict[str, Any]] = {}
+    for rec in records:
+        run_id = rec.get("run_id", "")
+        workflow = rec.get("workflow", "")
+        for lesson in rec.get("lessons", []) or []:
+            bucket = counts.setdefault(
+                lesson, {"lesson": lesson, "count": 0, "run_ids": [], "workflows": set()}
+            )
+            bucket["count"] += 1
+            bucket["run_ids"].append(run_id)
+            bucket["workflows"].add(workflow)
+    mined = [
+        {
+            "lesson": b["lesson"],
+            "count": b["count"],
+            "run_ids": b["run_ids"],
+            "workflows": sorted(b["workflows"]),
+        }
+        for b in counts.values()
+        if b["count"] >= min_count
+    ]
+    mined.sort(key=lambda b: (-b["count"], b["lesson"]))
+    return mined

--- a/scripts/social/platform_change_monitor.py
+++ b/scripts/social/platform_change_monitor.py
@@ -25,6 +25,11 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from scripts.autonomy.impact import build_impact_card
+from scripts.autonomy.ledger import LedgerRecord, record_run
+
+WORKFLOW = "scripts.social.platform_change_monitor"
+
 ROOT = Path(__file__).resolve().parents[2]
 REGISTRY = ROOT / "harness" / "references" / "social-platform-source-registry.json"
 SNAPSHOT = ROOT / "harness" / "references" / "social-platform-source-snapshot.json"
@@ -107,6 +112,7 @@ def check_sources(platforms: set[str] | None, limit: int | None, timeout: int) -
     registry = _load_json(REGISTRY, {"sources": []})
     snapshot = _load_json(SNAPSHOT, {"version": 1, "sources": {}})
     previous_sources = snapshot.get("sources", {})
+    previous_errors = snapshot.get("errors", {})
     selected = registry.get("sources", [])
     if platforms:
         selected = [s for s in selected if s.get("platform") in platforms]
@@ -115,16 +121,19 @@ def check_sources(platforms: set[str] | None, limit: int | None, timeout: int) -
 
     results: list[dict[str, Any]] = []
     new_sources = dict(previous_sources)
+    new_errors = dict(previous_errors)
 
     for source in selected:
         current = _fetch_source(source, timeout=timeout)
         previous = previous_sources.get(source["id"])
         state = _status(previous, current)
-        result = {**source, **current, "monitor_status": state}
+        was_error = source["id"] in previous_errors
+        result = {**source, **current, "monitor_status": state, "previous_error": was_error}
         if previous:
             result["previous_hash"] = previous.get("content_hash")
             result["previous_checked_at"] = previous.get("checked_at")
         if current.get("ok"):
+            new_errors.pop(source["id"], None)
             new_sources[source["id"]] = {
                 "platform": source.get("platform"),
                 "category": source.get("category"),
@@ -138,14 +147,28 @@ def check_sources(platforms: set[str] | None, limit: int | None, timeout: int) -
                 "status_code": current.get("status_code"),
                 "checked_at": current.get("fetched_at"),
             }
+        else:
+            new_errors[source["id"]] = {
+                "platform": source.get("platform"),
+                "url": source.get("url"),
+                "status_code": current.get("status_code"),
+                "error": current.get("error"),
+                "checked_at": current.get("fetched_at"),
+            }
         results.append(result)
 
     updated_snapshot = {
         "version": 1,
         "updated_at": datetime.now(timezone.utc).isoformat(),
         "sources": new_sources,
+        "errors": new_errors,
     }
     return results, updated_snapshot
+
+
+def build_impact_cards(results: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Turn raw source results into practical impact cards (issue #27)."""
+    return [build_impact_card(result) for result in results]
 
 
 def write_report(results: list[dict[str, Any]], path: Path = REPORT) -> None:
@@ -154,6 +177,15 @@ def write_report(results: list[dict[str, Any]], path: Path = REPORT) -> None:
     new = [r for r in results if r["monitor_status"] == "new"]
     errors = [r for r in results if r["monitor_status"] == "error"]
     unchanged = [r for r in results if r["monitor_status"] == "unchanged"]
+
+    cards = build_impact_cards(results)
+    # Surface anything that needs a human or moved this run.
+    actionable = [
+        c
+        for c in cards
+        if c["monitor_status"] in {"changed", "new", "error"}
+        or c["source_status"] in {"fixed", "replaced", "unresolved"}
+    ]
 
     lines = [
         "# Social Platform Monitor Report",
@@ -168,22 +200,23 @@ def write_report(results: list[dict[str, Any]], path: Path = REPORT) -> None:
         "",
     ]
 
-    for label, items in (("Changed", changed), ("New", new), ("Errors", errors)):
-        if not items:
-            continue
-        lines.append(f"## {label}")
+    if actionable:
+        lines.append("## Impact Cards")
         lines.append("")
-        for item in items:
-            owner = item.get("owner_file", "")
-            lines.append(f"- [{item['platform']}] {item['title']}: {item['url']}")
-            lines.append(f"  - Category: {item.get('category')}")
-            if owner:
-                lines.append(f"  - Review file: `{owner}`")
-            if item.get("error"):
-                lines.append(f"  - Error: {item['error']}")
-            if item.get("previous_hash") and item.get("content_hash"):
-                lines.append(f"  - Hash: `{item['previous_hash'][:12]}` -> `{item['content_hash'][:12]}`")
-        lines.append("")
+        for card in actionable:
+            lines.append(f"### [{card['platform']}] {card['title']}")
+            lines.append("")
+            lines.append(f"- **What changed:** {card['what_changed']}")
+            lines.append(f"- **Why it matters:** {card['why_it_matters']} (area: {card['impact_area']})")
+            lines.append(f"- **Action taken:** {card['action_taken']}")
+            lines.append(f"- **Remaining risk:** {card['remaining_risk']}")
+            lines.append(f"- **Decision:** `{card['decision']}` ({card['decision_reason']})")
+            lines.append(f"- **Risk:** `{card['risk_level']}` · **Confidence:** {card['confidence']}")
+            lines.append(f"- **Source:** {card['source_url']}")
+            if card.get("owner_file"):
+                lines.append(f"- **Owner doc:** `{card['owner_file']}`")
+            lines.append(f"- **Next step:** {card['next_step']}")
+            lines.append("")
 
     lines.append("## Reviewed Sources")
     lines.append("")
@@ -203,12 +236,54 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--json", action="store_true", help="Print results as JSON")
     args = parser.parse_args(argv)
 
+    record = LedgerRecord(
+        workflow=WORKFLOW,
+        inputs={
+            "platforms": sorted(args.platform) if args.platform else "all",
+            "limit": args.limit,
+            "dry_run": args.dry_run,
+        },
+    )
+
     platforms = set(args.platform) if args.platform else None
     results, snapshot = check_sources(platforms=platforms, limit=args.limit, timeout=args.timeout)
+    cards = build_impact_cards(results)
+
+    record.sources_checked = [r.get("id") for r in results]
+    record.findings = [
+        c
+        for c in cards
+        if c["monitor_status"] in {"changed", "new", "error"}
+        or c["source_status"] in {"fixed", "replaced", "unresolved"}
+    ]
+    record.followups = sorted(
+        {c["next_step"] for c in record.findings if c["next_step"] not in {"No action needed", ""}}
+    )
+    record.blockers = [
+        f"{c['platform']} {c['title']}: source unresolved ({c['source_url']})"
+        for c in record.findings
+        if c["source_status"] == "unresolved"
+    ]
+    if record.blockers:
+        record.lessons.append("social source unreachable; registry needs canonical replacement")
+    record.validation = {
+        "method": "content-hash diff vs snapshot",
+        "sources_checked": len(results),
+        "errors": sum(1 for r in results if r["monitor_status"] == "error"),
+    }
 
     if not args.dry_run:
         SNAPSHOT.write_text(json.dumps(snapshot, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         write_report(results)
+        record.files_changed = [
+            str(SNAPSHOT.relative_to(ROOT)),
+            str(REPORT.relative_to(ROOT)),
+        ]
+        record.actions_taken.append("Updated snapshot and impact report")
+    else:
+        record.actions_taken.append("Dry run; no files written")
+
+    record_run(record)
 
     if args.json:
         print(json.dumps(results, indent=2, sort_keys=True))

--- a/tests/test_autonomy_ledger.py
+++ b/tests/test_autonomy_ledger.py
@@ -1,0 +1,228 @@
+"""Tests for the Kai autonomy control layer (issue #27).
+
+Covers the append-only ledger schema, the policy decision router, and the
+impact classifier that backs the social platform monitor's impact cards.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.autonomy.decisions import ACTION_CLASSES, RISK_LEVELS, route_decision
+from scripts.autonomy.impact import build_impact_card, classify_source_status
+from scripts.autonomy.ledger import (
+    LEDGER_FIELDS,
+    LedgerRecord,
+    mine_repeated_lessons,
+    new_run_id,
+    read_records,
+    record_run,
+)
+
+
+class TestLedgerSchema(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = Path(os.environ.get("PYTEST_TMP", "/tmp")) / f"kai-ledger-{os.getpid()}"
+        self.ledger = self._tmp / "ledger.jsonl"
+        self._tmp.mkdir(parents=True, exist_ok=True)
+        if self.ledger.exists():
+            self.ledger.unlink()
+
+    def tearDown(self) -> None:
+        if self.ledger.exists():
+            self.ledger.unlink()
+
+    def test_run_id_is_unique_and_namespaced(self) -> None:
+        a = new_run_id("scripts.social.platform_change_monitor")
+        b = new_run_id("scripts.social.platform_change_monitor")
+        self.assertTrue(a.startswith("platform_change_monitor-"))
+        self.assertNotEqual(a, b)
+
+    def test_record_carries_every_field_in_order(self) -> None:
+        rec = LedgerRecord(workflow="demo.workflow").finish()
+        payload = rec.to_record()
+        self.assertEqual(tuple(payload.keys()), LEDGER_FIELDS)
+        for field_name in LEDGER_FIELDS:
+            self.assertIn(field_name, payload)
+
+    def test_finish_derives_risk_and_human_from_findings(self) -> None:
+        rec = LedgerRecord(
+            workflow="demo.workflow",
+            findings=[
+                {"risk_level": "low", "decision": "auto_fix"},
+                {"risk_level": "high", "decision": "stage_for_approval"},
+            ],
+        ).finish()
+        self.assertEqual(rec.risk_level, "high")
+        self.assertTrue(rec.requires_human)
+
+    def test_finish_no_findings_is_clean(self) -> None:
+        rec = LedgerRecord(workflow="demo.workflow").finish()
+        self.assertEqual(rec.risk_level, "none")
+        self.assertFalse(rec.requires_human)
+
+    def test_record_run_appends_jsonl(self) -> None:
+        rec = LedgerRecord(workflow="demo.workflow", actions_taken=["did a thing"])
+        written = record_run(rec, path=self.ledger)
+        self.assertIsNotNone(written)
+        self.assertTrue(self.ledger.exists())
+        lines = self.ledger.read_text().strip().splitlines()
+        self.assertEqual(len(lines), 1)
+        parsed = json.loads(lines[0])
+        self.assertEqual(parsed["workflow"], "demo.workflow")
+        self.assertEqual(parsed["actions_taken"], ["did a thing"])
+
+    def test_record_run_respects_opt_out(self) -> None:
+        os.environ["KAI_AUTONOMY_LEDGER"] = "0"
+        try:
+            written = record_run(LedgerRecord(workflow="demo.workflow"), path=self.ledger)
+        finally:
+            del os.environ["KAI_AUTONOMY_LEDGER"]
+        self.assertIsNone(written)
+        self.assertFalse(self.ledger.exists())
+
+    def test_record_run_never_raises(self) -> None:
+        # A directory path that cannot be written should be swallowed.
+        bad = Path("/proc/should-not-be-writable/ledger.jsonl")
+        self.assertIsNone(record_run(LedgerRecord(workflow="demo"), path=bad))
+
+    def test_mine_repeated_lessons(self) -> None:
+        for _ in range(3):
+            record_run(
+                LedgerRecord(workflow="demo.workflow", lessons=["source unreachable"]),
+                path=self.ledger,
+            )
+        record_run(LedgerRecord(workflow="demo.workflow", lessons=["one-off"]), path=self.ledger)
+        records = read_records(self.ledger)
+        self.assertEqual(len(records), 4)
+        mined = mine_repeated_lessons(records, min_count=2)
+        self.assertEqual(len(mined), 1)
+        self.assertEqual(mined[0]["lesson"], "source unreachable")
+        self.assertEqual(mined[0]["count"], 3)
+
+
+class TestDecisionRouter(unittest.TestCase):
+    def test_action_classes_are_known(self) -> None:
+        self.assertEqual(
+            ACTION_CLASSES,
+            ("auto_fix", "auto_pr", "stage_for_approval", "escalate", "block"),
+        )
+
+    def test_guardrail_blocks_win(self) -> None:
+        res = route_decision({"summary": "buy followers to inflate engagement", "risk_level": "low"})
+        self.assertEqual(res.action_class, "block")
+        self.assertEqual(res.risk_level, "critical")
+        self.assertTrue(res.requires_human)
+
+    def test_outbound_email_stages_for_approval(self) -> None:
+        res = route_decision({"action_kind": "send_email", "change_type": "content"})
+        self.assertEqual(res.action_class, "stage_for_approval")
+        self.assertTrue(res.requires_human)
+
+    def test_paid_spend_stages_for_approval(self) -> None:
+        res = route_decision({"action_kind": "paid_spend"})
+        self.assertEqual(res.action_class, "stage_for_approval")
+
+    def test_unresolved_source_escalates(self) -> None:
+        res = route_decision({"source_status": "unresolved", "change_type": "dead_link"})
+        self.assertEqual(res.action_class, "escalate")
+        self.assertTrue(res.requires_human)
+
+    def test_safe_docs_change_auto_fixes(self) -> None:
+        res = route_decision({"change_type": "snapshot", "risk_level": "low"})
+        self.assertEqual(res.action_class, "auto_fix")
+        self.assertFalse(res.requires_human)
+
+    def test_code_change_routes_to_pr(self) -> None:
+        res = route_decision({"change_type": "code", "risk_level": "medium"})
+        self.assertEqual(res.action_class, "auto_pr")
+
+    def test_risk_levels_ordered(self) -> None:
+        self.assertEqual(RISK_LEVELS, ("none", "low", "medium", "high", "critical"))
+
+
+class TestImpactClassifier(unittest.TestCase):
+    def test_classify_unresolved(self) -> None:
+        result = {"monitor_status": "error", "ok": False, "previous_error": True}
+        self.assertEqual(classify_source_status(result), "unresolved")
+
+    def test_classify_replaced(self) -> None:
+        result = {"monitor_status": "error", "ok": False, "replacement_url": "https://x/new"}
+        self.assertEqual(classify_source_status(result), "replaced")
+
+    def test_classify_fixed(self) -> None:
+        result = {"monitor_status": "unchanged", "ok": True, "previous_error": True}
+        self.assertEqual(classify_source_status(result), "fixed")
+
+    def test_classify_ok(self) -> None:
+        result = {"monitor_status": "unchanged", "ok": True, "previous_error": False}
+        self.assertEqual(classify_source_status(result), "ok")
+
+    def test_changed_policy_card_has_practical_impact(self) -> None:
+        card = build_impact_card(
+            {
+                "id": "x_rules",
+                "platform": "x",
+                "category": "policy",
+                "title": "X Rules",
+                "url": "https://help.x.com/rules",
+                "owner_file": "knowledge/channels/twitter-x.md",
+                "monitor_status": "changed",
+                "previous_hash": "a" * 64,
+                "content_hash": "b" * 64,
+                "ok": True,
+            }
+        )
+        # Practical impact, not just a hash.
+        self.assertIn("hash changed", card["what_changed"].lower())
+        self.assertEqual(card["impact_area"], "allowed content")
+        self.assertNotEqual(card["why_it_matters"], "No operational impact this run")
+        self.assertEqual(card["change_type"], "docs")
+        self.assertEqual(card["decision"], "auto_fix")
+        self.assertIn("twitter-x.md", card["next_step"])
+
+    def test_error_card_routes_to_escalate(self) -> None:
+        card = build_impact_card(
+            {
+                "id": "tt_changelog",
+                "platform": "tiktok",
+                "category": "changelog",
+                "title": "TikTok API Changelog",
+                "url": "https://developers.tiktok.com/changelog",
+                "monitor_status": "error",
+                "ok": False,
+                "status_code": 404,
+                "previous_error": False,
+            }
+        )
+        self.assertEqual(card["source_status"], "unresolved")
+        self.assertEqual(card["decision"], "escalate")
+        self.assertEqual(card["impact_area"], "scheduling/rate limits")
+        self.assertTrue(card["requires_human"])
+
+    def test_ai_policy_card_flags_disclosure_gate(self) -> None:
+        card = build_impact_card(
+            {
+                "id": "tt_ai",
+                "platform": "tiktok",
+                "category": "ai_policy",
+                "title": "TikTok AI Disclosure",
+                "url": "https://tiktok.com/ai",
+                "monitor_status": "changed",
+                "previous_hash": "c" * 64,
+                "content_hash": "d" * 64,
+                "ok": True,
+            }
+        )
+        self.assertEqual(card["impact_area"], "AI/synthetic media labels")
+        self.assertIn("disclosure", card["why_it_matters"].lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Builds the **first implementation milestone** of the Kai autonomy control layer from #27 — the minimum useful control loop that turns raw automation signals into typed, auditable decisions instead of scattered agent prose.

New package `scripts/autonomy/`:

- **`ledger.py`** — append-only JSONL run ledger (`data/autonomy/ledger.jsonl`) with the full typed schema from the issue (`run_id`, `workflow`, `started_at`/`finished_at`, `inputs`, `sources_checked`, `findings`, `actions_taken`, `files_changed`, `validation`, `risk_level`, `requires_human`, `blockers`, `lessons`, `followups`). Derives `risk_level`/`requires_human` from findings, never crashes the caller, opt-out via `KAI_AUTONOMY_LEDGER=0`, redirect via `KAI_AUTONOMY_DIR`. Includes `mine_repeated_lessons()` for promotion candidates.
- **`decisions.py`** — policy decision router mapping each finding to one explicit action class: `auto_fix`, `auto_pr`, `stage_for_approval`, `escalate`, `block`. Guardrail matches (deception, astroturfing, bought accounts, scraping outside terms, rule evasion) always block; outbound email / publishing / paid spend / account changes always stage for approval.
- **`impact.py`** — impact classifier producing practical impact cards (what changed · why it matters · action taken · remaining risk · confidence · source · next step) and classifying broken sources as `fixed`, `replaced`, or `unresolved`.

Converted automation:

- **`scripts.social.platform_change_monitor`** now writes a ledger entry per run, tracks source recovery (new `errors` map in the snapshot), and reports **impact cards** instead of bare hash diffs.

## Acceptance criteria (#27 milestone)

- [x] Every converted automation writes a structured ledger entry
- [x] Social policy monitor reports practical impacts, not only changed hashes
- [x] Broken sources classified as fixed / replaced / unresolved manual-review items
- [x] Risk class and action class explicit for each finding
- [x] Repeated lessons can be mined from ledger records (`mine_repeated_lessons`)
- [x] Rule/decision logic backed by tests (`tests/test_autonomy_ledger.py`, 23 cases)
- [x] High-risk actions staged for approval, not executed directly

## Verification

- `python -m unittest tests.test_autonomy_ledger` — 23 pass
- `python -m unittest tests.test_policy tests.test_autonomy_ledger` — 104 pass
- `python scripts/quality_gates/golden_check.py` — exit 0 (gates unchanged)
- Full-suite failure count identical to baseline (pre-existing missing `pytest`/`dotenv` only)
- End-to-end smoke of the monitor report + ledger output offline

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V93BuyJ34C9yUUqaR97Fej)_