### PR TITLE
feat(autonomy): approval queue + weekly operator brief (#27)

### DIFF
--- a/data/autonomy/README.md
+++ b/data/autonomy/README.md
@@ -1,10 +1,15 @@
-# Autonomy ledger
+# Autonomy data
 
-This folder holds `ledger.jsonl`, the append-only record of every autonomy run
-(GitHub issue #27). The file is runtime data and is gitignored; only this README
-is tracked so the location stays discoverable.
+This folder holds the runtime files behind the Kai autonomy control layer
+(GitHub issue #27). The files are runtime data and are gitignored; only this
+README is tracked so the location stays discoverable.
 
-## What writes here
+- `ledger.jsonl` — append-only record of every autonomy run.
+- `approval_queue.jsonl` — append-only queue of risky actions waiting on a human.
+
+Both honor `KAI_AUTONOMY_DIR` to redirect their location.
+
+## The ledger (`ledger.jsonl`)
 
 `scripts/autonomy/ledger.py` appends one JSON object per automation run. The
 social platform monitor (`scripts.social.platform_change_monitor`) is the first
@@ -27,7 +32,35 @@ records = read_records()
 repeated = mine_repeated_lessons(records, min_count=2)  # promotion candidates
 ```
 
+## The approval queue (`approval_queue.jsonl`)
+
+`scripts/autonomy/approval_queue.py` is the one canonical hold for risky actions
+(outbound email, client claims, live publish, paid media, account/credential
+changes, deploys). When `route_decision` routes a finding to
+`stage_for_approval`, `stage_findings(...)` lands it here instead of acting.
+
+The queue is an append-only **event log** folded into current state on read, so
+it doubles as an audit trail (queued → validated → resolved). Unlike the ledger,
+`enqueue` raises on persistence failure and there is no disable switch —
+silently dropping a staged action would be a safety regression.
+
+```python
+from scripts.autonomy.approval_queue import list_pending, approve, reject
+
+for item in list_pending():           # risky actions awaiting a human
+    print(item["action_kind"], item["risk_level"])
+approve(item_id, resolved_by="connor", resolution_note="ok")
+```
+
+## The operator brief
+
+`python -m scripts.autonomy.operator_brief [--since N] [--out PATH]` reads the
+ledger and approval queue and renders a decision-oriented weekly brief (biggest
+risks, approvals needed, failed automations, stale/broken sources, recurring
+lessons to promote). It only restates ledger/queue facts — it invents nothing.
+
 ## Controls
 
-- `KAI_AUTONOMY_LEDGER=0` disables writes.
-- `KAI_AUTONOMY_DIR=/some/path` redirects the ledger location.
+- `KAI_AUTONOMY_LEDGER=0` disables ledger writes (the approval queue has no
+  equivalent switch by design).
+- `KAI_AUTONOMY_DIR=/some/path` redirects both the ledger and the queue.

--- a/scripts/autonomy/approval_queue.py
+++ b/scripts/autonomy/approval_queue.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Approval queue — the one canonical hold for risky autonomous actions.
+
+When the decision router (``scripts/autonomy/decisions.py``) routes a finding to
+``stage_for_approval``, the action does not happen yet. It lands here: an
+append-only queue of items waiting on a human. Outbound email, client-facing
+claims, live publishing, paid media, account/credential changes, and deploys all
+pass through this gate before they touch the outside world.
+
+Design
+------
+The queue is an **append-only event log** (``data/autonomy/approval_queue.jsonl``)
+folded into current state on read. Every state change — queued, validated,
+resolved — is its own line, so the file doubles as an audit trail of who
+approved what and when. Nothing is mutated in place.
+
+Two deliberate differences from the ledger
+(``scripts/autonomy/ledger.py``):
+  - **enqueue raises on persistence failure.** A staged risky action that is
+    silently dropped is a safety regression, so we surface the error to the
+    caller instead of swallowing it. The ledger swallows because a missing log
+    line is harmless; a missing approval item is not.
+  - **there is no disable switch.** ``KAI_AUTONOMY_LEDGER=0`` turns off logging;
+    there is no equivalent here, because disabling the queue would let risky
+    actions through unreviewed. The location can still be redirected with
+    ``KAI_AUTONOMY_DIR`` (shared with the ledger).
+
+Schema (one event per line)::
+
+  event           "queued" | "validated" | "resolved"
+  item_id         stable id (action_kind + UTC timestamp + short uuid)
+  at              ISO-8601 UTC of the event
+
+A ``queued`` event additionally carries the item fields::
+
+  workflow        dotted automation name that staged the action
+  action_kind     what the action would do (e.g. "send_email", "paid_spend")
+  action_class    routed class (always "stage_for_approval" via the router)
+  risk_level      none|low|medium|high|critical
+  payload         dict describing the concrete action to perform on approval
+  source_refs     list of source ids / urls justifying the action
+  decision_reason why the router staged it
+  validation      {"status": "unvalidated"|"passed"|"failed", "notes": str}
+  dedupe_key      idempotency key; a pending item with the same key blocks re-queue
+
+A ``validated`` event carries ``status`` + ``notes``; a ``resolved`` event
+carries ``status`` ("approved"|"rejected"), ``resolved_by``, ``resolution_note``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+from scripts.autonomy.decisions import RISK_LEVELS  # noqa: E402  (shared vocabulary)
+
+VALIDATION_STATES: tuple[str, ...] = ("unvalidated", "passed", "failed")
+RESOLUTION_STATES: tuple[str, ...] = ("approved", "rejected")
+PENDING = "pending"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def queue_path() -> Path:
+    """Return the active queue path, honoring ``KAI_AUTONOMY_DIR``."""
+    base = os.environ.get("KAI_AUTONOMY_DIR")
+    if base:
+        return Path(base) / "approval_queue.jsonl"
+    return REPO_ROOT / "data" / "autonomy" / "approval_queue.jsonl"
+
+
+def new_item_id(action_kind: str) -> str:
+    """Build a sortable, unique id from the action kind and current time."""
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    short = uuid.uuid4().hex[:8]
+    leaf = (action_kind or "action").rsplit(".", 1)[-1] or "action"
+    return f"{leaf}-{stamp}-{short}"
+
+
+@dataclass
+class ApprovalItem:
+    """One risky action waiting on a human decision."""
+
+    workflow: str
+    action_kind: str
+    item_id: str = ""
+    action_class: str = "stage_for_approval"
+    risk_level: str = "high"
+    payload: dict[str, Any] = field(default_factory=dict)
+    source_refs: list[Any] = field(default_factory=list)
+    decision_reason: str = ""
+    validation: dict[str, Any] = field(default_factory=lambda: {"status": "unvalidated", "notes": ""})
+    dedupe_key: str = ""
+    created_at: str = field(default_factory=_utc_now)
+
+    def __post_init__(self) -> None:
+        if not self.item_id:
+            self.item_id = new_item_id(self.action_kind)
+        if self.risk_level not in RISK_LEVELS:
+            self.risk_level = "high"
+        if self.validation.get("status") not in VALIDATION_STATES:
+            self.validation = {"status": "unvalidated", "notes": str(self.validation.get("notes", ""))}
+        if not self.dedupe_key:
+            self.dedupe_key = self._default_dedupe_key()
+
+    def _default_dedupe_key(self) -> str:
+        """Derive a stable key so monthly re-runs don't re-queue the same action."""
+        ref = ""
+        if self.source_refs:
+            ref = str(self.source_refs[0])
+        return f"{self.workflow}|{self.action_kind}|{ref}".lower()
+
+    def queued_event(self) -> dict[str, Any]:
+        return {
+            "event": "queued",
+            "item_id": self.item_id,
+            "at": self.created_at,
+            "workflow": self.workflow,
+            "action_kind": self.action_kind,
+            "action_class": self.action_class,
+            "risk_level": self.risk_level,
+            "payload": self.payload,
+            "source_refs": self.source_refs,
+            "decision_reason": self.decision_reason,
+            "validation": self.validation,
+            "dedupe_key": self.dedupe_key,
+        }
+
+
+def _append_event(event: dict[str, Any], path: Path) -> dict[str, Any]:
+    """Append one event line. Raises on failure (callers depend on durability)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(event, ensure_ascii=False) + "\n")
+    return event
+
+
+def read_events(path: Path | None = None) -> list[dict[str, Any]]:
+    """Read every raw event. Skips malformed lines rather than raising."""
+    target = path or queue_path()
+    if not target.exists():
+        return []
+    events: list[dict[str, Any]] = []
+    for line in target.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+def _fold(events: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Fold the event log into current item state, keyed by item_id."""
+    items: dict[str, dict[str, Any]] = {}
+    for ev in events:
+        kind = ev.get("event")
+        item_id = ev.get("item_id")
+        if not item_id:
+            continue
+        if kind == "queued":
+            if item_id in items:
+                continue  # first queue wins; ignore accidental duplicates
+            items[item_id] = {
+                "item_id": item_id,
+                "created_at": ev.get("at", ""),
+                "workflow": ev.get("workflow", ""),
+                "action_kind": ev.get("action_kind", ""),
+                "action_class": ev.get("action_class", "stage_for_approval"),
+                "risk_level": ev.get("risk_level", "high"),
+                "payload": ev.get("payload", {}),
+                "source_refs": ev.get("source_refs", []),
+                "decision_reason": ev.get("decision_reason", ""),
+                "validation": ev.get("validation", {"status": "unvalidated", "notes": ""}),
+                "dedupe_key": ev.get("dedupe_key", ""),
+                "status": PENDING,
+                "resolved_at": "",
+                "resolved_by": "",
+                "resolution_note": "",
+            }
+        elif kind == "validated":
+            item = items.get(item_id)
+            if item is not None:
+                item["validation"] = {
+                    "status": ev.get("status", "unvalidated"),
+                    "notes": ev.get("notes", ""),
+                }
+        elif kind == "resolved":
+            item = items.get(item_id)
+            if item is not None:
+                item["status"] = ev.get("status", item["status"])
+                item["resolved_at"] = ev.get("at", "")
+                item["resolved_by"] = ev.get("resolved_by", "")
+                item["resolution_note"] = ev.get("resolution_note", "")
+    return items
+
+
+def read_items(path: Path | None = None, *, status: str | None = None) -> list[dict[str, Any]]:
+    """Return folded items, oldest first, optionally filtered by status."""
+    items = list(_fold(read_events(path)).values())
+    if status is not None:
+        items = [i for i in items if i["status"] == status]
+    items.sort(key=lambda i: (i.get("created_at", ""), i.get("item_id", "")))
+    return items
+
+
+def get_item(item_id: str, path: Path | None = None) -> dict[str, Any] | None:
+    """Return one folded item by id, or ``None`` if it was never queued."""
+    return _fold(read_events(path)).get(item_id)
+
+
+def list_pending(path: Path | None = None) -> list[dict[str, Any]]:
+    """Return every item still waiting on a human, oldest first."""
+    return read_items(path, status=PENDING)
+
+
+def enqueue(item: ApprovalItem, path: Path | None = None) -> dict[str, Any] | None:
+    """Append a queued event for ``item``. Returns the event, or ``None`` if a
+    pending item with the same ``dedupe_key`` already exists.
+
+    Raises on persistence failure — a dropped approval item is unsafe, so the
+    error reaches the caller rather than being swallowed (see module docstring).
+    """
+    target = path or queue_path()
+    if item.dedupe_key:
+        for existing in _fold(read_events(target)).values():
+            if existing["status"] == PENDING and existing.get("dedupe_key") == item.dedupe_key:
+                return None
+    return _append_event(item.queued_event(), target)
+
+
+def record_validation(
+    item_id: str,
+    status: str,
+    notes: str = "",
+    path: Path | None = None,
+) -> dict[str, Any]:
+    """Record a validation outcome for a queued item.
+
+    ``status`` must be one of ``VALIDATION_STATES``. Raises if the item is
+    unknown.
+    """
+    if status not in VALIDATION_STATES:
+        raise ValueError(f"validation status must be one of {VALIDATION_STATES}, got {status!r}")
+    target = path or queue_path()
+    if get_item(item_id, target) is None:
+        raise ValueError(f"unknown approval item: {item_id}")
+    return _append_event(
+        {"event": "validated", "item_id": item_id, "at": _utc_now(), "status": status, "notes": notes},
+        target,
+    )
+
+
+def resolve(
+    item_id: str,
+    status: str,
+    resolved_by: str,
+    resolution_note: str = "",
+    path: Path | None = None,
+) -> dict[str, Any]:
+    """Approve or reject a pending item. Append-only; the queued line stays.
+
+    ``status`` must be ``approved`` or ``rejected``. Raises if the item is
+    unknown or already resolved (re-resolving would muddy the audit trail).
+    """
+    if status not in RESOLUTION_STATES:
+        raise ValueError(f"resolution status must be one of {RESOLUTION_STATES}, got {status!r}")
+    target = path or queue_path()
+    item = get_item(item_id, target)
+    if item is None:
+        raise ValueError(f"unknown approval item: {item_id}")
+    if item["status"] != PENDING:
+        raise ValueError(f"item {item_id} already resolved as {item['status']!r}")
+    return _append_event(
+        {
+            "event": "resolved",
+            "item_id": item_id,
+            "at": _utc_now(),
+            "status": status,
+            "resolved_by": resolved_by,
+            "resolution_note": resolution_note,
+        },
+        target,
+    )
+
+
+def approve(item_id: str, resolved_by: str, resolution_note: str = "", path: Path | None = None) -> dict[str, Any]:
+    """Convenience wrapper: resolve ``item_id`` as approved."""
+    return resolve(item_id, "approved", resolved_by, resolution_note, path)
+
+
+def reject(item_id: str, resolved_by: str, resolution_note: str = "", path: Path | None = None) -> dict[str, Any]:
+    """Convenience wrapper: resolve ``item_id`` as rejected."""
+    return resolve(item_id, "rejected", resolved_by, resolution_note, path)
+
+
+def stage_finding(
+    finding: dict[str, Any],
+    workflow: str,
+    *,
+    payload: dict[str, Any] | None = None,
+    source_refs: list[Any] | None = None,
+    dedupe_key: str = "",
+    path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Enqueue a finding **only if** the router staged it for approval.
+
+    Returns the queued event, or ``None`` when the finding's ``decision`` is not
+    ``stage_for_approval`` or a matching pending item already exists. This is the
+    intended bridge from ``route_decision`` output to the queue.
+    """
+    if finding.get("decision") != "stage_for_approval":
+        return None
+    refs = source_refs if source_refs is not None else _finding_source_refs(finding)
+    item = ApprovalItem(
+        workflow=workflow,
+        action_kind=(finding.get("action_kind") or "review").strip().lower(),
+        action_class="stage_for_approval",
+        risk_level=finding.get("risk_level", "high"),
+        payload=payload if payload is not None else _finding_payload(finding),
+        source_refs=refs,
+        decision_reason=finding.get("decision_reason", ""),
+        dedupe_key=dedupe_key,
+    )
+    return enqueue(item, path)
+
+
+def stage_findings(
+    findings: list[dict[str, Any]],
+    workflow: str,
+    *,
+    path: Path | None = None,
+) -> list[dict[str, Any]]:
+    """Enqueue every finding routed to ``stage_for_approval``. Returns the events
+    actually written (deduped/non-staged findings are skipped)."""
+    staged: list[dict[str, Any]] = []
+    for finding in findings:
+        event = stage_finding(finding, workflow, path=path)
+        if event is not None:
+            staged.append(event)
+    return staged
+
+
+def _finding_source_refs(finding: dict[str, Any]) -> list[Any]:
+    refs = [finding.get("source_url"), finding.get("id")]
+    return [r for r in refs if r]
+
+
+def _finding_payload(finding: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "title": finding.get("title"),
+        "action_taken": finding.get("action_taken"),
+        "next_step": finding.get("next_step"),
+        "what_changed": finding.get("what_changed"),
+    }

--- a/scripts/autonomy/operator_brief.py
+++ b/scripts/autonomy/operator_brief.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Weekly operator brief — a decision, not a dump.
+
+The ledger and approval queue accumulate raw runs. An operator does not want raw
+runs; they want the few things that need a human this week. This module reads the
+autonomy ledger (``scripts/autonomy/ledger.py``) and the approval queue
+(``scripts/autonomy/approval_queue.py``) and renders a short, decision-oriented
+brief:
+
+  - biggest risks            high/critical findings across runs
+  - approvals needed         pending items in the approval queue
+  - actions taken            what automations actually did
+  - failed automations       runs that recorded blockers
+  - stale docs / broken      unresolved sources and stale owner docs
+  - suggested upgrades       lessons that recurred enough to promote
+
+Everything is derived; nothing new is asserted. Quantitative lines come straight
+from the ledger/queue, so the brief never invents numbers (Kai Data Provenance
+Rule). Stdlib only; no network.
+
+Usage:
+  python -m scripts.autonomy.operator_brief
+  python -m scripts.autonomy.operator_brief --since 7
+  python -m scripts.autonomy.operator_brief --out reports/operator-brief.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+from scripts.autonomy.approval_queue import list_pending, read_items
+from scripts.autonomy.decisions import RISK_LEVELS
+from scripts.autonomy.ledger import mine_repeated_lessons, read_records
+
+_HIGH_RISK = {"high", "critical"}
+
+
+def _parse_dt(value: str) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _within_window(records: list[dict[str, Any]], since_days: int | None) -> list[dict[str, Any]]:
+    """Keep records started within ``since_days``. Undated records are kept."""
+    if not since_days:
+        return records
+    cutoff = datetime.now(timezone.utc) - timedelta(days=since_days)
+    kept = []
+    for rec in records:
+        started = _parse_dt(rec.get("started_at", ""))
+        if started is None or started >= cutoff:
+            kept.append(rec)
+    return kept
+
+
+def brief_data(
+    *,
+    records: list[dict[str, Any]] | None = None,
+    pending: list[dict[str, Any]] | None = None,
+    since_days: int | None = 7,
+    ledger_path: Path | None = None,
+    queue_path: Path | None = None,
+) -> dict[str, Any]:
+    """Assemble the structured brief data from the ledger and approval queue.
+
+    Inputs can be injected (tests) or read from disk. Returns a dict with one key
+    per brief section plus a ``summary`` rollup.
+    """
+    if records is None:
+        records = read_records(ledger_path)
+    records = _within_window(records, since_days)
+    if pending is None:
+        pending = list_pending(queue_path)
+
+    biggest_risks: list[dict[str, Any]] = []
+    actions_taken: list[dict[str, Any]] = []
+    failed: list[dict[str, Any]] = []
+    stale_sources: list[dict[str, Any]] = []
+
+    for rec in records:
+        run_id = rec.get("run_id", "")
+        workflow = rec.get("workflow", "")
+        for finding in rec.get("findings", []) or []:
+            if finding.get("risk_level") in _HIGH_RISK or finding.get("decision") in {"escalate", "block"}:
+                biggest_risks.append(
+                    {
+                        "run_id": run_id,
+                        "workflow": workflow,
+                        "title": finding.get("title") or finding.get("id") or "(untitled finding)",
+                        "risk_level": finding.get("risk_level", "low"),
+                        "decision": finding.get("decision", ""),
+                        "why_it_matters": finding.get("why_it_matters", ""),
+                        "source_url": finding.get("source_url", ""),
+                    }
+                )
+            if finding.get("source_status") == "unresolved":
+                stale_sources.append(
+                    {
+                        "run_id": run_id,
+                        "workflow": workflow,
+                        "title": finding.get("title") or finding.get("id") or "(unknown source)",
+                        "source_url": finding.get("source_url", ""),
+                        "next_step": finding.get("next_step", ""),
+                    }
+                )
+        for action in rec.get("actions_taken", []) or []:
+            actions_taken.append({"run_id": run_id, "workflow": workflow, "action": action})
+        if rec.get("blockers"):
+            failed.append(
+                {
+                    "run_id": run_id,
+                    "workflow": workflow,
+                    "blockers": list(rec.get("blockers", [])),
+                }
+            )
+
+    biggest_risks.sort(key=lambda r: -_risk_rank(r["risk_level"]))
+    pending_sorted = sorted(pending, key=lambda i: -_risk_rank(i.get("risk_level", "low")))
+    upgrades = mine_repeated_lessons(records, min_count=2)
+
+    summary = {
+        "runs_considered": len(records),
+        "biggest_risks": len(biggest_risks),
+        "approvals_needed": len(pending_sorted),
+        "failed_automations": len(failed),
+        "stale_or_broken_sources": len(stale_sources),
+        "promotion_candidates": len(upgrades),
+        "since_days": since_days,
+    }
+    return {
+        "summary": summary,
+        "biggest_risks": biggest_risks,
+        "approvals_needed": pending_sorted,
+        "actions_taken": actions_taken,
+        "failed_automations": failed,
+        "stale_or_broken_sources": stale_sources,
+        "suggested_upgrades": upgrades,
+    }
+
+
+def _risk_rank(level: str) -> int:
+    return RISK_LEVELS.index(level) if level in RISK_LEVELS else 1
+
+
+def render_brief(data: dict[str, Any]) -> str:
+    """Render the structured brief data as operator-facing markdown."""
+    summary = data["summary"]
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    window = f"last {summary['since_days']} days" if summary.get("since_days") else "all time"
+
+    lines: list[str] = [
+        "# Kai Operator Brief",
+        "",
+        f"Generated: {now} · Window: {window}",
+        "",
+        "## At a glance",
+        "",
+        f"- Runs considered: {summary['runs_considered']}",
+        f"- Biggest risks: {summary['biggest_risks']}",
+        f"- Approvals needed: {summary['approvals_needed']}",
+        f"- Failed automations: {summary['failed_automations']}",
+        f"- Stale/broken sources: {summary['stale_or_broken_sources']}",
+        f"- Promotion candidates: {summary['promotion_candidates']}",
+        "",
+    ]
+
+    lines.append("## Approvals needed")
+    lines.append("")
+    if data["approvals_needed"]:
+        for item in data["approvals_needed"]:
+            val = item.get("validation", {}) or {}
+            lines.append(
+                f"- `{item.get('risk_level', 'low')}` **{item.get('action_kind', 'action')}** "
+                f"({item.get('workflow', '')}) — {item.get('decision_reason', '')}"
+            )
+            lines.append(
+                f"  - id: `{item.get('item_id', '')}` · validation: {val.get('status', 'unvalidated')}"
+            )
+            if item.get("source_refs"):
+                lines.append(f"  - sources: {', '.join(str(s) for s in item['source_refs'])}")
+    else:
+        lines.append("- None waiting.")
+    lines.append("")
+
+    lines.append("## Biggest risks")
+    lines.append("")
+    if data["biggest_risks"]:
+        for risk in data["biggest_risks"]:
+            lines.append(
+                f"- `{risk['risk_level']}` **{risk['title']}** ({risk['workflow']}) "
+                f"→ `{risk['decision']}`"
+            )
+            if risk.get("why_it_matters"):
+                lines.append(f"  - {risk['why_it_matters']}")
+            if risk.get("source_url"):
+                lines.append(f"  - source: {risk['source_url']}")
+    else:
+        lines.append("- No high/critical findings this window.")
+    lines.append("")
+
+    lines.append("## Failed automations")
+    lines.append("")
+    if data["failed_automations"]:
+        for fail in data["failed_automations"]:
+            lines.append(f"- **{fail['workflow']}** (`{fail['run_id']}`)")
+            for blocker in fail["blockers"]:
+                lines.append(f"  - {blocker}")
+    else:
+        lines.append("- None.")
+    lines.append("")
+
+    lines.append("## Stale docs / broken sources")
+    lines.append("")
+    if data["stale_or_broken_sources"]:
+        for src in data["stale_or_broken_sources"]:
+            lines.append(f"- **{src['title']}** ({src['workflow']}) — {src.get('source_url', '')}")
+            if src.get("next_step"):
+                lines.append(f"  - next: {src['next_step']}")
+    else:
+        lines.append("- None flagged.")
+    lines.append("")
+
+    lines.append("## Suggested upgrades (recurring lessons)")
+    lines.append("")
+    if data["suggested_upgrades"]:
+        for up in data["suggested_upgrades"]:
+            workflows = ", ".join(up.get("workflows", []))
+            lines.append(f"- {up['count']}× **{up['lesson']}** (workflows: {workflows})")
+        lines.append("")
+        lines.append(
+            "Promotion ladder: ledger → `memory/lessons.md` → checklist/doctrine → gate/eval → golden test."
+        )
+    else:
+        lines.append("- No lesson has recurred enough to promote yet.")
+    lines.append("")
+
+    lines.append("## Actions taken")
+    lines.append("")
+    if data["actions_taken"]:
+        for act in data["actions_taken"]:
+            lines.append(f"- [{act['workflow']}] {act['action']}")
+    else:
+        lines.append("- No actions recorded this window.")
+    lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_brief(
+    *,
+    since_days: int | None = 7,
+    ledger_path: Path | None = None,
+    queue_path: Path | None = None,
+) -> str:
+    """Read the ledger + queue and return the rendered markdown brief."""
+    data = brief_data(since_days=since_days, ledger_path=ledger_path, queue_path=queue_path)
+    return render_brief(data)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate the Kai operator brief from the autonomy ledger")
+    parser.add_argument("--since", type=int, default=7, help="Only consider runs from the last N days (0 = all)")
+    parser.add_argument("--out", help="Write the brief to this path instead of stdout")
+    args = parser.parse_args(argv)
+
+    since = args.since if args.since and args.since > 0 else None
+    brief = build_brief(since_days=since)
+
+    if args.out:
+        out = Path(args.out)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(brief, encoding="utf-8")
+        print(f"Wrote operator brief to {out}")
+    else:
+        print(brief)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/social/platform_change_monitor.py
+++ b/scripts/social/platform_change_monitor.py
@@ -25,6 +25,7 @@ from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from scripts.autonomy.approval_queue import stage_findings
 from scripts.autonomy.impact import build_impact_card
 from scripts.autonomy.ledger import LedgerRecord, record_run
 
@@ -280,6 +281,10 @@ def main(argv: list[str] | None = None) -> int:
             str(REPORT.relative_to(ROOT)),
         ]
         record.actions_taken.append("Updated snapshot and impact report")
+        # Any finding the router staged for a human lands in the approval queue.
+        staged = stage_findings(record.findings, WORKFLOW)
+        if staged:
+            record.actions_taken.append(f"Staged {len(staged)} finding(s) for approval")
     else:
         record.actions_taken.append("Dry run; no files written")
 

--- a/tests/test_autonomy_approval_queue.py
+++ b/tests/test_autonomy_approval_queue.py
@@ -1,0 +1,188 @@
+"""Tests for the autonomy approval queue (issue #27 item 4).
+
+Covers the append-only event log, fold-to-state reads, dedupe on enqueue,
+validation, approve/reject resolution, and the bridge from router findings.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.autonomy.approval_queue import (
+    ApprovalItem,
+    approve,
+    enqueue,
+    get_item,
+    list_pending,
+    read_events,
+    read_items,
+    record_validation,
+    reject,
+    resolve,
+    stage_finding,
+    stage_findings,
+)
+
+
+class _QueueCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = Path(os.environ.get("PYTEST_TMP", "/tmp")) / f"kai-queue-{os.getpid()}"
+        self.queue = self._tmp / "approval_queue.jsonl"
+        self._tmp.mkdir(parents=True, exist_ok=True)
+        if self.queue.exists():
+            self.queue.unlink()
+
+    def tearDown(self) -> None:
+        if self.queue.exists():
+            self.queue.unlink()
+
+    def _item(self, **over) -> ApprovalItem:
+        base = dict(
+            workflow="demo.workflow",
+            action_kind="send_email",
+            risk_level="high",
+            payload={"to": "lead@example.com"},
+            source_refs=["https://example.com/x"],
+            decision_reason="action 'send_email' touches a live/client surface",
+        )
+        base.update(over)
+        return ApprovalItem(**base)
+
+
+class TestEnqueue(_QueueCase):
+    def test_item_gets_id_and_default_dedupe_key(self) -> None:
+        item = self._item()
+        self.assertTrue(item.item_id.startswith("send_email-"))
+        self.assertEqual(item.dedupe_key, "demo.workflow|send_email|https://example.com/x")
+
+    def test_invalid_risk_defaults_high(self) -> None:
+        self.assertEqual(self._item(risk_level="bogus").risk_level, "high")
+
+    def test_enqueue_appends_and_reads_back(self) -> None:
+        item = self._item()
+        event = enqueue(item, path=self.queue)
+        self.assertIsNotNone(event)
+        items = read_items(self.queue)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["status"], "pending")
+        self.assertEqual(items[0]["action_kind"], "send_email")
+        self.assertEqual(items[0]["validation"]["status"], "unvalidated")
+
+    def test_enqueue_dedupes_pending_same_key(self) -> None:
+        self.assertIsNotNone(enqueue(self._item(dedupe_key="k1"), path=self.queue))
+        self.assertIsNone(enqueue(self._item(dedupe_key="k1"), path=self.queue))
+        self.assertEqual(len(list_pending(self.queue)), 1)
+
+    def test_resolved_item_does_not_block_requeue(self) -> None:
+        first = self._item(dedupe_key="k2")
+        enqueue(first, path=self.queue)
+        reject(first.item_id, "operator", path=self.queue)
+        # Same key may be queued again once the prior one is resolved.
+        self.assertIsNotNone(enqueue(self._item(dedupe_key="k2"), path=self.queue))
+        self.assertEqual(len(list_pending(self.queue)), 1)
+
+    def test_enqueue_raises_on_bad_path(self) -> None:
+        bad = Path("/proc/should-not-be-writable/approval_queue.jsonl")
+        with self.assertRaises(OSError):
+            enqueue(self._item(), path=bad)
+
+
+class TestResolution(_QueueCase):
+    def test_approve_records_who_and_when(self) -> None:
+        item = self._item()
+        enqueue(item, path=self.queue)
+        approve(item.item_id, "connor", "looks good", path=self.queue)
+        resolved = get_item(item.item_id, self.queue)
+        self.assertEqual(resolved["status"], "approved")
+        self.assertEqual(resolved["resolved_by"], "connor")
+        self.assertEqual(resolved["resolution_note"], "looks good")
+        self.assertTrue(resolved["resolved_at"])
+        self.assertEqual(list_pending(self.queue), [])
+
+    def test_reject_sets_status(self) -> None:
+        item = self._item()
+        enqueue(item, path=self.queue)
+        reject(item.item_id, "connor", path=self.queue)
+        self.assertEqual(get_item(item.item_id, self.queue)["status"], "rejected")
+
+    def test_double_resolution_raises(self) -> None:
+        item = self._item()
+        enqueue(item, path=self.queue)
+        approve(item.item_id, "connor", path=self.queue)
+        with self.assertRaises(ValueError):
+            resolve(item.item_id, "rejected", "someone", path=self.queue)
+
+    def test_resolve_unknown_item_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            approve("does-not-exist", "connor", path=self.queue)
+
+    def test_invalid_resolution_status_raises(self) -> None:
+        item = self._item()
+        enqueue(item, path=self.queue)
+        with self.assertRaises(ValueError):
+            resolve(item.item_id, "maybe", "connor", path=self.queue)
+
+    def test_append_only_keeps_queued_line(self) -> None:
+        item = self._item()
+        enqueue(item, path=self.queue)
+        approve(item.item_id, "connor", path=self.queue)
+        events = read_events(self.queue)
+        self.assertEqual([e["event"] for e in events], ["queued", "resolved"])
+
+
+class TestValidation(_QueueCase):
+    def test_record_validation_updates_state(self) -> None:
+        item = self._item()
+        enqueue(item, path=self.queue)
+        record_validation(item.item_id, "passed", "gates clean", path=self.queue)
+        val = get_item(item.item_id, self.queue)["validation"]
+        self.assertEqual(val["status"], "passed")
+        self.assertEqual(val["notes"], "gates clean")
+
+    def test_invalid_validation_status_raises(self) -> None:
+        item = self._item()
+        enqueue(item, path=self.queue)
+        with self.assertRaises(ValueError):
+            record_validation(item.item_id, "great", path=self.queue)
+
+    def test_validate_unknown_item_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            record_validation("nope", "passed", path=self.queue)
+
+
+class TestFindingBridge(_QueueCase):
+    def test_stage_finding_only_for_approval_decisions(self) -> None:
+        approval = {
+            "decision": "stage_for_approval",
+            "action_kind": "paid_spend",
+            "risk_level": "high",
+            "decision_reason": "paid run",
+            "source_url": "https://ads.example.com",
+            "id": "ad_1",
+        }
+        other = {"decision": "auto_fix", "action_kind": "review", "id": "doc_1"}
+        self.assertIsNotNone(stage_finding(approval, "demo.workflow", path=self.queue))
+        self.assertIsNone(stage_finding(other, "demo.workflow", path=self.queue))
+        pending = list_pending(self.queue)
+        self.assertEqual(len(pending), 1)
+        self.assertEqual(pending[0]["action_kind"], "paid_spend")
+        self.assertIn("https://ads.example.com", pending[0]["source_refs"])
+
+    def test_stage_findings_filters_and_returns_written(self) -> None:
+        findings = [
+            {"decision": "stage_for_approval", "action_kind": "send_email", "id": "a", "source_url": "u1"},
+            {"decision": "escalate", "action_kind": "review", "id": "b"},
+            {"decision": "stage_for_approval", "action_kind": "publish", "id": "c", "source_url": "u2"},
+        ]
+        staged = stage_findings(findings, "demo.workflow", path=self.queue)
+        self.assertEqual(len(staged), 2)
+        self.assertEqual(len(list_pending(self.queue)), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_autonomy_operator_brief.py
+++ b/tests/test_autonomy_operator_brief.py
@@ -1,0 +1,135 @@
+"""Tests for the weekly operator brief (issue #27 item 8).
+
+Covers section assembly from injected ledger records + queue items, the time
+window filter, risk sorting, recurring-lesson upgrades, and markdown rendering.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.autonomy.operator_brief import brief_data, render_brief
+
+
+def _iso(days_ago: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days_ago)).isoformat(timespec="seconds")
+
+
+def _record(**over) -> dict:
+    base = dict(
+        run_id="run-1",
+        workflow="demo.workflow",
+        started_at=_iso(1),
+        findings=[],
+        actions_taken=[],
+        blockers=[],
+        lessons=[],
+    )
+    base.update(over)
+    return base
+
+
+def _pending(**over) -> dict:
+    base = dict(
+        item_id="send_email-x",
+        workflow="demo.workflow",
+        action_kind="send_email",
+        risk_level="high",
+        decision_reason="touches a live surface",
+        source_refs=["https://example.com"],
+        validation={"status": "unvalidated", "notes": ""},
+        status="pending",
+    )
+    base.update(over)
+    return base
+
+
+class TestBriefData(unittest.TestCase):
+    def test_sections_assembled(self) -> None:
+        records = [
+            _record(
+                findings=[
+                    {"title": "X policy changed", "risk_level": "high", "decision": "auto_pr",
+                     "why_it_matters": "allowed content shifted"},
+                    {"title": "dead source", "risk_level": "medium", "decision": "escalate",
+                     "source_status": "unresolved", "next_step": "find replacement"},
+                ],
+                actions_taken=["Updated snapshot"],
+                blockers=["source unreachable"],
+                lessons=["source unreachable; needs replacement"],
+            ),
+            _record(
+                run_id="run-2",
+                lessons=["source unreachable; needs replacement"],
+            ),
+        ]
+        data = brief_data(records=records, pending=[_pending()], since_days=7)
+        s = data["summary"]
+        self.assertEqual(s["approvals_needed"], 1)
+        self.assertEqual(s["failed_automations"], 1)
+        self.assertEqual(s["stale_or_broken_sources"], 1)
+        # high finding + escalate finding both count as biggest risks
+        self.assertEqual(s["biggest_risks"], 2)
+        # lesson recurred twice across runs -> one promotion candidate
+        self.assertEqual(s["promotion_candidates"], 1)
+        self.assertEqual(data["actions_taken"][0]["action"], "Updated snapshot")
+
+    def test_window_filters_old_runs(self) -> None:
+        records = [_record(started_at=_iso(1)), _record(run_id="old", started_at=_iso(40))]
+        data = brief_data(records=records, pending=[], since_days=7)
+        self.assertEqual(data["summary"]["runs_considered"], 1)
+
+    def test_window_zero_keeps_all(self) -> None:
+        records = [_record(started_at=_iso(1)), _record(run_id="old", started_at=_iso(40))]
+        data = brief_data(records=records, pending=[], since_days=None)
+        self.assertEqual(data["summary"]["runs_considered"], 2)
+
+    def test_biggest_risks_sorted_desc(self) -> None:
+        records = [
+            _record(findings=[
+                {"title": "med", "risk_level": "medium", "decision": "auto_pr"},
+                {"title": "crit", "risk_level": "critical", "decision": "block"},
+            ])
+        ]
+        data = brief_data(records=records, pending=[], since_days=7)
+        self.assertEqual(data["biggest_risks"][0]["risk_level"], "critical")
+
+    def test_low_risk_findings_excluded_from_risks(self) -> None:
+        records = [_record(findings=[{"title": "minor", "risk_level": "low", "decision": "auto_fix"}])]
+        data = brief_data(records=records, pending=[], since_days=7)
+        self.assertEqual(data["summary"]["biggest_risks"], 0)
+
+
+class TestRender(unittest.TestCase):
+    def test_render_has_all_headers(self) -> None:
+        data = brief_data(records=[_record()], pending=[], since_days=7)
+        md = render_brief(data)
+        for header in [
+            "# Kai Operator Brief",
+            "## Approvals needed",
+            "## Biggest risks",
+            "## Failed automations",
+            "## Stale docs / broken sources",
+            "## Suggested upgrades",
+            "## Actions taken",
+        ]:
+            self.assertIn(header, md)
+
+    def test_render_empty_states(self) -> None:
+        md = render_brief(brief_data(records=[], pending=[], since_days=7))
+        self.assertIn("None waiting.", md)
+        self.assertIn("No high/critical findings", md)
+
+    def test_render_lists_pending_approval(self) -> None:
+        md = render_brief(brief_data(records=[], pending=[_pending()], since_days=7))
+        self.assertIn("send_email", md)
+        self.assertIn("send_email-x", md)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this adds

Milestone 2 of the Kai autonomy control layer (issue #27), built on the ledger / decision router / impact-card layer merged in #28. Two slices that stack cleanly and need no network:

### 1. Approval queue (`scripts/autonomy/approval_queue.py`) — #27 item 4
The one canonical hold for risky actions: outbound email, client-facing claims, live publish, paid media, account/credential changes, deploys.

- **Append-only event log** (`data/autonomy/approval_queue.jsonl`) folded into current state on read — `queued → validated → resolved`. Nothing is mutated in place, so the file doubles as an audit trail of who approved what and when.
- `enqueue` **dedupes** pending items by key (so monthly re-runs don't re-queue the same action) and **raises on persistence failure** — dropping a staged risky action is a safety regression, unlike a missing ledger line. There is deliberately **no disable switch** (location is still redirectable via `KAI_AUTONOMY_DIR`).
- `stage_findings(...)` is the bridge from `route_decision` output: it enqueues exactly the findings routed to `action_class == stage_for_approval`.
- `approve` / `reject` / `record_validation` append resolution + validation events; re-resolving a resolved item raises.

### 2. Weekly operator brief (`scripts/autonomy/operator_brief.py`) — #27 item 8
A decision, not a dump. Reads the ledger + approval queue and renders a short markdown brief:

- biggest risks (high/critical findings + escalate/block), approvals needed (pending queue items), failed automations (runs with blockers), stale docs / broken sources (unresolved sources), suggested upgrades (recurring lessons via `mine_repeated_lessons`), actions taken.
- `--since N` time window, `--out PATH` to write. Restates ledger/queue facts only — invents no numbers (Kai Data Provenance Rule).

### Wiring
`scripts/social/platform_change_monitor.py` now stages any `stage_for_approval` findings into the queue on a real run.

## Tests & checks
- 25 new `unittest` cases (`tests/test_autonomy_approval_queue.py`, `tests/test_autonomy_operator_brief.py`); existing `test_autonomy_ledger.py` still passes (48 total).
- `python scripts/doctor.py --ci`, `golden_check.py`, and the self-check stay green. No gate/decision logic changed, so the golden corpus is untouched.
- `data/autonomy/*.jsonl` stay gitignored; only the README is tracked (updated to document the queue + brief).

Part of #27 (roadmap items 4 and 8) — not closing it; capability registry, memory promotion, and a second converted automation remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013c9Qazoy5rUd5HNXHhpnVE)_