### PR TITLE
Wire the long-horizon loops: truthful publish, self-contained scheduler, goal loop, campaign identity

### DIFF
--- a/.claude/rules/architecture-and-memory.md
+++ b/.claude/rules/architecture-and-memory.md
@@ -1,0 +1,176 @@
+# Architecture & Memory — load-on-demand detail
+
+> Referenced from `AGENTS.md` / `CLAUDE.md` ("Load-on-demand detail"). Restored 2026-07-05 from the pre-slimming `CLAUDE.md.bak-20260618` sections (Memory & Self-Learning, Directory Structure, Ad Policy Compliance Gate) and updated against the current tree. Every path below is verified by `python scripts/doctor.py` — if you add a path here, doctor must keep passing.
+
+---
+
+## Ad Policy Compliance Gate — full per-platform table
+
+**Before writing any ad copy**, load the platform's policy reference. Every ad must pass platform TOS in addition to quality gates.
+
+| Platform | Policy Reference | Key Restrictions |
+|----------|-----------------|------------------|
+| Google Ads | `harness/references/google-ads-policy-reference.md` + `harness/references/google-ads-rules.md` | Healthcare certs, financial disclosures, no superlatives without proof |
+| Meta (FB/IG) | `harness/references/meta-ads-rules.md` + `harness/references/meta-ads-api-reference.md` | Special Ad Categories (housing/employment/credit), no before/after images, personal attributes ban. **API note:** use `instagram_user_id` not `instagram_actor_id` (EC-01) |
+| TikTok | `harness/references/tiktok-ads-policy-reference.md` | No political ads, weight management restrictions, AI content disclosure required |
+| LinkedIn | `harness/references/linkedin-ads-rules.md` | Professional context required, B2B claim substantiation |
+| Microsoft/Bing | `harness/references/microsoft-ads-rules.md` | Global gambling bans by country, clinical trials ban |
+| Pinterest | `harness/references/pinterest-ads-rules.md` | All weight loss ads banned (narrow GLP-1 exception), strict body image rules |
+| Snapchat | `harness/references/snapchat-ads-policy-reference.md` | Young audience protections, EU political ad ban |
+| Amazon | `harness/references/amazon-ads-policy-reference.md` | 18-month claim evidence rule, no competitor disparagement |
+| X/Twitter | `harness/references/x-ads-policy-reference.md` | Verification tier affects ad access, political ad certification by country |
+| OpenAI Ads measurement | `harness/references/openai-ads-measurement-reference.md` | Pixel/CAPI consent, hashed identifiers only, event ID deduplication, server-only CAPI token |
+| **All platforms — writing guardrails** | `harness/references/ad-write-guardrails.md` | Structural guardrails applied by `/kai-write` for every ad format |
+| **All platforms — law** | `harness/references/advertising-compliance.md` | FTC disclosures, GDPR consent, CAN-SPAM, COPPA, click-to-cancel rule |
+| **Creator/influencer content** | `harness/references/creator-disclosure.md` + `harness/references/creator-disclosure-presets.json` | Material-connection disclosure per platform, no buried #ad |
+
+Organic posting has its own per-platform rule files (approval doctrine applies — no live-channel mutation without human sign-off):
+
+| Surface | Rules |
+|---------|-------|
+| X/Twitter organic | `harness/references/x-organic-posting-rules.md` |
+| Meta/IG/FB/Threads organic | `harness/references/meta-organic-posting-rules.md` |
+| LinkedIn organic | `harness/references/linkedin-organic-posting-rules.md` |
+| TikTok organic | `harness/references/tiktok-organic-posting-rules.md` |
+| YouTube organic | `harness/references/youtube-organic-posting-rules.md` |
+| Pinterest organic | `harness/references/pinterest-organic-posting-rules.md` |
+| Snapchat organic | `harness/references/snapchat-organic-posting-rules.md` |
+| Reddit organic | `harness/references/reddit-organic-posting-rules.md` |
+| All social automation | `harness/references/social-automation-rules.md` |
+| Cold email | `harness/references/cold-email-rules.md` |
+
+```
+Write ad --> Load platform policy --> Quality gate --> Policy compliance check --> PASS/FAIL
+```
+
+Policy freshness: `python scripts/ads/policy_freshness.py` flags stale policy references; the social platform monitor (`scripts/social/platform_change_monitor.py`, cron: `.github/workflows/social-platform-monitor.yml`) tracks platform rule changes into `harness/references/social-platform-monitor-report.md`.
+
+---
+
+## Memory & Self-Learning
+
+The harness learns in both directions: winners feed `knowledge/playbooks/what-works.md` (automated 30-day loop), and failures feed `memory/`. Full doctrine: `docs/system/learning-loop.md`.
+
+### The memory layer
+
+| File | Contents |
+|------|----------|
+| `memory/MEMORY.md` | Index — read at session start, stays under 200 lines |
+| `memory/lessons.md` | Dated trigger→advice lessons, one line each |
+| `memory/edge-cases.md` | Platform/API/harness gotchas with enforcement status |
+| `memory/what-doesnt-work.md` | Measured losers and anti-patterns with diagnoses |
+
+### Write triggers — append a lesson when:
+
+1. You make the same mistake a second time.
+2. A human corrects you and the correction generalizes.
+3. A quality gate fails twice for the same reason on one piece.
+4. A platform/API/tool behaves differently than the docs or harness references say.
+5. A claim you almost shipped turned out to be wrong or unsourceable.
+
+Generalize at write time ("Meta carousel ads need X", not "the Acme campaign needed X"). One line, dated, with a source. Use `python scripts/self_improvement/lesson_capture.py add --trigger "..." --advice "..."` or edit `memory/lessons.md` directly.
+
+### Graduation ladder
+
+A lesson that keeps mattering must become more enforced and more compressed:
+
+```
+lessons.md entry --> CLAUDE.md rule / checklist line --> lint rule or contract check + golden case
+```
+
+Prefer the executable form: if a lesson can be a regex, threshold, or checklist line, promote it. Promotions into gate scripts REQUIRE a golden corpus case (`evals/golden/manifest.json`) and a passing `golden_check.py` run. New hard blocks need human approval. Promoted edge cases get regression coverage in `tests/test_promoted_edge_cases.py` (EC-06, EC-11, EC-12 are already enforced this way).
+
+### The retro cycle
+
+Run `/kai-retro` monthly or after any sprint with 5+ gated pieces:
+
+```bash
+python scripts/self_improvement/lesson_capture.py mine     # recurring gate failures --> candidate lessons
+python scripts/self_improvement/lesson_capture.py losers   # undiagnosed 30-day losers
+```
+
+Then triage every lesson — promote / keep / merge / retire (never delete; git keeps history).
+
+### Self-validation
+
+```bash
+python scripts/doctor.py                       # preflight: referenced files, instruction chain, gates, deps, credentials
+python scripts/quality_gates/golden_check.py   # gate verdicts on known content unchanged
+```
+
+CI runs both on every push (`.github/workflows/quality-gates.yml`).
+
+---
+
+## Directory Structure
+
+```
+kai-cmo-harness/
+├── CLAUDE.md                              # Claude Code entry — bridges to AGENTS.md
+├── AGENTS.md                              # Canonical agent context (single source of truth)
+├── .claude/rules/                         # Load-on-demand detail (this file + scripts-and-tools.md)
+│
+├── knowledge/                             # Marketing intelligence library
+│   ├── _index.md                          # Framework lookup table
+│   ├── _quick-reference.md                # One-page cheat sheet
+│   ├── _deep-research-prompts.md          # Prompts for generating new frameworks
+│   ├── frameworks/
+│   │   ├── content-copywriting/           # Writing rules and persuasion
+│   │   ├── aeo-ai-search/                 # AEO, patents, AI search ranking
+│   │   ├── google-ads/                    # Google Ads deep dives (auction, PMax, RSA)
+│   │   └── meta-advertising/              # Meta ad system internals
+│   ├── channels/                          # Channel-specific guides (26+ docs)
+│   ├── checklists/                        # Validation checklists (36+ docs)
+│   ├── personas/                          # 8 audience personas
+│   ├── playbooks/                         # Strategic playbooks (50+ docs)
+│   ├── people/                            # Cloned-expert knowledge bases
+│   ├── research/                          # Research syntheses
+│   ├── design/                            # UI/UX design patterns
+│   └── examples/                          # Reference examples
+│
+├── harness/                               # Content pipeline engine + operator surface
+│   ├── brief-schema.md                    # Content brief template
+│   ├── skill-contracts/                   # Per-format contracts (YAML)
+│   ├── skills/                            # 45+ kai-* operator skills (SKILL.md each)
+│   ├── workflow-skus/                     # Packaged workflow definitions (YAML)
+│   ├── references/                        # Platform-specific rules & policies (see ad-policy table above)
+│   └── ARCHITECTURE.md                    # Harness design docs
+│
+├── memory/                                # Git-backed learning layer
+│   ├── MEMORY.md                          # Index — read at session start
+│   ├── lessons.md                         # Trigger→advice lessons (dated, one line each)
+│   ├── edge-cases.md                      # Platform/API/harness gotchas + enforcement status
+│   └── what-doesnt-work.md                # Measured losers and anti-patterns
+│
+├── kai/                                   # Canonical runtime/workspace layer
+│   └── runtime/                           # Agents, goals, connections, audit, business profile
+│
+├── scripts/
+│   ├── doctor.py                          # Preflight self-check — run on every fresh clone
+│   ├── harness_cli.py                     # kai-harness pipeline CLI (run/brief/gate/report/patterns/status)
+│   ├── harness_config.py                  # Centralized config (env + config.yaml overrides)
+│   ├── content/                           # Outcome engine (engine.py), briefs, writers, Discord handler
+│   ├── quality/                           # Quality/policy layer
+│   ├── quality_gates/                     # Automated content validation
+│   │   ├── four_us_score.py               # Four U's scorer (12/16 threshold)
+│   │   ├── banned_word_check.py           # Banned word detection
+│   │   ├── seo_lint.py                    # SEO rule linter
+│   │   ├── agent_readiness_lint.py        # Agent-readiness linter (robots.txt, llms.txt, JS-gating, schema)
+│   │   ├── audit_provenance_lint.py       # Audit data-provenance enforcement
+│   │   ├── mutation_risk_lint.py          # Live-channel mutation risk linter
+│   │   ├── gate_logger.py                 # JSONL run logging --> data/learning/gate_runs.jsonl
+│   │   └── golden_check.py                # Golden corpus regression runner (evals/golden/)
+│   ├── self_improvement/                  # lesson_capture.py — failure-side learning CLI
+│   ├── publish/  social/  intel/  campaigns/  reporting/  ads/   # see scripts-and-tools.md
+│   ├── audit/  analytics/  autonomy/  cro/  leads/  security/    # domain script packs
+│   └── knowledge_cloner/                  # Expert knowledge extraction pipeline
+│
+├── agent/                                 # OpenClaw autonomous agent config
+├── gateway/                               # Remote runner and connector surface (FastAPI)
+├── workspace/                             # Working directory: HEARTBEAT.md, agents/, MARKETING.md, output
+├── evals/golden/                          # Golden corpus (gate regression cases)
+├── data/                                  # Runtime state: content log, pending checks, learning logs
+├── deploy/                                # Deployment scripts
+├── docs/                                  # Extended documentation (docs/system/ = doctrine)
+└── examples/                              # Usage examples
+```

--- a/.claude/rules/scripts-and-tools.md
+++ b/.claude/rules/scripts-and-tools.md
@@ -1,0 +1,183 @@
+# Scripts & Tools — load-on-demand detail
+
+> Referenced from `AGENTS.md` / `CLAUDE.md` ("Load-on-demand detail"). Restored 2026-07-05 from the pre-slimming `CLAUDE.md.bak-20260618` sections (Publishing & Social, Competitive Intelligence, Campaign Management, Reporting, Google Ads Integration, Knowledge Cloner, OpenClaw Autonomous Mode) and verified against the current scripts. Every path below is checked by `python scripts/doctor.py`.
+>
+> **Approval doctrine applies to everything here:** nothing publishes or mutates a live channel without human approval. Publishing is OFF by default (`publishing.enabled` in `config.yaml`, `KAI_PUBLISH_ENABLED` env override — see `scripts/harness_config.py`).
+
+---
+
+## Publishing & Social
+
+The content pipeline can publish to CMS platforms and social media **after human approval**.
+
+### CMS Publishing (`scripts/publish/`)
+
+| Platform | Script | Auth |
+|----------|--------|------|
+| WordPress | `scripts/publish/wordpress.py` | `WP_URL` + `WP_USERNAME` + `WP_APP_PASSWORD` |
+| Ghost | `scripts/publish/ghost.py` | `GHOST_URL` + `GHOST_ADMIN_KEY` |
+| Webflow | `scripts/publish/webflow.py` | `WEBFLOW_API_TOKEN` + `WEBFLOW_SITE_ID` + `WEBFLOW_COLLECTION_ID` |
+| Static sites | `scripts/publish/markdown_to_site.py` | None (outputs markdown with frontmatter) |
+
+### Social Posting (`scripts/social/`)
+
+| Platform | Script | Auth |
+|----------|--------|------|
+| LinkedIn | `scripts/social/linkedin.py` | `LINKEDIN_ACCESS_TOKEN` |
+| Twitter/X | `scripts/social/twitter.py` | Twitter API keys (4 vars) |
+| Buffer | `scripts/social/buffer.py` | `BUFFER_ACCESS_TOKEN` (posts to all connected platforms) |
+| Platform rule changes | `scripts/social/platform_change_monitor.py` | None (monitors policy pages → `harness/references/social-platform-monitor-report.md`) |
+
+Per-platform organic posting rules live in `harness/references/` (see the ad-policy/organic table in `.claude/rules/architecture-and-memory.md`). Automation limits: `harness/references/social-automation-rules.md`.
+
+### CLI Integration
+
+```bash
+python scripts/harness_cli.py run --task blog --site mysite --keyword "..." --publish wordpress
+```
+
+(`kai-harness` is this CLI; wrappers live in `bin/`.)
+
+---
+
+## Competitive Intelligence
+
+### Scripts (`scripts/intel/`)
+
+| Script | Purpose |
+|--------|---------|
+| `python scripts/intel/competitor_monitor.py --check` | Scan competitor RSS feeds + sitemaps for new content |
+| `python scripts/intel/competitor_monitor.py --diff` | Show new pages since last scan |
+| `python scripts/intel/serp_tracker.py --track` | Track keyword rankings daily |
+| `python scripts/intel/serp_tracker.py --alerts` | Show position changes > 3 |
+| `python scripts/intel/content_gap.py --site X` | Keywords competitors rank for that you don't |
+| `python scripts/intel/market_brief.py` | AI-synthesized weekly competitive brief |
+| `python scripts/intel/brand_pulse.py <brand> --domain <domain>` | Brand-pulse snapshot (reviews, mentions, share of voice) |
+
+Reddit listening: `scripts/reddit_monitor/reddit_listener.py` + `scripts/reddit_monitor/reddit_digest.py` (profiles in `scripts/reddit_monitor/profiles`).
+
+Add competitors to `config.yaml`:
+```yaml
+competitors:
+  - url: "https://competitor.com"
+    name: "Competitor Name"
+    rss_feed: "https://competitor.com/blog/feed"
+```
+
+---
+
+## Campaign Management
+
+### Campaign Planner (`scripts/campaigns/campaign_planner.py`)
+
+Generates all assets for a multi-channel campaign:
+
+```bash
+python scripts/campaigns/campaign_planner.py --goal "product launch" --product myproduct --keyword "ai crm" --type launch --save campaigns/q1/
+```
+
+**Output:** landing page copy, 5-email nurture sequence, social variants (LinkedIn/Twitter/Instagram), ad variants (Meta + Google), content calendar.
+
+**Campaign types:** launch, promotion, webinar, seasonal, awareness
+
+### Campaign Tracker (`scripts/campaigns/campaign_tracker.py`)
+
+Track campaign performance across channels:
+
+```bash
+python scripts/campaigns/campaign_tracker.py --create "Q1 Launch" --dir campaigns/q1/
+python scripts/campaigns/campaign_tracker.py --update "Q1 Launch" --channel email --metric opens --value 2450
+python scripts/campaigns/campaign_tracker.py --report "Q1 Launch"
+```
+
+Editorial calendar store: `scripts/campaigns/calendar.py` (JSONL under `data/calendar`, path via `get_calendar_dir()` in `scripts/harness_config.py`).
+
+---
+
+## Reporting
+
+| Script | Output |
+|--------|--------|
+| `scripts/reporting/weekly_report.py` | Markdown report (traffic, SEO, content, competitive, recommendations) |
+| `scripts/reporting/ceo_deck.py` | 5-slide Marp/Slidev deck |
+| `scripts/reporting/dashboard.html` | Single-file HTML dashboard (open in browser, no server) |
+
+```bash
+python scripts/reporting/weekly_report.py --save reports/week.md
+python scripts/build_dashboard.py   # rebuild the HTML dashboard
+```
+
+---
+
+## Google Ads Integration
+
+### API Scripts (`scripts/ads/`)
+
+| Script | Purpose |
+|--------|---------|
+| `python scripts/ads/google_ads.py campaigns` | Campaign performance (spend, ROAS, CPC, CTR) |
+| `python scripts/ads/google_ads.py keywords` | Keyword performance with Quality Scores |
+| `python scripts/ads/google_ads.py search-terms` | Search terms report for negatives + opportunities |
+| `python scripts/ads/google_ads.py summary` | Account-level summary |
+| `python scripts/ads/google_ads_optimize.py --analyze` | Full AI-powered optimization report |
+| `python scripts/ads/google_ads_optimize.py --negatives` | Negative keyword suggestions |
+| `python scripts/ads/google_ads_optimize.py --budget` | Budget reallocation recommendations |
+
+Read-only pulls are safe to run; **anything that mutates a live ad account goes through the approval gate first** (see `scripts/ads/upload.py` guardrails and `tests/test_ads_upload_guardrails.py`).
+
+### Knowledge (`knowledge/frameworks/google-ads/`)
+
+| File | Topic |
+|------|-------|
+| `knowledge/frameworks/google-ads/google-ads-auction-deep-dive.md` | Ad Rank, Quality Score, Smart Bidding |
+| `knowledge/frameworks/google-ads/google-ads-pmax-deep-dive.md` | Performance Max architecture + optimization |
+| `knowledge/frameworks/google-ads/google-ads-rsa-deep-dive.md` | RSA combinations, pinning, ad strength |
+
+---
+
+## Knowledge Cloner
+
+Extract expert knowledge from any source into structured, actionable knowledge bases.
+
+**Pipeline:** Discover → Transcribe → Extract → Distill → Synthesize → Operationalize → Quality Gate
+
+```bash
+python -m scripts.knowledge_cloner init "Expert Name" --domain "Marketing"
+python -m scripts.knowledge_cloner discover expert-name --youtube https://www.youtube.com/@Channel/videos
+python -m scripts.knowledge_cloner pipeline expert-name --max-cost 10.00
+```
+
+**Sources:** YouTube channels, podcast RSS feeds, articles, GitHub repos, local files
+
+**Output (per expert):** 5 distilled docs (frameworks, tactics, edges, principles, anti-patterns), 4 operational outputs (quick reference, decision trees, checklists, AI prompts), and a quality report with 5-gate evaluation. Results land in `knowledge/people/`.
+
+**Cost:** ~$3.50 for 40 sources via OpenRouter. See `scripts/knowledge_cloner/README.md`.
+
+---
+
+## Advanced: OpenClaw Autonomous Mode
+
+The harness can run as a fully autonomous marketing agent via OpenClaw. This enables:
+
+- Discord-based command interface for content requests (`scripts/content/harness_discord.py` — paths come from `scripts/harness_config.py`; set `CMO_BASE_DIR`/`VENV_PYTHON` for deployed installs)
+- Scheduled heartbeats that monitor content performance (`workspace/HEARTBEAT.md`)
+- Domain-specific agents with skill routing (`workspace/agents/`)
+- Human-in-the-loop approval gates before publishing
+- Persistent memory across sessions via git-backed state (`memory/`)
+
+Setup requires a server, Discord bot token, and OpenClaw runtime. See `docs/OPENCLAW_SETUP.md` for the full walkthrough. The optional proactive memory scan in `workspace/HEARTBEAT.md` step 4 is external deployment tooling — configure it with `KAI_PROACTIVE_HEARTBEAT` or skip it on a fresh clone.
+
+---
+
+## Usage Pattern
+
+```
+1. Check the AGENTS.md Framework Map to find the right framework for your task
+2. Load the primary framework file as context
+3. Load the skill contract from harness/skill-contracts/
+4. Create a brief using harness/brief-schema.md
+5. Write the content applying framework rules
+6. Run quality gate scripts to validate
+7. Fix failures and re-run (max 2 retries)
+8. Get human approval, then ship it
+```

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,11 @@ Thumbs.db
 .idea/
 *.code-workspace
 
-# Claude Code
-.claude/
+# Claude Code — local settings/state stay untracked, but .claude/rules/ SHIPS
+# with the repo (CLAUDE.md/AGENTS.md load-on-demand pointers and
+# doctor.py check_instruction_chain both require those files on a fresh clone).
+.claude/*
+!.claude/rules/
 
 # Temp
 /tmp/

--- a/agent/loop.py
+++ b/agent/loop.py
@@ -213,6 +213,13 @@ class AgentLoop:
         if fresh_graph:
             self._skip_descendants(fresh_graph, node_id)
 
+        # Replan instead of dead-end: flag the graph so the weekly CMO review
+        # (agent/tasks/cmo_review.py) re-decomposes the remaining work with
+        # this failure as context. needs_replan graphs are excluded from
+        # list_active_task_graphs, so execution of this graph stops here.
+        agent_db.update_task_graph_status(graph.graph_id, "needs_replan")
+        print(f"[{datetime.now()}] Task graph {graph.graph_id} marked needs_replan after node {node_id} failed")
+
     def _skip_descendants(self, graph, node_id: str):
         """Recursively mark all downstream child nodes as skipped in the database."""
         children = [edge[1] for edge in graph.edges if edge[0] == node_id]
@@ -232,6 +239,11 @@ class AgentLoop:
         """Update overall graph status if all nodes are terminal."""
         fresh_graph = agent_db.get_task_graph(graph_id)
         if not fresh_graph:
+            return
+
+        # A graph flagged for replan keeps that status — the weekly CMO
+        # review owns its next transition (needs_replan -> replanned).
+        if fresh_graph.status == "needs_replan":
             return
 
         all_terminal = True

--- a/agent/scheduler.py
+++ b/agent/scheduler.py
@@ -192,6 +192,11 @@ class Scheduler:
         - ad_performance: 12:00 PM
         - seo_opportunities: 2:00 PM
         - weekly_report: Sunday 9:00 AM
+        - performance_check_30d: 2:00 AM daily
+        - pattern_extract_weekly: Monday 2:00 PM
+        - harness_defaults_update: Monday 2:30 PM
+        - editorial_calendar_tick: hourly
+        - cmo_review: Monday 7:00 AM
         """
         from uuid import uuid4
 
@@ -389,6 +394,44 @@ class Scheduler:
                     "notify_on_complete": True,
                     "extra": {"window_days": 7},
                 },
+            },
+            # Self-improvement loop (docs/OPENCLAW_SETUP.md section 3) —
+            # 30-day check → pattern mining → defaults update
+            {
+                "name": "30-Day Performance Check",
+                "cron_expression": "0 2 * * *",  # 2 AM daily
+                "task_type": "performance_check_30d",
+                "config": {"notify_on_complete": True}
+            },
+            {
+                "name": "Weekly Pattern Extraction",
+                "cron_expression": "0 14 * * 1",  # 2 PM Mondays
+                "task_type": "pattern_extract_weekly",
+                "config": {"notify_on_complete": True}
+            },
+            {
+                "name": "Harness Defaults Update",
+                "cron_expression": "30 14 * * 1",  # 2:30 PM Mondays
+                "task_type": "harness_defaults_update",
+                "config": {"notify_on_complete": True}
+            },
+            # Editorial calendar executor — drafts only; the approval flow
+            # (execute_approved_actions) is the only path that publishes.
+            {
+                "name": "Editorial Calendar Tick",
+                "cron_expression": "0 * * * *",  # Hourly
+                "task_type": "editorial_calendar_tick",
+                "config": {"notify_on_complete": False}
+            },
+            # Weekly CMO review — closes the goal loop (plan → act → measure
+            # → replan): refreshes goal KPIs, checks pace vs deadline, and
+            # decomposes behind-pace goals into task graphs the loop executes.
+            # Resulting actions still pass ActionStore approval + mandates.
+            {
+                "name": "Weekly CMO Review",
+                "cron_expression": "0 7 * * 1",  # 7 AM Mondays
+                "task_type": "cmo_review",
+                "config": {"notify_on_complete": True}
             },
         ]
 

--- a/agent/tasks/__init__.py
+++ b/agent/tasks/__init__.py
@@ -24,6 +24,13 @@ from .creative_assets import CreativeAssetsTask
 from .social_staleness import SocialStalenessTask
 from .claude_agent import ClaudeAgentTask
 from .harness_review import HarnessReviewTask
+from .editorial_calendar import EditorialCalendarTickTask
+from .cmo_review import CMOReviewTask
+from .self_improvement import (
+    HarnessDefaultsUpdateTask,
+    PatternExtractWeeklyTask,
+    PerformanceCheck30dTask,
+)
 
 # Task type to handler mapping (generic handlers only)
 TASK_HANDLERS: dict[str, type[BaseTask]] = {
@@ -46,6 +53,14 @@ TASK_HANDLERS: dict[str, type[BaseTask]] = {
     "claude_competitors": ClaudeAgentTask,
     # HALO-style harness review
     "harness_review": HarnessReviewTask,
+    # Self-improvement loop (30-day check → pattern mining → defaults update)
+    "performance_check_30d": PerformanceCheck30dTask,
+    "pattern_extract_weekly": PatternExtractWeeklyTask,
+    "harness_defaults_update": HarnessDefaultsUpdateTask,
+    # Editorial calendar executor (drafts only — approval flow publishes)
+    "editorial_calendar_tick": EditorialCalendarTickTask,
+    # Weekly CMO review — goal loop: measure KPIs, check pace, (re)plan
+    "cmo_review": CMOReviewTask,
 }
 
 
@@ -90,6 +105,11 @@ __all__ = [
     "SocialStalenessTask",
     "ClaudeAgentTask",
     "HarnessReviewTask",
+    "PerformanceCheck30dTask",
+    "PatternExtractWeeklyTask",
+    "HarnessDefaultsUpdateTask",
+    "EditorialCalendarTickTask",
+    "CMOReviewTask",
     "register_task",
     "get_task_handler",
 ]

--- a/agent/tasks/cmo_review.py
+++ b/agent/tasks/cmo_review.py
@@ -1,0 +1,415 @@
+"""Weekly CMO review — closes the goal loop: plan -> act -> measure -> replan.
+
+Scheduled Monday 07:00 (agent/scheduler.py create_default_tasks). Each run:
+
+1. Loads all active goals from the GoalRegistry (kai/runtime/goals.py).
+2. Refreshes each goal's ``current_value`` where it is derivable from the
+   content log (``data/content_log.json``) using the dict-tolerant grade
+   helpers (``scripts/self_improvement/grades.py``). A KPI with no measured
+   data is a DATA GAP — the stored value is left untouched, never zeroed
+   (memory/lessons.md 2026-06-09: missing connectors are data gaps).
+3. Computes pace vs deadline via ``compute_goal_pace``.
+4. For each behind-pace goal with NO active task graph, decomposes the goal
+   via GoalDecomposer and persists the graph (``agent_db.create_task_graph``)
+   so the existing agent loop executes it. Graphs the loop flagged
+   ``needs_replan`` count as inactive: the remaining work is re-decomposed
+   with the failure context injected into the decomposer prompt (via goal
+   metadata, which the decomposer already serializes), and the exhausted
+   graph is marked ``replanned``.
+5. Writes a review snapshot to ``<runtime>/goals/reviews/<date>.json``.
+6. Notifies via the shared BaseTask notification helper.
+
+Approval doctrine: this task reads local state and writes goal files and
+snapshots only. Any execution it triggers flows through the existing
+orchestrator, whose actions pass ActionStore approval + mandate validation
+(kai/execution/executor.py). Nothing here publishes or mutates a live channel.
+
+No LLM key configured? Decomposition is skipped as a data gap; measurement,
+pace, snapshot, and notification still run — never an exception that puts
+the scheduler into a crash/retry loop.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import sys
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..models import ScheduledTask
+from .base import BaseTask
+
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Any of these makes agent.llm.router usable (see router PROVIDER_KEY_ENV).
+LLM_KEY_ENV_VARS = (
+    "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY",
+    "GEMINI_API_KEY",
+    "ANTHROPIC_API_KEY",
+)
+
+# Graph statuses that mean "the goal already has a plan in flight".
+ACTIVE_GRAPH_STATUSES = ("pending", "running")
+
+# KPI aliases the review can derive from the content log. Anything else is
+# left to connectors/manual updates (kai-harness goals update --current).
+_PUBLISHED_KPIS = {"content_published", "published_count", "published_pieces", "posts_published"}
+_WINNER_KPIS = {"content_winners", "winner_count", "winners", "winners_30d"}
+_CLICK_KPIS = {"organic_clicks", "gsc_clicks", "clicks", "clicks_30d"}
+_IMPRESSION_KPIS = {"organic_impressions", "gsc_impressions", "impressions", "impressions_30d"}
+
+
+class CMOReviewTask(BaseTask):
+    """Weekly goal review: measure KPIs, check pace, (re)plan behind goals."""
+
+    @property
+    def task_type(self) -> str:
+        return "cmo_review"
+
+    @property
+    def description(self) -> str:
+        return "Weekly CMO review — refresh goal KPIs, check pace, decompose behind-pace goals"
+
+    async def execute(self, task: ScheduledTask, **kwargs) -> Optional[Dict[str, Any]]:
+        try:
+            from kai.runtime.goals import GoalRegistry, compute_goal_pace
+        except Exception as e:
+            logger.exception("goal registry unavailable")
+            return {"success": False, "error": f"goal registry unavailable: {e}"}
+
+        try:
+            registry = GoalRegistry()
+            goals = [g for g in registry.list_goals() if g.status == "active"]
+        except Exception as e:
+            logger.exception("could not load goals")
+            return {"success": False, "error": f"could not load goals: {e}"}
+
+        entries = self._load_content_log()
+        db = self._db()
+        graph_index = self._graph_index(db)
+        llm_available = self._llm_available()
+
+        goal_rows: List[Dict[str, Any]] = []
+        deltas: List[Dict[str, Any]] = []
+        decisions: List[Dict[str, Any]] = []
+        graphs_created: List[str] = []
+        behind_count = 0
+
+        for goal in goals:
+            previous_value = goal.current_value
+            derived = self._derive_kpi_value(goal, entries)
+            refreshed = derived is not None and float(derived) != previous_value
+            if refreshed:
+                if goal.metadata is None:
+                    goal.metadata = {}
+                # Keep the original baseline so pace math stays anchored.
+                goal.metadata.setdefault("baseline_value", previous_value)
+                goal.current_value = float(derived)
+                try:
+                    registry.save_goal(goal)
+                except Exception:
+                    logger.warning("could not persist refreshed goal %s", goal.goal_id, exc_info=True)
+                deltas.append({
+                    "goal_id": goal.goal_id,
+                    "kpi_name": goal.kpi_name,
+                    "previous_value": previous_value,
+                    "current_value": goal.current_value,
+                    "source": "content_log",
+                })
+
+            pace = compute_goal_pace(goal)
+            slot = graph_index.get(goal.goal_id, {"active": [], "needs_replan": []})
+            goal_rows.append({
+                "goal_id": goal.goal_id,
+                "brand_id": goal.brand_id,
+                "name": goal.name,
+                "kpi_name": goal.kpi_name,
+                "target_value": goal.target_value,
+                "current_value": goal.current_value,
+                "previous_value": previous_value,
+                "target_direction": goal.target_direction,
+                "deadline": goal.deadline,
+                "refreshed": refreshed,
+                "pace": pace,
+                "active_graphs": slot["active"],
+                "needs_replan_graphs": slot["needs_replan"],
+            })
+
+            if not pace["behind_pace"]:
+                decisions.append({
+                    "goal_id": goal.goal_id,
+                    "decision": "achieved" if pace["achieved"] else "on_pace",
+                })
+                continue
+
+            behind_count += 1
+            if slot["active"]:
+                decisions.append({
+                    "goal_id": goal.goal_id,
+                    "decision": "active_graph_exists",
+                    "graph_ids": list(slot["active"]),
+                })
+                continue
+
+            replan_context = None
+            if slot["needs_replan"]:
+                replan_context = self._failure_context(db, slot["needs_replan"][-1])
+
+            if not llm_available:
+                decisions.append({
+                    "goal_id": goal.goal_id,
+                    "decision": "decomposition_skipped_no_llm",
+                    "data_gap": True,
+                })
+                continue
+
+            graph_id, error = await self._decompose_and_persist(db, goal, replan_context)
+            if graph_id:
+                graphs_created.append(graph_id)
+                # Retire the exhausted graph(s) so next week's review doesn't
+                # re-inject the same failure context against the new plan.
+                for old_id in slot["needs_replan"]:
+                    try:
+                        db.update_task_graph_status(old_id, "replanned")
+                    except Exception:
+                        logger.warning("could not mark graph %s replanned", old_id, exc_info=True)
+                decisions.append({
+                    "goal_id": goal.goal_id,
+                    "decision": "replanned" if replan_context else "decomposed",
+                    "graph_id": graph_id,
+                    "replanned_graphs": list(slot["needs_replan"]),
+                })
+            else:
+                decisions.append({
+                    "goal_id": goal.goal_id,
+                    "decision": "decomposition_failed",
+                    "error": error,
+                })
+
+        snapshot_payload = {
+            "task": "cmo_review",
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "llm_available": llm_available,
+            "goals": goal_rows,
+            "deltas": deltas,
+            "decisions": decisions,
+            "graphs_created": graphs_created,
+        }
+        snapshot_path = self._write_snapshot(registry, snapshot_payload)
+
+        summary = (
+            f"CMO review: {len(goals)} active goal(s), {len(deltas)} KPI value(s) "
+            f"refreshed, {behind_count} behind pace, {len(graphs_created)} task "
+            f"graph(s) created (execution stays behind ActionStore approval)"
+        )
+        if behind_count and not llm_available:
+            summary += " — decomposition skipped: no LLM key configured (data gap)"
+
+        try:
+            await self.send_notification(summary, task=task)
+        except Exception:
+            logger.warning("cmo_review notification failed", exc_info=True)
+
+        return {
+            "success": True,
+            "summary": summary,
+            "goals_reviewed": len(goals),
+            "values_refreshed": len(deltas),
+            "behind_pace": behind_count,
+            "graphs_created": graphs_created,
+            "decisions": decisions,
+            "snapshot": str(snapshot_path) if snapshot_path else None,
+            "llm_available": llm_available,
+        }
+
+    # ── Collaborators (small methods so tests can monkeypatch cleanly) ──────
+
+    def _db(self):
+        """Return the agent database at call time (test fixtures patch it)."""
+        from .. import models as agent_models
+        return agent_models.agent_db
+
+    @staticmethod
+    def _llm_available() -> bool:
+        return any(os.getenv(var, "").strip() for var in LLM_KEY_ENV_VARS)
+
+    def _load_content_log(self) -> List[Dict[str, Any]]:
+        """Read the content log, returning [] on any problem (data gap)."""
+        try:
+            from scripts.harness_config import get_config
+            path = Path(get_config().content_log)
+        except Exception:
+            logger.warning("harness config unavailable — no content log", exc_info=True)
+            return []
+        try:
+            if not path.exists():
+                return []
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return data if isinstance(data, list) else []
+        except Exception:
+            logger.warning("could not read content log %s", path, exc_info=True)
+            return []
+
+    def _derive_kpi_value(self, goal, entries: List[Dict[str, Any]]) -> Optional[float]:
+        """Derive a goal's current KPI value from content-log entries.
+
+        Returns None when the KPI is not derivable OR when there is no
+        measured data for it — a data gap is never reported as zero.
+        """
+        try:
+            from scripts.self_improvement.grades import get_grade, get_published_at
+        except Exception:
+            logger.warning("grades helpers unavailable", exc_info=True)
+            return None
+
+        kpi = (goal.kpi_name or "").strip().lower()
+        site = (goal.metadata or {}).get("site") or goal.brand_id
+        scoped = [
+            e for e in entries
+            if isinstance(e, dict) and (site in (None, "", "all") or e.get("site") == site)
+        ]
+
+        if kpi in _PUBLISHED_KPIS:
+            if not scoped:
+                return None  # no log entries for this site at all — data gap
+            return float(sum(
+                1 for e in scoped if e.get("url") and get_published_at(e)
+            ))
+
+        if kpi in _WINNER_KPIS:
+            graded = [e for e in scoped if get_grade(e)]
+            if not graded:
+                return None  # nothing measured yet — data gap, not zero
+            return float(sum(1 for e in graded if get_grade(e) == "winner"))
+
+        if kpi in _CLICK_KPIS or kpi in _IMPRESSION_KPIS:
+            field = "clicks" if kpi in _CLICK_KPIS else "impressions"
+            values: List[float] = []
+            for e in scoped:
+                perf = e.get("performance_30d")
+                if not isinstance(perf, dict):
+                    continue
+                gsc = perf.get("gsc")
+                if isinstance(gsc, dict) and gsc.get(field) is not None:
+                    try:
+                        values.append(float(gsc[field]))
+                    except (TypeError, ValueError):
+                        continue
+            if not values:
+                return None  # no GSC-measured entries — data gap
+            return float(sum(values))
+
+        return None  # KPI not derivable from the content log
+
+    def _graph_index(self, db) -> Dict[str, Dict[str, List[str]]]:
+        """Index task graphs by goal_id into active / needs_replan buckets."""
+        index: Dict[str, Dict[str, List[str]]] = {}
+        try:
+            with db.connect() as conn:
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT graph_id, goal_id, status FROM task_graphs "
+                    "WHERE goal_id IS NOT NULL ORDER BY created_at ASC"
+                ).fetchall()
+        except Exception:
+            logger.warning("could not index task graphs", exc_info=True)
+            return index
+        for row in rows:
+            slot = index.setdefault(row["goal_id"], {"active": [], "needs_replan": []})
+            if row["status"] in ACTIVE_GRAPH_STATUSES:
+                slot["active"].append(row["graph_id"])
+            elif row["status"] == "needs_replan":
+                slot["needs_replan"].append(row["graph_id"])
+        return index
+
+    def _failure_context(self, db, graph_id: str) -> Optional[Dict[str, Any]]:
+        """Summarize a needs_replan graph for the decomposer prompt."""
+        try:
+            graph = db.get_task_graph(graph_id)
+        except Exception:
+            logger.warning("could not load graph %s for replan context", graph_id, exc_info=True)
+            return None
+        if not graph:
+            return None
+        failed = [
+            {"node_id": n.node_id, "task_type": n.task_type, "error": n.error}
+            for n in graph.nodes.values() if n.status == "failed"
+        ]
+        completed = [
+            {"node_id": n.node_id, "task_type": n.task_type}
+            for n in graph.nodes.values() if n.status == "completed"
+        ]
+        remaining = [
+            {"node_id": n.node_id, "task_type": n.task_type, "status": n.status}
+            for n in graph.nodes.values() if n.status in ("pending", "skipped")
+        ]
+        return {
+            "previous_graph_id": graph_id,
+            "failed_nodes": failed,
+            "completed_nodes": completed,
+            "remaining_nodes": remaining,
+            "instruction": (
+                "This is a REPLAN after a failed task graph. Plan only the "
+                "remaining work: do not repeat completed nodes, and design "
+                "around the listed failures instead of retrying them verbatim."
+            ),
+        }
+
+    async def _decompose_and_persist(
+        self, db, goal, replan_context: Optional[Dict[str, Any]]
+    ) -> Tuple[Optional[str], Optional[str]]:
+        """Decompose a goal into a TaskGraph and persist it. Never raises."""
+        try:
+            from ..decomposer import GoalDecomposer
+        except Exception as e:
+            logger.warning("GoalDecomposer unavailable: %s", e)
+            return None, f"decomposer unavailable: {e}"
+
+        prompt_goal = goal
+        if replan_context:
+            # The decomposer serializes goal.metadata into its prompt, so the
+            # failure context rides along without touching decomposer code.
+            metadata = dict(goal.metadata or {})
+            metadata["replan_context"] = replan_context
+            prompt_goal = replace(goal, metadata=metadata)
+
+        try:
+            graph = await GoalDecomposer().decompose(prompt_goal)
+        except Exception as e:
+            logger.warning("goal decomposition failed for %s: %s", goal.goal_id, e)
+            return None, str(e)
+
+        try:
+            db.create_task_graph(graph)
+        except Exception as e:
+            logger.exception("could not persist task graph for %s", goal.goal_id)
+            return None, f"could not persist graph: {e}"
+        return graph.graph_id, None
+
+    def _write_snapshot(self, registry, payload: Dict[str, Any]) -> Optional[Path]:
+        """Write the review snapshot atomically; return its path or None."""
+        try:
+            reviews_dir = registry.goals_dir / "reviews"
+            reviews_dir.mkdir(parents=True, exist_ok=True)
+            date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+            path = reviews_dir / f"{date_str}.json"
+            tmp = path.with_suffix(".tmp")
+            tmp.write_text(
+                json.dumps(payload, indent=2, sort_keys=True, default=str),
+                encoding="utf-8",
+            )
+            tmp.replace(path)
+            return path
+        except Exception:
+            logger.warning("could not write review snapshot", exc_info=True)
+            return None

--- a/agent/tasks/editorial_calendar.py
+++ b/agent/tasks/editorial_calendar.py
@@ -1,0 +1,149 @@
+"""Editorial calendar executor — turns due calendar items into content drafts.
+
+Hourly task that pulls due ``planned`` items from the structured editorial
+calendar (``scripts/campaigns/calendar.py`` → ``data/calendar/editorial.jsonl``)
+and runs each through the SAME generation path ContentPipelineTask uses
+(``_generate_draft`` + ``_save_drafts``), advancing status
+planned -> generating -> ready.
+
+Approval doctrine: this task produces DRAFTS only. Drafts land in the client
+outputs directory and flow through the normal quality-gate + human-approval
+pipeline. This task NEVER publishes or mutates a live channel, and it never
+sets an item's status to ``published``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from ..models import ScheduledTask
+from .base import BaseTask
+from .content_pipeline import ContentPipelineTask
+
+logger = logging.getLogger(__name__)
+
+# Matches ContentPipelineTask's 3-drafts-per-run cap.
+DEFAULT_MAX_ITEMS_PER_RUN = 3
+
+
+class EditorialCalendarTickTask(BaseTask):
+    """Hourly: generate drafts for due editorial calendar items."""
+
+    @property
+    def task_type(self) -> str:
+        return "editorial_calendar_tick"
+
+    @property
+    def description(self) -> str:
+        return "Generate drafts for due editorial calendar items (drafts only, never publishes)"
+
+    async def execute(self, task: ScheduledTask, **kwargs) -> Optional[Dict[str, Any]]:
+        try:
+            from scripts.campaigns import calendar as editorial_calendar
+        except Exception as e:
+            logger.warning("Editorial calendar store unavailable: %s", e)
+            return {"success": False, "error": f"calendar store unavailable: {e}"}
+
+        try:
+            due = editorial_calendar.due_items()
+        except Exception as e:
+            logger.exception("failed to read editorial calendar")
+            return {"success": False, "error": f"failed to read editorial calendar: {e}"}
+
+        if not due:
+            return {
+                "success": True,
+                "summary": "No editorial calendar items due",
+                "generated": 0,
+            }
+
+        extra = getattr(task.config, "extra", None) or {}
+        try:
+            max_items = int(extra.get("max_items", DEFAULT_MAX_ITEMS_PER_RUN))
+        except (TypeError, ValueError):
+            max_items = DEFAULT_MAX_ITEMS_PER_RUN
+
+        pipeline = ContentPipelineTask()
+        generated: List[Dict[str, Any]] = []
+        failures: List[str] = []
+
+        for item in due[:max_items]:
+            item_id = item.get("id", "?")
+            editorial_calendar.mark_status(item_id, "generating")
+            try:
+                client = self._resolve_client(task, item)
+                keyword = item.get("keyword") or ""
+                opportunity = {
+                    "type": item.get("format") or "blog",
+                    "topic": item.get("title", ""),
+                    "keywords": [keyword] if keyword else [],
+                    "priority": "high",
+                    "persona": item.get("persona"),
+                    "calendar_item_id": item_id,
+                }
+
+                # Same code path content_pipeline.py uses: draft + save only.
+                draft = await pipeline._generate_draft(client, opportunity)
+
+                if draft and "error" not in draft:
+                    client_id = client.get("id") or item.get("site", "")
+                    saved = pipeline._save_drafts(client_id, [draft])
+                    note = (
+                        f"draft saved: {saved[0]}; awaiting quality gate + human approval"
+                        if saved
+                        else "draft generated but not saved; awaiting quality gate + human approval"
+                    )
+                    editorial_calendar.mark_status(item_id, "ready", notes=note)
+                    generated.append({
+                        "id": item_id,
+                        "title": item.get("title"),
+                        "site": item.get("site"),
+                        "saved_paths": saved,
+                    })
+                else:
+                    err = (draft or {}).get("error", "generation returned no draft")
+                    # Revert to planned so the next tick retries; note the failure.
+                    editorial_calendar.mark_status(
+                        item_id, "planned", notes=f"generation failed: {err}"
+                    )
+                    failures.append(f"{item_id}: {err}")
+            except Exception as e:
+                logger.exception("editorial calendar item %s failed", item_id)
+                try:
+                    editorial_calendar.mark_status(
+                        item_id, "planned", notes=f"generation failed: {e}"
+                    )
+                except Exception:
+                    pass
+                failures.append(f"{item_id}: {e}")
+
+        return {
+            "success": not failures,
+            "summary": (
+                f"Editorial calendar: {len(generated)} draft(s) generated, "
+                f"{len(failures)} failure(s), {max(len(due) - max_items, 0)} deferred "
+                f"— drafts await quality gate + human approval (nothing published)"
+            ),
+            "generated": len(generated),
+            "items": generated,
+            "errors": failures,
+        }
+
+    def _resolve_client(self, task: ScheduledTask, item: Dict[str, Any]) -> Dict[str, Any]:
+        """Resolve the client/brand for an item: task.client, else item site.
+
+        Falls back to a minimal client dict so draft generation still works
+        when the site isn't a registered brand (the draft simply lacks brand
+        voice/previous-content context).
+        """
+        client_id = task.client or item.get("site") or ""
+        if client_id:
+            try:
+                from gateway.config import config
+                client = config.get_client(client_id)
+                if client:
+                    return client
+            except Exception:
+                logger.warning("Could not load client config for %s", client_id, exc_info=True)
+        return {"id": client_id or "unknown", "name": client_id or "unknown"}

--- a/agent/tasks/self_improvement.py
+++ b/agent/tasks/self_improvement.py
@@ -1,0 +1,345 @@
+"""Self-improvement loop task handlers.
+
+Wraps the scripts in ``scripts/self_improvement/`` so the agent scheduler
+runs the documented loop (docs/OPENCLAW_SETUP.md section 3) without external
+cron:
+
+- ``performance_check_30d``  — daily 02:00: 30-day GSC/GA4 pull, winner/loser
+  grading, pending-check reconciliation (memory/edge-cases.md EC-12)
+- ``pattern_extract_weekly`` — Mon 14:00: winner pattern mining + weekly
+  aggregation into ``what-works.md`` / ``weekly-patterns.md``
+- ``harness_defaults_update`` — Mon 14:30: statistically-significant defaults
+  written via the EC-11 safe-write path (safe_write.py validates + backs up)
+
+All handlers degrade gracefully: missing credentials (Google/Gemini) or a
+missing optional dependency is a DATA GAP reported in the result dict —
+never an exception that puts the scheduler into a crash/retry loop, and
+never a reason to grade content against empty analytics (memory/lessons.md
+2026-06-09: missing connectors are data gaps, never zeros).
+
+These handlers only read analytics and update local knowledge/policy files
+through their guarded write paths. They never publish or mutate a live
+channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..models import ScheduledTask
+from .base import BaseTask
+
+logger = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+PATTERN_EXTRACT_TIMEOUT = 120  # seconds per winner subprocess
+
+
+def _import_module(dotted: str) -> Tuple[Optional[Any], Optional[str]]:
+    """Import a self-improvement module, returning (module, error).
+
+    Import failures (e.g. ``google-genai`` not installed for
+    pattern_extract.py) are returned as strings, not raised — the caller
+    reports them as a data gap instead of crash-looping the scheduler.
+    """
+    try:
+        return importlib.import_module(dotted), None
+    except Exception as e:  # ImportError or import-time config side effects
+        logger.warning("Could not import %s: %s", dotted, e)
+        return None, str(e)
+
+
+class PerformanceCheck30dTask(BaseTask):
+    """Daily 30-day performance check (performance_check.py main flow)."""
+
+    @property
+    def task_type(self) -> str:
+        return "performance_check_30d"
+
+    @property
+    def description(self) -> str:
+        return "Run due 30-day GSC/GA4 performance checks and grade content"
+
+    async def execute(self, task: ScheduledTask, **kwargs) -> Optional[Dict[str, Any]]:
+        return await asyncio.to_thread(self._run)
+
+    def _run(self) -> Dict[str, Any]:
+        mod, err = _import_module("scripts.self_improvement.performance_check")
+        if mod is None:
+            return {
+                "success": False,
+                "error": f"performance_check unavailable: {err}",
+                "summary": "30-day check skipped — performance_check.py could not be loaded",
+            }
+
+        # Self-heal the schedule first (EC-12): pending_checks/<id>.json is the
+        # only schedule record, so rebuild missing files from the content log.
+        try:
+            reconciled = mod.reconcile_pending_checks()
+        except Exception as e:
+            logger.exception("pending-check reconciliation failed")
+            return {"success": False, "error": f"reconciliation failed: {e}"}
+
+        try:
+            checks = mod.get_pending_checks()
+        except Exception as e:
+            logger.exception("could not read pending checks")
+            return {
+                "success": False,
+                "error": f"could not read pending checks: {e}",
+                "reconciled": reconciled,
+            }
+
+        if not checks:
+            return {
+                "success": True,
+                "summary": f"No 30-day checks due ({reconciled} pending check(s) reconciled)",
+                "checked": 0,
+                "winners": 0,
+                "reconciled": reconciled,
+            }
+
+        # Credentials gate: without GSC/GA4 access every check would read as
+        # zero data and grade "underperformer". Missing data is a data gap —
+        # defer the checks instead of mis-grading them.
+        creds_path = os.environ.get("GOOGLE_CREDENTIALS_PATH", "")
+        if not creds_path or not os.path.exists(creds_path):
+            msg = (
+                f"GOOGLE_CREDENTIALS_PATH not configured — deferred "
+                f"{len(checks)} due 30-day check(s) rather than grading against "
+                f"empty analytics (data gap, not a zero)"
+            )
+            logger.warning(msg)
+            return {
+                "success": False,
+                "error": msg,
+                "summary": msg,
+                "data_gap": True,
+                "deferred": len(checks),
+                "reconciled": reconciled,
+            }
+
+        results: List[Dict[str, Any]] = []
+        errors: List[str] = []
+        for check_file, check in checks:
+            try:
+                results.append(mod.run_check(check_file, check))
+            except Exception as e:
+                logger.exception("30-day check failed for %s", check.get("id"))
+                errors.append(f"{check.get('id', '?')}: {e}")
+
+        winners = [r for r in results if r.get("evaluation", {}).get("is_winner")]
+
+        # Winners feed pattern extraction (same as performance_check.py main()).
+        # Subprocess keeps the optional google-genai dependency out of the
+        # agent process; a failure here is logged, never fatal.
+        for winner in winners:
+            url = winner.get("url", "")
+            try:
+                proc = subprocess.run(
+                    [sys.executable, "-m", "scripts.self_improvement.pattern_extract",
+                     "--url", url],
+                    cwd=str(_REPO_ROOT),
+                    capture_output=True,
+                    text=True,
+                    timeout=PATTERN_EXTRACT_TIMEOUT,
+                )
+                if proc.returncode != 0:
+                    errors.append(
+                        f"pattern_extract {url}: exit {proc.returncode} "
+                        f"{(proc.stderr or '')[:200]}"
+                    )
+            except Exception as e:
+                logger.warning("Pattern extraction failed for %s: %s", url, e)
+                errors.append(f"pattern_extract {url}: {e}")
+
+        return {
+            "success": not errors,
+            "summary": (
+                f"{len(results)}/{len(checks)} 30-day check(s) run, "
+                f"{len(winners)} winner(s), {reconciled} reconciled"
+            ),
+            "checked": len(results),
+            "winners": len(winners),
+            "reconciled": reconciled,
+            "errors": errors,
+        }
+
+
+class PatternExtractWeeklyTask(BaseTask):
+    """Weekly pattern mining: process unprocessed winners + aggregate patterns."""
+
+    @property
+    def task_type(self) -> str:
+        return "pattern_extract_weekly"
+
+    @property
+    def description(self) -> str:
+        return "Mine winner patterns into what-works.md and run weekly aggregation"
+
+    async def execute(self, task: ScheduledTask, **kwargs) -> Optional[Dict[str, Any]]:
+        return await asyncio.to_thread(self._run)
+
+    def _run(self) -> Dict[str, Any]:
+        mod, err = _import_module("scripts.self_improvement.pattern_extract")
+        if mod is None:
+            # google-genai (or config) unavailable — data gap, not a crash.
+            return {
+                "success": False,
+                "error": f"pattern_extract unavailable: {err}",
+                "summary": "Weekly pattern extraction skipped — dependency/config missing (data gap)",
+                "data_gap": True,
+            }
+
+        cfg = getattr(mod, "_CFG", None)
+        if cfg is not None and not getattr(cfg, "gemini_api_key", ""):
+            msg = "GEMINI_API_KEY not configured — weekly pattern extraction skipped (data gap)"
+            logger.warning(msg)
+            return {"success": False, "error": msg, "summary": msg, "data_gap": True}
+
+        errors: List[str] = []
+
+        # 1) Process unprocessed winners (default main() flow).
+        processed = 0
+        try:
+            entries = mod.load_log()
+            dirty = False
+            for entry in entries:
+                if mod.is_winner(entry) and not entry.get("patterns_extracted"):
+                    analysis = mod.analyze_winner(entry)
+                    mod.append_to_what_works(entry, analysis)
+                    entry["patterns_extracted"] = True
+                    processed += 1
+                    dirty = True
+            if dirty:
+                import json as _json
+                with open(mod.CONTENT_LOG, "w") as f:
+                    _json.dump(entries, f, indent=2)
+        except Exception as e:
+            # EC-13: pattern_extract's circuit breaker is in-memory; once it
+            # opens we get a fast RuntimeError here instead of hammering Gemini.
+            logger.exception("winner pattern extraction failed")
+            errors.append(f"winner extraction: {e}")
+
+        # 2) Weekly aggregation across all sites.
+        patterns_text = ""
+        try:
+            patterns_text = mod.run_weekly_aggregation("all")
+        except Exception as e:
+            logger.exception("weekly aggregation failed")
+            errors.append(f"weekly aggregation: {e}")
+
+        return {
+            "success": not errors,
+            "summary": (
+                f"{processed} winner(s) mined; weekly aggregation: "
+                f"{(patterns_text or 'skipped')[:300]}"
+            ),
+            "winners_processed": processed,
+            "patterns": patterns_text,
+            "errors": errors,
+        }
+
+
+class HarnessDefaultsUpdateTask(BaseTask):
+    """Weekly defaults update (harness_defaults_update.py main flow)."""
+
+    @property
+    def task_type(self) -> str:
+        return "harness_defaults_update"
+
+    @property
+    def description(self) -> str:
+        return "Update MARKETING.md/policy defaults when patterns reach significance"
+
+    async def execute(self, task: ScheduledTask, **kwargs) -> Optional[Dict[str, Any]]:
+        return await asyncio.to_thread(self._run)
+
+    def _run(self) -> Dict[str, Any]:
+        mod, err = _import_module("scripts.self_improvement.harness_defaults_update")
+        if mod is None:
+            return {
+                "success": False,
+                "error": f"harness_defaults_update unavailable: {err}",
+                "summary": "Defaults update skipped — harness_defaults_update.py could not be loaded",
+            }
+
+        try:
+            entries = mod.load_log()
+            patterns = mod.analyze_patterns(entries)
+        except Exception as e:
+            logger.exception("pattern analysis failed")
+            return {"success": False, "error": f"pattern analysis failed: {e}"}
+
+        if patterns.get("insufficient_data"):
+            n = patterns.get("n", 0)
+            required = patterns.get("required", 0)
+            return {
+                "success": True,
+                "summary": (
+                    f"Insufficient data ({n}/{required} measured entries) — "
+                    f"defaults unchanged (data gap, keep publishing)"
+                ),
+                "updated": 0,
+            }
+
+        # Writes below go through safe_write.py (EC-11): round-trip-validated
+        # atomic replaces with .bak backups; aborted writes leave originals.
+        try:
+            updates = mod.update_marketing_md(patterns)
+        except Exception as e:
+            logger.exception("MARKETING.md update failed")
+            return {"success": False, "error": f"MARKETING.md update failed: {e}"}
+
+        try:
+            policy_result = mod.update_policy_thresholds(patterns)
+        except Exception as e:
+            logger.exception("policy threshold update failed")
+            return {"success": False, "error": f"policy threshold update failed: {e}"}
+
+        policy_updates = policy_result.get("updates", [])
+        drift_alerts = policy_result.get("drift_alerts", [])
+        all_updates = list(updates) + list(policy_updates)
+
+        if drift_alerts:
+            try:
+                mod.post_drift_alert(drift_alerts)
+            except Exception:
+                logger.warning("drift alert notification failed", exc_info=True)
+
+        if all_updates:
+            try:
+                mod.save_defaults(patterns)
+            except Exception as e:
+                logger.exception("saving harness defaults failed")
+                return {
+                    "success": False,
+                    "error": f"saving defaults failed: {e}",
+                    "updates": all_updates,
+                    "drift_alerts": drift_alerts,
+                }
+            try:
+                mod.post_discord(all_updates, patterns)
+            except Exception:
+                logger.warning("defaults digest notification failed", exc_info=True)
+
+        summary_bits = [f"{len(all_updates)} default(s) updated"]
+        if drift_alerts:
+            summary_bits.append(f"{len(drift_alerts)} drift alert(s) — policy writes halted")
+        return {
+            "success": True,
+            "summary": "; ".join(summary_bits),
+            "updated": len(all_updates),
+            "updates": all_updates,
+            "drift_alerts": drift_alerts,
+        }

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -56,6 +56,18 @@ server:
 
 # Publishing — CMS integration for content pipeline output
 publishing:
+  # Master switch for auto-publish after gate + approval. Default OFF: the
+  # engine logs approved content as status=approved_unpublished (url: null)
+  # and a human publishes + backfills via content_log.mark_published().
+  # Env override: KAI_PUBLISH_ENABLED=1/0.
+  enabled: false
+  # Per-site routing — a site auto-publishes only when listed here.
+  # Extra keys (status, categories, tags, output_dir, ...) pass through to
+  # the publisher; status defaults to "draft" so nothing goes live unseen.
+  sites: {}
+  #  kaicalls:
+  #    platform: "wordpress"        # wordpress | ghost | webflow | markdown
+  #    status: "draft"
   default_platform: "wordpress"    # wordpress | ghost | webflow | markdown
   wordpress:
     url_env: "WP_URL"

--- a/content-report/SKILL.md
+++ b/content-report/SKILL.md
@@ -24,6 +24,15 @@ Example: `/content-report`
 
 ## The Skill
 
+### Step 0: Fold In Any Legacy Log
+
+The CANONICAL publish log is `data/content_log.json` (the learning loop — performance_check, pattern_extract, weekly_report — reads only this file). If a legacy `~/.kai-marketing/content-log.jsonl` still exists, merge it first so its winners reach the learning loop (idempotent; safe to re-run):
+
+```bash
+python3 -m scripts.content.migrate_legacy_log
+python3 -m scripts.self_improvement.performance_check --reconcile-only   # rebuild 30-day checks in data/pending_checks/
+```
+
 ### Step 1: Refresh Data
 
 Before the report, refresh the data sources you care about. Skip any step where you don't have the API key.
@@ -118,7 +127,9 @@ Based on the data:
 
 | Source | Where it lives | Refreshed by |
 |--------|---------------|--------------|
-| Publish log | `~/.kai-marketing/content-log.jsonl` | `/content-gate` passes it through on publish |
+| Publish log (canonical) | `data/content_log.json` | `/content-write` Step 6 / `scripts.content.content_log.log_entry` + `mark_published` |
+| 30-day pending checks | `data/pending_checks/{id}.json` | Auto-created by `content_log` when a real URL is set; rebuilt by `performance_check --reconcile-only` |
+| Legacy publish log | `~/.kai-marketing/content-log.jsonl` | Read-only — fold into the canonical log via `scripts.content.migrate_legacy_log` (Step 0) |
 | Platform metrics (Dev.to, LinkedIn) | `~/.kai-marketing/metrics/{id}.json` | `kai-tracker pull-devto` / `kai-tracker linkedin` |
 | AI citation events | `~/.kai-marketing/citations/{id}.jsonl` | `kai-tracker citations` (cron-compatible) |
 | Citation targets | `~/.kai-marketing/citations-targets.json` | `kai-tracker targets --id <id> --add-query '...'` |
@@ -143,7 +154,7 @@ If a key is missing, the corresponding check is skipped with a warning — the r
 
 ## Chain State
 
-**Reads from:** `~/.kai-marketing/content-log.jsonl`, `~/.kai-marketing/metrics/`, `~/.kai-marketing/citations/`
+**Reads from:** `data/content_log.json` (canonical publish log), `data/pending_checks/`, `~/.kai-marketing/metrics/`, `~/.kai-marketing/citations/` (platform/citation scratch)
 **Feeds into:** `/content-retro` (weekly pattern analysis, now including citation patterns)
 
 ## Scheduling

--- a/content-write/SKILL.md
+++ b/content-write/SKILL.md
@@ -103,14 +103,34 @@ If the gate **fails**:
 
 ### Step 6: Log to Content Chain
 
-After gate pass, append to `~/.kai-marketing/content-log.jsonl`:
-```json
-{"id": "{site}-{format}-{date}", "site": "{site}", "keyword": "{keyword}", "format": "{format}", "publish_date": "{date}", "four_us_score": {score}, "hook_type": "{hook_type}", "persona": "{persona}", "draft_path": "{draft_path}", "performance_30d": null}
+After gate pass, log to the CANONICAL content log (`data/content_log.json`) — this is the log the learning loop (performance_check, pattern_extract, weekly_report) actually reads. Do NOT append to `~/.kai-marketing/content-log.jsonl` (legacy; fold old entries in with `python3 -m scripts.content.migrate_legacy_log`) and do NOT write `~/.kai-marketing/pending/*.json` (orphaned — nothing reads them; canonical pending checks live in `data/pending_checks/` and are created automatically).
+
+The draft is not live yet, so log it WITHOUT a url (status becomes `approved_unpublished`; no 30-day check is scheduled until a real URL exists):
+
+```bash
+python3 - <<'PY'
+from scripts.content.content_log import log_entry, compute_content_hash
+
+body = open("{draft_path}").read()
+entry = log_entry(
+    url=None,                      # never fabricate a URL
+    keyword="{keyword}",
+    site="{site}",
+    format="{format}",
+    title="{title}",
+    four_us={score},
+    notes="hook_type={hook_type}; draft={draft_path}",
+    content_hash=compute_content_hash(body),
+    campaign_id={campaign_id_or_None},   # cmp-YYYYMMDD-<slug> if part of a campaign
+)
+print(entry["id"])
+PY
 ```
 
-Create a pending check file at `~/.kai-marketing/pending/{id}.json`:
-```json
-{"id": "{id}", "url": "", "check_after": "{date+30days}", "status": "pending"}
+When the piece actually goes live, backfill the REAL url — this flips status to `published` and schedules the 30-day check in `data/pending_checks/` automatically:
+
+```bash
+python3 -c "from scripts.content.content_log import mark_published; mark_published('{entry_id}', '{real_url}')"
 ```
 
 ## Error Handling
@@ -123,5 +143,5 @@ Create a pending check file at `~/.kai-marketing/pending/{id}.json`:
 ## Chain State
 
 **Reads from:** `~/.kai-marketing/briefs/{date}-{slug}.json`
-**Writes to:** `~/.kai-marketing/drafts/{date}-{slug}.md`, `~/.kai-marketing/content-log.jsonl`
-**Read by:** `/content-gate` (if user wants full gate proposal)
+**Writes to:** `~/.kai-marketing/drafts/{date}-{slug}.md` (scratch), `data/content_log.json` (canonical log; pending checks auto-created in `data/pending_checks/` once a real URL is set)
+**Read by:** `/content-gate` (if user wants full gate proposal), `/content-report`, the 30-day performance_check cron

--- a/gateway/jobs.py
+++ b/gateway/jobs.py
@@ -3,6 +3,7 @@
 import asyncio
 import gc
 import json
+import os
 import sqlite3
 import threading
 import uuid
@@ -14,6 +15,28 @@ from typing import Any, Callable, Dict, List, Optional
 from kai.runtime import get_default_runtime_store
 
 from .models import ArtifactType, JobInfo, JobStatus, RunSurface
+
+# Jobs/runs/artifacts must outlive the 30-day learning loop (the 30-day
+# performance check joins back to run/artifact ids), so retention defaults
+# to 45 days — NOT the old 7, which deleted lineage before it was graded.
+DEFAULT_JOB_RETENTION_DAYS = 45
+
+
+def get_job_retention_days() -> int:
+    """Job retention window in days (default 45).
+
+    Override with the KAI_JOB_RETENTION_DAYS env var. Invalid or
+    non-positive values fall back to the default.
+    """
+    raw = os.environ.get("KAI_JOB_RETENTION_DAYS", "").strip()
+    if raw:
+        try:
+            days = int(raw)
+            if days > 0:
+                return days
+        except ValueError:
+            pass
+    return DEFAULT_JOB_RETENTION_DAYS
 
 
 class JobQueue:
@@ -487,11 +510,23 @@ class JobQueue:
             )
         return artifacts
 
-    def cleanup_old_jobs(self, days: int = 7):
-        """Remove jobs older than N days."""
+    def cleanup_old_jobs(self, days: Optional[int] = None):
+        """Remove jobs/runs/artifacts older than the retention window.
+
+        Retention defaults to ``get_job_retention_days()`` (45 days,
+        KAI_JOB_RETENTION_DAYS to override). The configured retention is a
+        FLOOR: an explicit ``days`` argument may lengthen the window but
+        never shorten it below the configured value — legacy callers that
+        still pass ``days=7`` (pre-45-day default) must not delete lineage
+        the 30-day learning loop has yet to grade. To genuinely shorten
+        retention, set KAI_JOB_RETENTION_DAYS.
+        """
         from datetime import timedelta
 
-        cutoff = (datetime.utcnow() - timedelta(days=days)).isoformat()
+        retention = get_job_retention_days()
+        effective_days = retention if days is None else max(days, retention)
+
+        cutoff = (datetime.utcnow() - timedelta(days=effective_days)).isoformat()
 
         with sqlite3.connect(self.db_path) as conn:
             conn.execute("DELETE FROM jobs WHERE created_at < ?", (cutoff,))

--- a/harness/skill-contracts/campaign.yaml
+++ b/harness/skill-contracts/campaign.yaml
@@ -1,10 +1,25 @@
 skill: campaign
-version: 2.0
+version: 2.1
 harness: kai-harness
 
 description: >
   Multi-channel marketing campaign with coordinated assets across landing page,
   email sequence, social posts, and ads. Ensures cross-channel message consistency.
+
+# Campaign identity — the join key across every campaign store.
+# campaign_planner mints "cmp-YYYYMMDD-<slug>" and writes it into
+# manifest.json; with --save it also auto-creates the campaign_tracker row
+# and records a campaign_plan artifact in the RuntimeStore. Thread the same
+# id into engine.generate(campaign_id=...) so content_log entries and 30-day
+# pending checks roll up per campaign; editorial calendar items carry it too.
+identity:
+  campaign_id: cmp-YYYYMMDD-<slug>  # minted by scripts/campaigns/campaign_planner.py (mint_campaign_id)
+  stores:
+    - campaigns/<dir>/manifest.json            # planner output
+    - data/campaigns/campaigns.db              # campaign_tracker (campaign_id column)
+    - data/runtime/artifacts/                  # campaign_plan artifact (data.campaign_id)
+    - data/calendar/editorial.jsonl            # editorial calendar items (campaign_id field)
+    - data/content_log.json                    # content_log entries + data/pending_checks/*.json
 
 inputs:
   required:
@@ -15,8 +30,10 @@ inputs:
     - budget: number
     - timeline_weeks: int
     - product_id: string
+    - campaign_id: string  # reuse an existing id; minted when omitted
 
 outputs:
+  campaign_id: string  # cmp-YYYYMMDD-<slug> (also in manifest.json)
   landing_page_copy: markdown
   email_sequence: list  # 5 emails
   social_variants: list  # 3 per platform
@@ -36,5 +53,9 @@ hooks:
   post_write: run_quality_gate_per_asset
   on_fail: revise_failing_assets
   on_pass: post_campaign_for_approval
+  # content_log.log_entry(campaign_id=<campaign_id>) — url=None until a human
+  # actually publishes; mark_published() backfills the real URL.
   on_approve: save_campaign_bundle + content_log
+  # No longer prose-only: campaign_planner --save auto-runs
+  # campaign_tracker.create_campaign with the minted campaign_id.
   on_publish: create_campaign_tracker

--- a/harness/skills/kai-content-calendar/SKILL.md
+++ b/harness/skills/kai-content-calendar/SKILL.md
@@ -41,7 +41,7 @@ Pillar: [Broad Topic]
 └── Cluster: [Specific angle 3] — targets "[keyword]"
 ```
 
-This structure builds topical authority for SEO. Load `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\content-copywriting\qdp-qdh-qds-content-architecture.md` for the full architecture framework.
+This structure builds topical authority for SEO. Load `knowledge/frameworks/content-copywriting/qdp-qdh-qds-content-architecture.md` for the full architecture framework.
 
 ### Calendar Table
 
@@ -53,7 +53,7 @@ This structure builds topical authority for SEO. Load `E:\Dev2\kai-cmo-harness-w
 
 ### Persona Rotation
 
-Rotate across personas to avoid speaking to only one audience. Map each piece to one of the 8 personas from `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`.
+Rotate across personas to avoid speaking to only one audience. Map each piece to one of the 8 personas from `knowledge/personas/_persona-index.md`.
 
 ### Idea Eval and Kill List
 
@@ -93,7 +93,7 @@ Present the content map to the user. Confirm:
 
 ## Phase 3: Brief Generation
 
-For each piece on the calendar, generate a brief using the schema from `E:\Dev2\kai-cmo-harness-work\harness\brief-schema.md`.
+For each piece on the calendar, generate a brief using the schema from `harness/brief-schema.md`.
 
 Output briefs to `workspace/content-calendar/briefs/[week]-[slug].json`.
 
@@ -118,7 +118,7 @@ If the user wants content produced (not just planned), batch-produce using `/kai
 5. Run quality gates (Four U's >= 12/16 for blog, banned words, SEO lint)
 6. Max 2 retries on failure
 
-All paths relative to `E:\Dev2\kai-cmo-harness-work\`.
+All paths are relative to the repo root (the directory containing CLAUDE.md).
 
 ### Parallelization
 

--- a/harness/skills/kai-retro/SKILL.md
+++ b/harness/skills/kai-retro/SKILL.md
@@ -9,7 +9,7 @@ Run the Kai learning retrospective. This is how the harness gets smarter: raw fa
 
 - Monthly, or after any sprint that produced 5+ gated pieces
 - Whenever the same gate failure shows up twice in one session
-- When a 30-day performance check grades new losers
+- When a 30-day performance check grades new underperformers
 
 ## Step 1 — Mine the gate logs
 
@@ -19,13 +19,13 @@ python scripts/self_improvement/lesson_capture.py mine
 
 This groups recurring failure signatures from `data/learning/gate_runs.jsonl`. Append candidates with `--write`. If the log is empty, note it and move on — the gates only log when they run.
 
-## Step 2 — Diagnose losers
+## Step 2 — Diagnose underperformers
 
 ```bash
 python scripts/self_improvement/lesson_capture.py losers
 ```
 
-For each undiagnosed loser, read the piece and its `content_log.json` entry, write a one-line diagnosis (hook type, persona mismatch, seasonality, thin proof — name the cause, not the symptom), and add it to `memory/what-doesnt-work.md` under "Measured losers" with the piece id. Check seasonality and competitor moves before blaming the content (see `memory/edge-cases.md` EC-15).
+This lists pieces whose 30-day grade is `underperformer` (the grade vocabulary is `winner`/`average`/`underperformer`; older docs said "loser") with no diagnosis yet. For each one, read the piece and its `content_log.json` entry, write a one-line diagnosis (hook type, persona mismatch, seasonality, thin proof — name the cause, not the symptom), and add it to `memory/what-doesnt-work.md` under "Measured losers" with the piece id. Check seasonality and competitor moves before blaming the content (see `memory/edge-cases.md` EC-15).
 
 ## Step 3 — Triage every lesson
 
@@ -67,7 +67,7 @@ Output a retro summary:
 ## Kai Retro — [date]
 
 **Mined:** [N] recurring failure signatures ([gate]: [signature] ×[count], ...)
-**Losers diagnosed:** [N] ([id]: [one-line diagnosis], ...)
+**Underperformers diagnosed:** [N] ([id]: [one-line diagnosis], ...)
 **Promoted:** [lesson] → [enforcement target] (+ golden case [id])
 **Retired:** [lesson] — [reason]
 **Edge cases:** [new/closed entries]

--- a/harness/skills/kai-start/SKILL.md
+++ b/harness/skills/kai-start/SKILL.md
@@ -105,7 +105,29 @@ Use this structure:
 
 Fill in everything you can from auto-detection. Mark unknowns with `[TODO]` — the user can fill these in later. Every field should have SOMETHING, even if approximate.
 
-## Step 4: Recommend First Command
+## Step 4: Create the First Goal (goal loop)
+
+Ask ONE question: "What's the single marketing number you want to move in the next 90 days?" (e.g. organic clicks, published pieces, signups). Then register it so the weekly CMO review can measure pace and plan work against it:
+
+```bash
+python -m scripts.harness_cli goals add \
+  --brand <brand-id> \
+  --name "<goal name>" \
+  --kpi <kpi_name> \
+  --target <number> \
+  --current <today's number, or 0> \
+  --deadline <ISO date ~90 days out>
+```
+
+Notes:
+- KPIs the harness can refresh automatically from the content log: `content_published`, `content_winners`, `organic_clicks`, `organic_impressions`. Any other KPI works but needs manual updates via `goals update --current`.
+- Use the real current value if the user knows it; never invent one. Unknown today is `--current 0` plus a `[TODO]` note in MARKETING.md.
+- Check progress anytime with `python -m scripts.harness_cli goals list`.
+- The Monday CMO review (agent scheduler task `cmo_review`) refreshes goal values, flags behind-pace goals, and proposes task graphs — all resulting actions still require human approval before anything publishes.
+
+If the user doesn't want a goal yet, skip this step — everything else works without one.
+
+## Step 5: Recommend First Command
 
 Based on what you found, recommend ONE command:
 

--- a/kai/runtime/business_profile.py
+++ b/kai/runtime/business_profile.py
@@ -3,12 +3,28 @@
 Provides the structured business understanding that audit, scoring,
 and proposal layers consume. Archetype-aware with local-service as
 the first target.
+
+Also owns the durable profile overlay store: facts learned during a
+session (onboarding answers, enrichment) persist to
+``data/runtime/profile/<brand>.json`` and are deep-merged over
+config-derived values on every profile build, so learned state
+survives process restarts.
 """
 
 from __future__ import annotations
 
+import copy
+import json
+import os
+import re
+import threading
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from functools import lru_cache
+from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from scripts.harness_config import get_config
 
 from .models import KaiBrandProfile, SerializableModel
 
@@ -373,6 +389,168 @@ def _apply_defaults(target: dict, defaults: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Profile overlay store — durable, per-brand learned facts
+# ---------------------------------------------------------------------------
+#
+# Overlay file format (data/runtime/profile/<brand>.json):
+#   {
+#     "brand_id": "<brand>",
+#     "updated_at": "<ISO-8601 UTC>",
+#     "profile": { ...partial raw BusinessProfile dict... }
+#   }
+#
+# The "profile" payload uses the same raw-dict schema consumed by
+# build_business_profile(), so overlays merge cleanly over config-derived
+# values (overlay wins; nested dicts deep-merge; lists replace).
+
+_PROFILE_OVERLAY_SUBDIR = "profile"
+_OVERLAY_RESERVED_KEYS = {"brand_id", "updated_at"}
+_OVERLAY_LOCK = threading.RLock()
+
+
+def _sanitize_brand_id(brand_id: str) -> str:
+    """Make a brand id safe to use as a filename."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", str(brand_id).strip())
+    return cleaned.strip("-.") or "default"
+
+
+def profile_overlay_dir() -> Path:
+    """Directory holding per-brand profile overlays.
+
+    Follows the same KAI_RUNTIME_DIR convention as RuntimeStore, resolved
+    at call time so tests and long-running agents can repoint it.
+    """
+    cfg = get_config()
+    base = Path(os.environ.get("KAI_RUNTIME_DIR", str(cfg.data_dir / "runtime")))
+    return base / _PROFILE_OVERLAY_SUBDIR
+
+
+def profile_overlay_path(brand_id: str) -> Path:
+    """Path of the overlay file for a brand."""
+    return profile_overlay_dir() / f"{_sanitize_brand_id(brand_id)}.json"
+
+
+def deep_merge_profile(base: dict, updates: dict) -> dict:
+    """Deep-merge ``updates`` over ``base`` and return a new dict.
+
+    Nested dicts merge recursively; lists and scalars are replaced.
+    Neither input is mutated.
+    """
+    merged = dict(base)
+    for key, value in updates.items():
+        existing = merged.get(key)
+        if isinstance(value, dict) and isinstance(existing, dict):
+            merged[key] = deep_merge_profile(existing, value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+@lru_cache(maxsize=128)
+def _read_overlay_text(path_str: str) -> Optional[str]:
+    """Cached raw read of an overlay file (None when missing)."""
+    path = Path(path_str)
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def invalidate_profile_overlay_cache() -> None:
+    """Bust the in-process overlay read cache."""
+    _read_overlay_text.cache_clear()
+
+
+def _invalidate_workspace_profile_cache() -> None:
+    """Bust the lru-cached workspace profile so a session sees its own writes."""
+    try:
+        from .loader import load_workspace_profile
+        load_workspace_profile.cache_clear()
+    except Exception:  # pragma: no cover — cache bust must never fail a save
+        pass
+
+
+def load_profile_overlay_record(brand_id: str) -> Dict[str, Any]:
+    """Load the full overlay record (brand_id, updated_at, profile) for a brand.
+
+    Returns an empty dict when no overlay exists or the file is unreadable.
+    """
+    text = _read_overlay_text(str(profile_overlay_path(brand_id)))
+    if not text:
+        return {}
+    try:
+        record = json.loads(text)
+    except ValueError:
+        return {}
+    return record if isinstance(record, dict) else {}
+
+
+def load_profile_overlay(brand_id: str) -> Dict[str, Any]:
+    """Load the overlay profile payload for a brand (empty dict when absent)."""
+    payload = load_profile_overlay_record(brand_id).get("profile")
+    return payload if isinstance(payload, dict) else {}
+
+
+def save_profile_overlay(brand_id: str, updates: Dict[str, Any]) -> Dict[str, Any]:
+    """Deep-merge ``updates`` into the brand's stored overlay and persist it.
+
+    Nested dicts merge; lists replace. Stamps ``updated_at`` (UTC ISO-8601),
+    writes atomically, and invalidates the in-process caches so the current
+    session sees its own writes. Returns the persisted record.
+    """
+    if not brand_id or not str(brand_id).strip():
+        raise ValueError("brand_id is required")
+    if not isinstance(updates, dict):
+        raise TypeError(f"updates must be a dict, got {type(updates)!r}")
+
+    payload = {k: v for k, v in updates.items() if k not in _OVERLAY_RESERVED_KEYS}
+
+    with _OVERLAY_LOCK:
+        existing = load_profile_overlay(brand_id)
+        record = {
+            "brand_id": str(brand_id),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "profile": deep_merge_profile(existing, payload),
+        }
+        path = profile_overlay_path(brand_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        tmp_path.write_text(
+            json.dumps(record, indent=2, sort_keys=True, default=str),
+            encoding="utf-8",
+        )
+        tmp_path.replace(path)
+        invalidate_profile_overlay_cache()
+
+    _invalidate_workspace_profile_cache()
+    return record
+
+
+def clear_profile_overlay(brand_id: str) -> bool:
+    """Delete a brand's overlay file. Returns True if one existed."""
+    with _OVERLAY_LOCK:
+        path = profile_overlay_path(brand_id)
+        existed = path.exists()
+        if existed:
+            path.unlink()
+        invalidate_profile_overlay_cache()
+    if existed:
+        _invalidate_workspace_profile_cache()
+    return existed
+
+
+def _resolve_overlay_brand_id(raw: Dict[str, Any], brand: Optional[KaiBrandProfile]) -> Optional[str]:
+    """Mirror build_business_profile's brand_id derivation for overlay lookup."""
+    brand_id = raw.get("brand_id") or (brand.id if brand else None)
+    if brand_id:
+        return str(brand_id)
+    identity_raw = raw.get("identity") or {}
+    name = identity_raw.get("name") or (brand.name if brand else raw.get("name", ""))
+    if name:
+        return str(name).lower().replace(" ", "-")
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Loader / builder
 # ---------------------------------------------------------------------------
 
@@ -541,6 +719,7 @@ def build_business_profile(
     *,
     brand: Optional[KaiBrandProfile] = None,
     apply_archetype_defaults: bool = True,
+    apply_overlay: bool = True,
 ) -> BusinessProfile:
     """Build a BusinessProfile from a raw config dict.
 
@@ -548,9 +727,23 @@ def build_business_profile(
     active_channels, persona_defaults, archetype) are used as fallbacks
     for any fields not explicitly set in raw.
 
+    When apply_overlay is True (the default), any persisted profile
+    overlay for the brand (data/runtime/profile/<brand>.json) is
+    deep-merged over the config-derived values first — overlay wins,
+    nested dicts merge, lists replace.
+
     When apply_archetype_defaults is True, archetype-specific defaults
-    (e.g. LOCAL_SERVICE_DEFAULTS) are merged before building.
+    (e.g. LOCAL_SERVICE_DEFAULTS) are merged before building. Defaults
+    never overwrite config or overlay values — they only fill gaps.
     """
+    # Merge any persisted overlay over config-derived values
+    if apply_overlay:
+        overlay_brand_id = _resolve_overlay_brand_id(raw, brand)
+        if overlay_brand_id:
+            overlay = load_profile_overlay(overlay_brand_id)
+            if overlay:
+                raw = deep_merge_profile(dict(raw), overlay)
+
     # Determine archetype
     archetype = raw.get("archetype")
     if not archetype and brand:
@@ -605,14 +798,22 @@ def build_business_profile(
 def build_business_profile_from_brand(
     brand: KaiBrandProfile,
     overrides: Optional[Dict[str, Any]] = None,
+    *,
+    apply_overlay: bool = True,
 ) -> BusinessProfile:
     """Convenience: build a BusinessProfile primarily from a KaiBrandProfile.
 
     Any overrides dict is merged on top (useful for enrichment from
-    a dedicated profile YAML or operator input).
+    a dedicated profile YAML or operator input). Persisted profile
+    overlays merge over both unless apply_overlay is False.
     """
     raw = overrides or {}
-    return build_business_profile(raw, brand=brand, apply_archetype_defaults=True)
+    return build_business_profile(
+        raw,
+        brand=brand,
+        apply_archetype_defaults=True,
+        apply_overlay=apply_overlay,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -748,8 +949,11 @@ LOCAL_SERVICE_FIXTURE: Dict[str, Any] = {
 
 
 def load_local_service_fixture() -> BusinessProfile:
-    """Load the canonical local-service example profile."""
-    return build_business_profile(LOCAL_SERVICE_FIXTURE)
+    """Load the canonical local-service example profile.
+
+    Overlays are skipped so the fixture stays deterministic for demos/tests.
+    """
+    return build_business_profile(LOCAL_SERVICE_FIXTURE, apply_overlay=False)
 
 
 ANDON_WINDOW_CLEANING_FIXTURE: Dict[str, Any] = {
@@ -928,5 +1132,8 @@ ANDON_WINDOW_CLEANING_FIXTURE: Dict[str, Any] = {
 
 
 def load_andon_window_cleaning_fixture() -> BusinessProfile:
-    """Load the canonical Andon Window Cleaning business profile fixture."""
-    return build_business_profile(ANDON_WINDOW_CLEANING_FIXTURE)
+    """Load the canonical Andon Window Cleaning business profile fixture.
+
+    Overlays are skipped so the fixture stays deterministic for demos/tests.
+    """
+    return build_business_profile(ANDON_WINDOW_CLEANING_FIXTURE, apply_overlay=False)

--- a/kai/runtime/goals.py
+++ b/kai/runtime/goals.py
@@ -143,3 +143,120 @@ def get_default_goal_registry() -> GoalRegistry:
         if _global_registry is None:
             _global_registry = GoalRegistry.default()
         return _global_registry
+
+
+# ── Pace helpers (pure functions — no I/O) ──────────────────────────────────
+# Used by the goals CLI (scripts/harness_cli.py) and the weekly CMO review
+# (agent/tasks/cmo_review.py) to decide whether a goal is behind pace.
+
+# A goal is "on pace" while its progress fraction is within this slack of the
+# elapsed-time fraction. Keeps the review from replanning on tiny wobbles.
+PACE_TOLERANCE = 0.05
+
+
+def parse_goal_datetime(value: Any) -> Optional[datetime]:
+    """Parse a goal timestamp/deadline into an aware UTC datetime, or None.
+
+    Tolerates ISO-8601 strings (date-only like ``2026-12-31`` included, with
+    or without a trailing ``Z``), datetime objects, and blank/garbage values.
+    Naive datetimes are treated as UTC.
+    """
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value or not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def is_goal_achieved(goal: KaiGoal) -> bool:
+    """Return True when current_value has met the target in the goal's direction."""
+    if goal.target_direction == "decrease":
+        return goal.current_value <= goal.target_value
+    return goal.current_value >= goal.target_value
+
+
+def compute_goal_pace(goal: KaiGoal, now: Optional[datetime] = None) -> Dict[str, Any]:
+    """Compute pace-vs-deadline for a goal.
+
+    Returns a dict with:
+      - ``achieved``          — target already met (direction-aware)
+      - ``overdue``           — deadline passed without achieving
+      - ``time_fraction``     — elapsed/(created→deadline), clamped 0..1, or
+                                None when the deadline is missing/unparsable
+      - ``progress_fraction`` — (current-baseline)/(target-baseline) clamped
+                                0..1, or None when no baseline is derivable
+      - ``expected_value``    — linear on-pace value for today, or None
+      - ``behind_pace``       — True when progress trails elapsed time by more
+                                than PACE_TOLERANCE
+
+    Baseline comes from ``goal.metadata["baseline_value"]`` (the goals CLI and
+    CMO review both record it); "increase" goals fall back to a 0.0 baseline.
+    When pace cannot be measured (no deadline, or a "decrease" goal with no
+    baseline), an unachieved active goal is treated as behind pace so the goal
+    loop keeps pursuing it — downstream plans still flow through ActionStore
+    approval, so this never mutates a live channel by itself.
+    """
+    if now is None:
+        now = datetime.now(timezone.utc)
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+
+    achieved = is_goal_achieved(goal)
+    deadline = parse_goal_datetime(goal.deadline)
+    created = parse_goal_datetime(goal.created_at)
+    overdue = bool(deadline is not None and now >= deadline and not achieved)
+
+    time_fraction: Optional[float] = None
+    if deadline is not None:
+        if created is not None and deadline > created:
+            span_s = (deadline - created).total_seconds()
+            elapsed_s = (now - created).total_seconds()
+            time_fraction = min(max(elapsed_s / span_s, 0.0), 1.0)
+        elif now >= deadline:
+            time_fraction = 1.0
+
+    baseline: Optional[float] = None
+    raw_baseline = (goal.metadata or {}).get("baseline_value")
+    if raw_baseline is not None:
+        try:
+            baseline = float(raw_baseline)
+        except (TypeError, ValueError):
+            baseline = None
+    if baseline is None and goal.target_direction == "increase":
+        baseline = 0.0
+
+    progress_fraction: Optional[float] = None
+    expected_value: Optional[float] = None
+    if baseline is not None:
+        span = goal.target_value - baseline
+        if abs(span) > 1e-12:
+            progress_fraction = min(max((goal.current_value - baseline) / span, 0.0), 1.0)
+            if time_fraction is not None:
+                expected_value = baseline + span * time_fraction
+
+    if achieved:
+        behind_pace = False
+    elif overdue:
+        behind_pace = True
+    elif time_fraction is not None and progress_fraction is not None:
+        behind_pace = (progress_fraction + PACE_TOLERANCE) < time_fraction
+    else:
+        # Pace unmeasurable (no deadline / no baseline): an active, unmet goal
+        # still needs pursuit — conservative for the goal, safe for channels.
+        behind_pace = True
+
+    return {
+        "achieved": achieved,
+        "overdue": overdue,
+        "time_fraction": time_fraction,
+        "progress_fraction": progress_fraction,
+        "expected_value": expected_value,
+        "behind_pace": behind_pace,
+    }

--- a/kai/runtime/models.py
+++ b/kai/runtime/models.py
@@ -228,7 +228,11 @@ class TaskGraph(SerializableModel):
     graph_id: str
     goal_id: Optional[str]
     brand_id: str
-    status: Literal["pending", "running", "completed", "failed"] = "pending"
+    # needs_replan: a node failed and the weekly CMO review should
+    # re-decompose the remaining work; replanned: a successor graph exists.
+    status: Literal[
+        "pending", "running", "completed", "failed", "needs_replan", "replanned"
+    ] = "pending"
     nodes: Dict[str, TaskNode] = field(default_factory=dict)
     edges: List[List[str]] = field(default_factory=list)  # List of [from_node, to_node]
     created_at: str = ""

--- a/kai/runtime/onboarding.py
+++ b/kai/runtime/onboarding.py
@@ -13,9 +13,110 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from .business_profile import deep_merge_profile, save_profile_overlay
 from .models import SerializableModel
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Durable-fact extraction — onboarding answers → profile overlay updates
+# ---------------------------------------------------------------------------
+
+# Raw BusinessProfile sections that may be passed through whole.
+_PROFILE_SECTION_KEYS = {
+    "identity", "offers", "geography", "personas", "trust",
+    "goals", "channels", "constraints", "metadata",
+}
+
+# Flat answer keys (kai/packaging/setup.py conventions) → (section, field).
+_FLAT_ANSWER_MAP = {
+    "business_name": ("identity", "name"),
+    "name": ("identity", "name"),
+    "website_url": ("identity", "url"),
+    "url": ("identity", "url"),
+    "business_description": ("identity", "description"),
+    "tagline": ("identity", "tagline"),
+    "year_founded": ("identity", "year_founded"),
+    "employee_count_range": ("identity", "employee_count_range"),
+    "primary_service": ("offers", "primary_offer"),
+    "primary_offer": ("offers", "primary_offer"),
+    "pricing_model": ("offers", "pricing_model"),
+    "average_deal_value": ("offers", "average_deal_value"),
+    "phone_number": ("channels", "phone_number"),
+    "primary_lead_source": ("channels", "primary_lead_source"),
+    "primary_kpi": ("goals", "primary_kpi"),
+    "monthly_budget_range": ("goals", "monthly_budget_range"),
+    "budget_ceiling": ("constraints", "budget_ceiling"),
+    "icp_description": ("personas", "icp_description"),
+    "years_in_business": ("trust", "years_in_business"),
+    "review_count": ("trust", "review_count"),
+    "review_average": ("trust", "review_average"),
+}
+
+# Flat geography answers land under geography.primary_location.
+_GEO_PRIMARY_MAP = {
+    "primary_city": "city",
+    "state_province": "state",
+    "service_radius_miles": "radius_miles",
+}
+
+# Session-scoped keys that never belong in the durable overlay.
+_TRANSIENT_ANSWER_KEYS = {
+    "brand_id", "onboarding_stage", "connections_pending",
+    "connections_complete", "known_client", "connected", "updated_at",
+}
+
+
+def _normalize_archetype_id(value: Any) -> str:
+    """Normalize archetype ids ('local_service' → 'local-service')."""
+    return str(value).strip().lower().replace("_", "-")
+
+
+def extract_profile_facts(answers: Dict[str, Any]) -> Dict[str, Any]:
+    """Map onboarding answers to a raw BusinessProfile overlay update.
+
+    Accepts both flat answer keys (business_name, primary_city, ...) and
+    whole profile sections (identity, offers, ...). Unknown scalar answers
+    are preserved under metadata so durable facts never evaporate; keys
+    starting with '_' and session-transient keys are dropped.
+    """
+    updates: Dict[str, Any] = {}
+    metadata: Dict[str, Any] = {}
+
+    for key, value in (answers or {}).items():
+        if key.startswith("_") or key in _TRANSIENT_ANSWER_KEYS:
+            continue
+        if value is None or (isinstance(value, str) and not value.strip()):
+            continue
+
+        if key == "archetype":
+            updates["archetype"] = _normalize_archetype_id(value)
+        elif key == "archetype_overlays" and isinstance(value, list):
+            updates["archetype_overlays"] = list(value)
+        elif key in _PROFILE_SECTION_KEYS and isinstance(value, dict):
+            updates[key] = deep_merge_profile(updates.get(key) or {}, value)
+        elif key in _FLAT_ANSWER_MAP:
+            section, field_name = _FLAT_ANSWER_MAP[key]
+            updates.setdefault(section, {})[field_name] = value
+        elif key in _GEO_PRIMARY_MAP:
+            geo = updates.setdefault("geography", {})
+            geo.setdefault("primary_location", {})[_GEO_PRIMARY_MAP[key]] = value
+        elif key == "service_list":
+            primary = str((answers or {}).get("primary_service", "")).strip().lower()
+            items = [s.strip() for s in str(value).split(",") if s.strip()]
+            if items:
+                updates.setdefault("offers", {})["offer_list"] = [
+                    {"name": item, "is_primary": item.lower() == primary}
+                    for item in items
+                ]
+        elif isinstance(value, (str, int, float, bool)):
+            metadata[key] = value
+
+    if metadata:
+        updates["metadata"] = deep_merge_profile(updates.get("metadata") or {}, metadata)
+
+    return updates
 
 
 # ---------------------------------------------------------------------------
@@ -195,9 +296,15 @@ class OnboardingFlow:
         name: str,
         archetype: str = "local_service",
         url: Optional[str] = None,
+        persist_profile: bool = True,
     ) -> Dict[str, Any]:
-        """Create the minimal brand record to start onboarding."""
-        return {
+        """Create the minimal brand record to start onboarding.
+
+        By default the durable identity facts (name, url, archetype) are
+        persisted to the brand's profile overlay so they survive the
+        session instead of evaporating with the process.
+        """
+        stub = {
             "brand_id": brand_id,
             "name": name,
             "archetype": archetype,
@@ -205,6 +312,47 @@ class OnboardingFlow:
             "onboarding_stage": "profile",
             "connections_pending": [],
             "connections_complete": [],
+        }
+        if persist_profile:
+            identity: Dict[str, Any] = {"name": name}
+            if url:
+                identity["url"] = url
+            save_profile_overlay(brand_id, {
+                "archetype": _normalize_archetype_id(archetype),
+                "identity": identity,
+            })
+        return stub
+
+    # ------------------------------------------------------------------
+    # Step 2: Persist profile answers (durable business facts)
+    # ------------------------------------------------------------------
+
+    def record_profile_answers(
+        self,
+        brand_id: str,
+        answers: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Persist durable business facts from onboarding answers.
+
+        Answers are mapped to the raw BusinessProfile schema via
+        ``extract_profile_facts`` and deep-merged into the brand's
+        profile overlay (data/runtime/profile/<brand>.json), so
+        subsequent ``build_business_profile`` calls — in this session
+        and future ones — reflect them.
+        """
+        updates = extract_profile_facts(answers)
+        if not updates:
+            return {
+                "brand_id": brand_id,
+                "persisted": False,
+                "updates": {},
+            }
+        record = save_profile_overlay(brand_id, updates)
+        return {
+            "brand_id": brand_id,
+            "persisted": True,
+            "updates": updates,
+            "updated_at": record.get("updated_at"),
         }
 
     # ------------------------------------------------------------------

--- a/memory/what-doesnt-work.md
+++ b/memory/what-doesnt-work.md
@@ -1,6 +1,6 @@
 # What Doesn't Work
 
-Anti-pattern log — the failure-side complement to `knowledge/playbooks/what-works.md`. Published losers, rejected drafts, and approaches that measured badly land here so they aren't retried.
+Anti-pattern log — the failure-side complement to `knowledge/playbooks/what-works.md`. Published underperformers, rejected drafts, and approaches that measured badly land here so they aren't retried.
 
 ## Format
 
@@ -9,9 +9,9 @@ Anti-pattern log — the failure-side complement to `knowledge/playbooks/what-wo
 ```
 
 Rules:
-- Only add entries with evidence: a 30-day "loser" grade, a human rejection with a stated reason, or 2+ gate failures with the same diagnosis.
+- Only add entries with evidence: a 30-day "underperformer" grade, a human rejection with a stated reason, or 2+ gate failures with the same diagnosis.
 - Generalize the anti-pattern, keep the evidence specific.
-- During `/kai-retro`, pull new losers from `content_log.json` (`performance_30d.grade == "loser"`) and add a diagnosis for each.
+- During `/kai-retro`, pull new underperformers from `content_log.json` (`performance_30d.grade == "underperformer"` — the grade vocabulary is winner/average/underperformer; "loser" is a retired legacy alias) and add a diagnosis for each. `python scripts/self_improvement/lesson_capture.py losers` surfaces the undiagnosed ones.
 - An anti-pattern confirmed 3+ times should graduate: add a contract constraint, checklist line, or lint rule, then mark it `(promoted)` here.
 
 ## Structural anti-patterns (seeded from harness doctrine)

--- a/scripts/analytics/performance_dashboard.py
+++ b/scripts/analytics/performance_dashboard.py
@@ -25,6 +25,8 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(_ROOT))
 
+from scripts.self_improvement.grades import get_grade, get_published_at  # noqa: E402
+
 KAI_DIR = Path.home() / ".kai-marketing"
 SNAPSHOT_DIR = KAI_DIR / "analytics" / "snapshots"
 CONTENT_LOG = KAI_DIR / "content-log.jsonl"
@@ -74,7 +76,7 @@ def weekly_summary() -> dict:
     # This week's content
     this_week = []
     for e in entries:
-        pub_date = e.get("publish_date", "")
+        pub_date = get_published_at(e) or ""
         if pub_date:
             try:
                 pd = datetime.fromisoformat(pub_date).replace(tzinfo=timezone.utc)
@@ -83,12 +85,12 @@ def weekly_summary() -> dict:
             except (ValueError, TypeError):
                 pass
 
-    # Performance breakdown
-    graded = [e for e in entries if e.get("performance_30d")]
-    winners = [e for e in graded if e["performance_30d"] == "winner"]
-    average = [e for e in graded if e["performance_30d"] == "average"]
-    under = [e for e in graded if e["performance_30d"] == "underperformer"]
-    pending = [e for e in entries if not e.get("performance_30d")]
+    # Performance breakdown (performance_30d may be a dict or legacy string)
+    graded = [e for e in entries if get_grade(e)]
+    winners = [e for e in graded if get_grade(e) == "winner"]
+    average = [e for e in graded if get_grade(e) == "average"]
+    under = [e for e in graded if get_grade(e) == "underperformer"]
+    pending = [e for e in entries if not get_grade(e)]
 
     # Quality scores
     quality_entries = _load_jsonl(QUALITY_LOG)
@@ -127,7 +129,7 @@ def trend_analysis(weeks: int = 12) -> dict:
     weekly_data = defaultdict(lambda: {"published": 0, "winners": 0, "graded": 0})
 
     for e in entries:
-        pub_date = e.get("publish_date", "")
+        pub_date = get_published_at(e) or ""
         if not pub_date:
             continue
         try:
@@ -137,9 +139,10 @@ def trend_analysis(weeks: int = 12) -> dict:
 
         week_key = pd.strftime("%Y-W%U")
         weekly_data[week_key]["published"] += 1
-        if e.get("performance_30d"):
+        grade = get_grade(e)
+        if grade:
             weekly_data[week_key]["graded"] += 1
-            if e["performance_30d"] == "winner":
+            if grade == "winner":
                 weekly_data[week_key]["winners"] += 1
 
     # Sort by week and take last N

--- a/scripts/campaigns/calendar.py
+++ b/scripts/campaigns/calendar.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""
+Kai CMO Harness — Editorial Calendar Store
+==========================================
+First-class structured editorial calendar: "publish X on date D" as data the
+scheduler can execute, instead of prose markdown nothing consumes.
+
+Storage: one JSON object per line in ``<calendar_dir>/editorial.jsonl``.
+The directory comes from ``scripts.harness_config.get_calendar_dir()``
+(default ``data/calendar``, override with ``KAI_CALENDAR_DIR``).
+
+Item schema:
+  {
+    "id": "cal-1a2b3c4d",
+    "campaign_id": null,          # optional link to a tracked campaign
+    "site": "kaicalls",           # brand/client key
+    "title": "...",               # working title / topic
+    "format": "blog",             # blog | linkedin-article | email | ...
+    "keyword": "...",             # target keyword ("" if none)
+    "persona": null,              # one of the 8 marketing personas, or null
+    "publish_at": "2026-07-10T14:00:00+00:00",  # ISO 8601, stored UTC
+    "status": "planned",          # planned|generating|ready|published|skipped
+    "notes": "",
+    "created_at": "...",
+    "updated_at": "..."
+  }
+
+Status doctrine: this module only tracks state. The scheduler's
+``editorial_calendar_tick`` task moves planned -> generating -> ready by
+producing DRAFTS that flow through the normal quality-gate + human-approval
+pipeline. Nothing in this repo sets ``published`` without an approved,
+human-in-the-loop publish.
+
+Usage:
+  python scripts/campaigns/calendar.py --add --site kaicalls --title "..." \
+      --publish-at 2026-07-10T14:00Z --format blog --keyword "ai receptionist"
+  python scripts/campaigns/calendar.py --list [--status planned] [--site kaicalls]
+  python scripts/campaigns/calendar.py --due
+  python scripts/campaigns/calendar.py --mark cal-1a2b3c4d --status skipped
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.harness_config import get_calendar_dir
+
+VALID_STATUSES = ("planned", "generating", "ready", "published", "skipped")
+
+CALENDAR_FILENAME = "editorial.jsonl"
+
+
+def calendar_path() -> Path:
+    """Full path to the editorial calendar JSONL file."""
+    return get_calendar_dir() / CALENDAR_FILENAME
+
+
+# ── Time helpers (timezone-safe: naive timestamps are treated as UTC) ────────
+
+
+def _parse_utc(value: Any) -> datetime:
+    """Parse an ISO 8601 timestamp into an aware UTC datetime.
+
+    Accepts a trailing 'Z', an explicit offset, or a naive timestamp
+    (interpreted as UTC). Raises ValueError on anything unparseable.
+    """
+    if isinstance(value, datetime):
+        dt = value
+    elif isinstance(value, str) and value.strip():
+        dt = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    else:
+        raise ValueError(f"publish_at must be an ISO 8601 timestamp, got: {value!r}")
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+# ── Store primitives ─────────────────────────────────────────────────────────
+
+
+def _load_items() -> List[Dict[str, Any]]:
+    path = calendar_path()
+    if not path.exists():
+        return []
+    items: List[Dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue  # skip corrupt lines rather than losing the whole store
+        if isinstance(item, dict):
+            items.append(item)
+    return items
+
+
+def _write_items(items: List[Dict[str, Any]]):
+    """Atomically rewrite the whole store (tmp file + os.replace)."""
+    path = calendar_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = "".join(json.dumps(item, ensure_ascii=False) + "\n" for item in items)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def add_item(
+    site: str,
+    title: str,
+    publish_at: Any,
+    format: str = "blog",
+    keyword: str = "",
+    persona: Optional[str] = None,
+    campaign_id: Optional[str] = None,
+    notes: str = "",
+    status: str = "planned",
+    item_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Add an item to the editorial calendar and return it.
+
+    ``publish_at`` accepts an ISO 8601 string or datetime; it is normalized
+    to UTC before storage. Raises ValueError on a bad timestamp or status.
+    """
+    if not site:
+        raise ValueError("site is required")
+    if not title:
+        raise ValueError("title is required")
+    if status not in VALID_STATUSES:
+        raise ValueError(f"Invalid status {status!r}; must be one of {VALID_STATUSES}")
+
+    now_iso = _now_utc().isoformat()
+    item = {
+        "id": item_id or f"cal-{uuid.uuid4().hex[:8]}",
+        "campaign_id": campaign_id,
+        "site": site,
+        "title": title,
+        "format": format or "blog",
+        "keyword": keyword or "",
+        "persona": persona,
+        "publish_at": _parse_utc(publish_at).isoformat(),
+        "status": status,
+        "notes": notes or "",
+        "created_at": now_iso,
+        "updated_at": now_iso,
+    }
+
+    path = calendar_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as handle:
+        handle.write(json.dumps(item, ensure_ascii=False) + "\n")
+    return item
+
+
+def list_items(
+    status: Optional[str] = None,
+    site: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    """List calendar items, optionally filtered by status and/or site.
+
+    Sorted by publish_at ascending.
+    """
+    items = _load_items()
+    if status is not None:
+        items = [i for i in items if i.get("status") == status]
+    if site is not None:
+        items = [i for i in items if i.get("site") == site]
+
+    def _sort_key(item: Dict[str, Any]) -> datetime:
+        try:
+            return _parse_utc(item.get("publish_at"))
+        except ValueError:
+            return datetime.max.replace(tzinfo=timezone.utc)
+
+    return sorted(items, key=_sort_key)
+
+
+def get_item(item_id: str) -> Optional[Dict[str, Any]]:
+    """Return the item with the given id, or None."""
+    for item in _load_items():
+        if item.get("id") == item_id:
+            return item
+    return None
+
+
+def due_items(now: Optional[datetime] = None) -> List[Dict[str, Any]]:
+    """Return planned items whose publish_at is at or before ``now``.
+
+    ``now`` defaults to the current UTC time; a naive ``now`` is treated
+    as UTC. Sorted oldest-due first so backlogs drain in order.
+    """
+    if now is None:
+        now = _now_utc()
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    else:
+        now = now.astimezone(timezone.utc)
+
+    due: List[Dict[str, Any]] = []
+    for item in list_items(status="planned"):
+        try:
+            when = _parse_utc(item.get("publish_at"))
+        except ValueError:
+            continue  # unparseable schedule — leave it alone, never guess
+        if when <= now:
+            due.append(item)
+    return due
+
+
+def mark_status(
+    item_id: str,
+    status: str,
+    notes: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Update an item's status (and optionally notes). Returns the updated item.
+
+    Returns None when the id is unknown. Raises ValueError on a bad status.
+    """
+    if status not in VALID_STATUSES:
+        raise ValueError(f"Invalid status {status!r}; must be one of {VALID_STATUSES}")
+
+    items = _load_items()
+    updated: Optional[Dict[str, Any]] = None
+    for item in items:
+        if item.get("id") == item_id:
+            item["status"] = status
+            if notes is not None:
+                item["notes"] = notes
+            item["updated_at"] = _now_utc().isoformat()
+            updated = item
+            break
+
+    if updated is None:
+        return None
+
+    _write_items(items)
+    return updated
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Editorial calendar store")
+    parser.add_argument("--add", action="store_true", help="Add a calendar item")
+    parser.add_argument("--list", action="store_true", help="List calendar items")
+    parser.add_argument("--due", action="store_true", help="List due planned items")
+    parser.add_argument("--mark", metavar="ITEM_ID", help="Update an item's status")
+    parser.add_argument("--site", help="Site/brand key")
+    parser.add_argument("--title", help="Working title / topic")
+    parser.add_argument("--publish-at", help="ISO 8601 publish time (UTC assumed if naive)")
+    parser.add_argument("--format", default="blog", help="Content format (default: blog)")
+    parser.add_argument("--keyword", default="", help="Target keyword")
+    parser.add_argument("--persona", help="Marketing persona")
+    parser.add_argument("--campaign-id", help="Linked campaign id")
+    parser.add_argument("--status", help="Status filter (--list) or new status (--mark)")
+    parser.add_argument("--notes", help="Notes to attach")
+    args = parser.parse_args()
+
+    if args.add:
+        if not (args.site and args.title and args.publish_at):
+            parser.error("--add requires --site, --title, and --publish-at")
+        item = add_item(
+            site=args.site,
+            title=args.title,
+            publish_at=args.publish_at,
+            format=args.format,
+            keyword=args.keyword,
+            persona=args.persona,
+            campaign_id=args.campaign_id,
+            notes=args.notes or "",
+        )
+        print(json.dumps(item, indent=2))
+        return
+
+    if args.mark:
+        if not args.status:
+            parser.error("--mark requires --status")
+        item = mark_status(args.mark, args.status, notes=args.notes)
+        if item is None:
+            print(f"Item not found: {args.mark}", file=sys.stderr)
+            sys.exit(1)
+        print(json.dumps(item, indent=2))
+        return
+
+    if args.due:
+        for item in due_items():
+            print(f"{item['id']}  {item['publish_at']}  [{item['site']}] {item['title']}")
+        return
+
+    # Default: list
+    for item in list_items(status=args.status, site=args.site):
+        print(
+            f"{item['id']}  {item['publish_at']}  {item['status']:<10}  "
+            f"[{item['site']}] {item['title']}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/campaigns/campaign_planner.py
+++ b/scripts/campaigns/campaign_planner.py
@@ -15,6 +15,7 @@ Generates: landing page copy, 5-email sequence, 3 social variants, 3 ad variants
 import argparse
 import json
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,6 +27,53 @@ load_dotenv()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 KNOWLEDGE = REPO_ROOT / "knowledge"
+
+
+def _slugify(text: str) -> str:
+    """Lowercase slug: alphanumerics joined by hyphens."""
+    return re.sub(r"[^a-z0-9]+", "-", (text or "").lower()).strip("-")
+
+
+def mint_campaign_id(goal: str, keyword: str = "", when: datetime | None = None) -> str:
+    """Mint the shared campaign identity: ``cmp-YYYYMMDD-<slug>``.
+
+    This is THE join key across the five campaign stores: planner
+    manifest.json, campaign_tracker SQLite, RuntimeStore ``campaign_plan``
+    artifacts, editorial calendar items, and content_log entries
+    (threaded via ``engine.generate(campaign_id=...)``).
+    """
+    when = when or datetime.now(timezone.utc)
+    slug = _slugify(goal) or _slugify(keyword) or "campaign"
+    return f"cmp-{when.strftime('%Y%m%d')}-{slug[:48].strip('-')}"
+
+
+def _record_campaign_plan_artifact(manifest: dict, save_dir: str) -> str | None:
+    """Record a ``campaign_plan`` artifact in the RuntimeStore.
+
+    Uses the artifact type declared in kai/runtime/models.py. Local
+    workspace state only — nothing here touches a live channel.
+    Returns the artifact_id, or None if the runtime store is unavailable.
+    """
+    try:
+        from kai.runtime import get_default_runtime_store
+
+        store = get_default_runtime_store()
+        artifact = store.record_artifact(
+            {
+                "artifact_type": "campaign_plan",
+                "brand_id": manifest.get("product", ""),
+                "workflow": "campaign-plan",
+                "data": {
+                    "campaign_id": manifest.get("campaign_id"),
+                    "manifest": manifest,
+                    "assets_dir": str(save_dir),
+                },
+            }
+        )
+        return artifact.get("artifact_id")
+    except Exception as e:  # never let bookkeeping kill the asset save
+        print(f"  Warning: could not record campaign_plan artifact: {e}")
+        return None
 
 
 def _load_config() -> dict:
@@ -96,9 +144,18 @@ def generate_campaign(
     keyword: str,
     campaign_type: str = "launch",
     save_dir: str | None = None,
+    campaign_id: str | None = None,
 ) -> dict:
-    """Generate all campaign assets."""
+    """Generate all campaign assets.
 
+    ``campaign_id`` is minted (``cmp-YYYYMMDD-<slug>``) when not supplied.
+    With ``save_dir``, it is written into manifest.json, a tracker row is
+    auto-created (campaign_tracker.create_campaign), and a ``campaign_plan``
+    artifact is recorded in the RuntimeStore — one join key across all
+    campaign stores.
+    """
+
+    campaign_id = campaign_id or mint_campaign_id(goal, keyword)
     template = CAMPAIGN_TEMPLATES.get(campaign_type, CAMPAIGN_TEMPLATES["launch"])
     product_context = _get_product_context(product_id)
     pe_framework = _load_framework("frameworks/content-copywriting/perception-engineering.md")
@@ -107,6 +164,7 @@ def generate_campaign(
 
     print(f"\n{'═'*60}")
     print(f"  Campaign Planner — {campaign_type.upper()}")
+    print(f"  Campaign ID: {campaign_id}")
     print(f"  Goal: {goal}")
     print(f"  Product: {product_id} | Keyword: {keyword}")
     print(f"{'═'*60}")
@@ -326,8 +384,9 @@ Requirements: Standard AP style, no banned words, specific numbers.""")
         for name, content in assets.items():
             (out / f"{name}.md").write_text(content)
 
-        # Save campaign manifest
+        # Save campaign manifest — campaign_id is the cross-store join key
         manifest = {
+            "campaign_id": campaign_id,
             "campaign_type": campaign_type,
             "goal": goal,
             "product": product_id,
@@ -342,6 +401,28 @@ Requirements: Standard AP style, no banned words, specific numbers.""")
         for name in assets:
             print(f"    {name}.md")
         print(f"    manifest.json")
+
+        # Auto-create the tracker row so the campaign is joinable from day 0
+        # (previously a prose-only hook in harness/skill-contracts/campaign.yaml).
+        try:
+            from scripts.campaigns.campaign_tracker import create_campaign
+
+            create_campaign(
+                campaign_id,
+                assets_dir=str(out),
+                campaign_type=campaign_type,
+                goal=goal,
+                product=product_id,
+                keyword=keyword,
+                campaign_id=campaign_id,
+            )
+        except Exception as e:
+            print(f"  Warning: could not create campaign tracker row: {e}")
+
+        # Record the campaign_plan artifact (declared in kai/runtime/models.py).
+        artifact_id = _record_campaign_plan_artifact(manifest, str(out))
+        if artifact_id:
+            print(f"  RuntimeStore campaign_plan artifact: {artifact_id}")
     else:
         for name, content in assets.items():
             print(f"\n{'═'*60}")
@@ -363,6 +444,7 @@ def main():
     parser.add_argument("--type", default="launch", choices=list(CAMPAIGN_TEMPLATES.keys()),
                         help="Campaign type")
     parser.add_argument("--save", help="Directory to save campaign assets")
+    parser.add_argument("--campaign-id", help="Reuse an existing campaign id (default: mint cmp-YYYYMMDD-<slug>)")
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args()
 
@@ -372,6 +454,7 @@ def main():
         keyword=args.keyword,
         campaign_type=args.type,
         save_dir=args.save,
+        campaign_id=args.campaign_id,
     )
 
     if args.json:

--- a/scripts/campaigns/campaign_tracker.py
+++ b/scripts/campaigns/campaign_tracker.py
@@ -31,6 +31,7 @@ def _init_db():
         CREATE TABLE IF NOT EXISTS campaigns (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT UNIQUE NOT NULL,
+            campaign_id TEXT,
             campaign_type TEXT,
             goal TEXT,
             product TEXT,
@@ -53,12 +54,26 @@ def _init_db():
         CREATE INDEX IF NOT EXISTS idx_metrics_campaign ON metrics(campaign_name);
         CREATE INDEX IF NOT EXISTS idx_metrics_channel ON metrics(campaign_name, channel);
     """)
+    # Migrate pre-campaign_id databases in place (ALTER is a no-op after the
+    # first run; CREATE TABLE IF NOT EXISTS never adds columns to old DBs).
+    cols = [row[1] for row in conn.execute("PRAGMA table_info(campaigns)")]
+    if "campaign_id" not in cols:
+        conn.execute("ALTER TABLE campaigns ADD COLUMN campaign_id TEXT")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_campaigns_campaign_id ON campaigns(campaign_id)"
+    )
+    conn.commit()
     conn.close()
 
 
 def create_campaign(name: str, assets_dir: str = "", campaign_type: str = "", goal: str = "",
-                    product: str = "", keyword: str = ""):
-    """Register a new campaign for tracking."""
+                    product: str = "", keyword: str = "", campaign_id: str = ""):
+    """Register a new campaign for tracking.
+
+    ``campaign_id`` is the shared join key minted by campaign_planner
+    (``cmp-YYYYMMDD-<slug>``). It is read from the manifest.json in
+    ``assets_dir`` when not passed explicitly.
+    """
     _init_db()
     conn = sqlite3.connect(str(DB_PATH))
 
@@ -71,19 +86,42 @@ def create_campaign(name: str, assets_dir: str = "", campaign_type: str = "", go
             goal = goal or manifest.get("goal", "")
             product = product or manifest.get("product", "")
             keyword = keyword or manifest.get("keyword", "")
+            campaign_id = campaign_id or manifest.get("campaign_id", "")
 
     try:
         conn.execute(
-            "INSERT INTO campaigns (name, campaign_type, goal, product, keyword, assets_dir, start_date) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (name, campaign_type, goal, product, keyword, assets_dir,
+            "INSERT INTO campaigns (name, campaign_id, campaign_type, goal, product, keyword, assets_dir, start_date) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            (name, campaign_id or None, campaign_type, goal, product, keyword, assets_dir,
              datetime.now(timezone.utc).strftime("%Y-%m-%d")),
         )
         conn.commit()
         print(f"Campaign '{name}' created.")
     except sqlite3.IntegrityError:
+        # Row exists — backfill campaign_id if we now have one and it is empty.
+        if campaign_id:
+            conn.execute(
+                "UPDATE campaigns SET campaign_id = ? WHERE name = ? "
+                "AND (campaign_id IS NULL OR campaign_id = '')",
+                (campaign_id, name),
+            )
+            conn.commit()
         print(f"Campaign '{name}' already exists.")
     conn.close()
+
+
+def find_campaign(campaign_id: str) -> dict | None:
+    """Look up a tracked campaign by its shared campaign_id join key."""
+    if not campaign_id:
+        return None
+    _init_db()
+    conn = sqlite3.connect(str(DB_PATH))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM campaigns WHERE campaign_id = ?", (campaign_id,)
+    ).fetchone()
+    conn.close()
+    return dict(row) if row else None
 
 
 def update_metric(campaign_name: str, channel: str, metric: str, value: float):
@@ -112,6 +150,8 @@ def show_report(campaign_name: str):
 
     print(f"\n{'═'*60}")
     print(f"  Campaign: {campaign['name']}")
+    if campaign["campaign_id"]:
+        print(f"  Campaign ID: {campaign['campaign_id']}")
     print(f"  Type: {campaign['campaign_type']} | Goal: {campaign['goal']}")
     print(f"  Product: {campaign['product']} | Keyword: {campaign['keyword']}")
     print(f"  Status: {campaign['status']} | Started: {campaign['start_date']}")
@@ -170,6 +210,7 @@ def main():
     parser = argparse.ArgumentParser(description="Track campaign performance")
     parser.add_argument("--create", metavar="NAME", help="Create a new campaign")
     parser.add_argument("--dir", help="Campaign assets directory (for --create)")
+    parser.add_argument("--campaign-id", help="Shared campaign id (cmp-YYYYMMDD-<slug>; read from manifest.json if omitted)")
     parser.add_argument("--update", metavar="NAME", help="Update campaign metric")
     parser.add_argument("--channel", help="Channel (email, social, ads, landing_page, etc.)")
     parser.add_argument("--metric", help="Metric name (opens, clicks, spend, conversions, etc.)")
@@ -180,7 +221,7 @@ def main():
     args = parser.parse_args()
 
     if args.create:
-        create_campaign(args.create, assets_dir=args.dir or "")
+        create_campaign(args.create, assets_dir=args.dir or "", campaign_id=args.campaign_id or "")
     elif args.update:
         if not all([args.channel, args.metric, args.value is not None]):
             print("--update requires --channel, --metric, and --value")

--- a/scripts/content/content_log.py
+++ b/scripts/content/content_log.py
@@ -3,7 +3,18 @@
 Content Publish Logger — Kai Harness
 
 Logs published content for 30-day performance tracking.
-Appends to /opt/meetkai-data/content-calendar.md and writes to content_log.json.
+Appends to the content calendar (KAI_CONTENT_CALENDAR_PATH, default
+<data_dir>/content-calendar.md) and writes to content_log.json.
+
+Entry lifecycle:
+  - status "approved_unpublished": passed gates + approval but not yet live
+    (url is None; no 30-day check scheduled — checks need a real URL).
+  - status "published": live with a REAL url; 30-day check scheduled.
+  - Legacy entries predate the status/content_hash fields — readers must
+    treat a missing status with a url as published.
+
+Idempotency: entries carry content_hash (sha256 of the draft body) and
+log_entry dedupes on (site, content_hash) — re-runs update in place.
 
 Usage:
   python3 content_log.py \
@@ -19,17 +30,27 @@ Usage:
 """
 
 import argparse
+import hashlib
 import json
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from scripts.harness_config import get_config
+from scripts.harness_config import get_config, get_content_calendar_path
 
 _CFG = get_config()
 
 LOG_FILE = str(_CFG.content_log)
-CALENDAR_FILE = "/opt/meetkai-data/content-calendar.md"
+
+
+def _calendar_file() -> str:
+    """Resolve the content calendar path at call time (env/config override)."""
+    return str(get_content_calendar_path())
+
+
+def compute_content_hash(body: str) -> str:
+    """sha256 of a draft body — the idempotency key for (site, content_hash)."""
+    return hashlib.sha256((body or "").encode("utf-8")).hexdigest()
 
 
 def load_log(log_file: str | None = None) -> list:
@@ -47,8 +68,23 @@ def save_log(entries: list, log_file: str | None = None):
         json.dump(entries, f, indent=2)
 
 
+def find_entry_by_hash(site: str, content_hash: str, log_file: str | None = None) -> dict | None:
+    """Return the log entry matching (site, content_hash), or None.
+
+    Legacy entries have no content_hash and never match.
+    """
+    if not content_hash:
+        return None
+    for entry in load_log(log_file):
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("site") == site and entry.get("content_hash") == content_hash:
+            return entry
+    return None
+
+
 def log_entry(
-    url: str,
+    url: str | None,
     keyword: str,
     site: str,
     format: str,
@@ -60,16 +96,75 @@ def log_entry(
     proposal_id: str | None = None,
     module_set: list[str] | None = None,
     artifact_refs: dict | None = None,
+    content_hash: str | None = None,
+    status: str | None = None,
+    campaign_id: str | None = None,
     log_file: str | None = None,
 ) -> dict:
-    """Programmatic API to log a published content entry.
+    """Programmatic API to log a content entry.
 
-    Returns the created entry dict.
+    url must be the REAL published URL — pass None when the piece is approved
+    but not published (status becomes "approved_unpublished"; no 30-day check
+    is scheduled; use mark_published() once it goes live).
+
+    Dedupes on (site, content_hash): a matching existing entry is updated in
+    place instead of appended, and never downgraded from published.
+
+    campaign_id is the shared join key minted by campaign_planner
+    (``cmp-YYYYMMDD-<slug>``); it is carried onto the entry and into the
+    30-day pending-check file so performance rolls up per campaign.
+
+    Returns the created (or updated) entry dict.
     """
     brief = brief or {}
     now = datetime.now(timezone.utc).isoformat()
-    entry_id = f"{site}-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
 
+    if status is None:
+        status = "published" if url else "approved_unpublished"
+
+    existing = find_entry_by_hash(site, content_hash, log_file) if content_hash else None
+    if existing is not None:
+        log = load_log(log_file)
+        # Re-find inside the list we will save (find_entry_by_hash reloaded).
+        entry = next(
+            (e for e in log if isinstance(e, dict)
+             and e.get("site") == site and e.get("content_hash") == content_hash),
+            None,
+        )
+        if entry is not None:
+            url_was_set = bool(entry.get("url"))
+            for key, value in (
+                ("keyword", keyword),
+                ("title", title or brief.get("angle")),
+                ("four_us_score", four_us or brief.get("four_us_score")),
+                ("persona", brief.get("persona")),
+                ("angle", brief.get("angle")),
+                ("notes", notes),
+                ("source_run", source_run),
+                ("proposal_id", proposal_id),
+                ("module_set", module_set),
+                ("artifact_refs", artifact_refs),
+                ("campaign_id", campaign_id),
+            ):
+                if value:
+                    entry[key] = value
+            if url and not url_was_set:
+                # Only a real URL can move an entry forward; never overwrite
+                # an existing URL with None or downgrade published status.
+                # Already-published entries keep their original published_at:
+                # re-stamping on a re-run (e.g. engine "already_published")
+                # would re-count the piece as new and shift the 30-day window.
+                entry["url"] = url
+                entry["status"] = "published"
+                entry["published_at"] = now
+            entry["updated_at"] = now
+            save_log(log, log_file)
+            if url and not url_was_set:
+                append_to_calendar(entry)
+                schedule_30day_check(entry)
+            return entry
+
+    entry_id = f"{site}-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
     entry = {
         "id": entry_id,
         "url": url,
@@ -88,37 +183,90 @@ def log_entry(
         "proposal_id": proposal_id,
         "module_set": module_set or [],
         "artifact_refs": artifact_refs or {},
+        "content_hash": content_hash,
+        "status": status,
+        "campaign_id": campaign_id,
     }
 
     log = load_log(log_file)
     log.append(entry)
     save_log(log, log_file)
-    append_to_calendar(entry)
-    schedule_30day_check(entry)
+    if url:
+        append_to_calendar(entry)
+        schedule_30day_check(entry)
 
     return entry
 
 
+def mark_published(
+    entry_id: str,
+    url: str,
+    published_at: str | None = None,
+    log_file: str | None = None,
+) -> dict | None:
+    """Backfill the REAL url onto an existing entry once it actually goes live.
+
+    Flips status to "published", appends the calendar line, and schedules the
+    30-day pending check (checks only make sense with a real URL). This is the
+    hook for humans/skills that publish manually after an
+    "approved_unpublished" run.
+
+    Returns the updated entry, or None if entry_id is unknown or url is empty.
+    """
+    if not url:
+        return None
+    log = load_log(log_file)
+    entry = next(
+        (e for e in log if isinstance(e, dict) and e.get("id") == entry_id), None
+    )
+    if entry is None:
+        return None
+    entry["url"] = url
+    entry["status"] = "published"
+    entry["published_at"] = published_at or datetime.now(timezone.utc).isoformat()
+    save_log(log, log_file)
+    append_to_calendar(entry)
+    schedule_30day_check(entry)
+    return entry
+
+
 def append_to_calendar(entry: dict):
+    if not entry.get("url"):
+        return  # calendar tracks live content only
     try:
-        os.makedirs(os.path.dirname(CALENDAR_FILE), exist_ok=True)
-        date_str = entry["published_at"][:10]
+        calendar_file = _calendar_file()
+        parent = os.path.dirname(calendar_file)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        date_str = (entry.get("published_at") or "")[:10]
         line = f"- [{entry['format'].upper()}] [{entry['site']}] {entry.get('title') or entry['keyword']} — {entry['url']} — published {date_str} [done]\n"
-        with open(CALENDAR_FILE, "a") as f:
+        with open(calendar_file, "a") as f:
             f.write(line)
     except Exception as e:
         print(f"  Warning: could not append to calendar: {e}")
 
 
 def schedule_30day_check(entry: dict):
-    """Write a pending check file for the performance_check cron to pick up."""
+    """Write a pending check file for the performance_check cron to pick up.
+
+    Skipped when the entry has no real URL — a check without a URL can never
+    be measured (and would poison the GSC learning loop).
+    """
+    if not entry.get("url"):
+        return None
     checks_dir = str(_CFG.pending_checks_dir)
     os.makedirs(checks_dir, exist_ok=True)
     check_id = entry["id"]
     check_file = f"{checks_dir}/{check_id}.json"
-    # Approximate +30 days via timestamp
-    from datetime import timedelta
-    due_dt = datetime.now(timezone.utc) + timedelta(days=30)
+    # Due +30 days after publish (falls back to now when unparseable)
+    published = entry.get("published_at")
+    try:
+        published_dt = datetime.fromisoformat(published)
+        if published_dt.tzinfo is None:
+            published_dt = published_dt.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        published_dt = datetime.now(timezone.utc)
+    due_dt = published_dt + timedelta(days=30)
     check_data = {
         "id": check_id,
         "url": entry["url"],
@@ -131,10 +279,12 @@ def schedule_30day_check(entry: dict):
         "proposal_id": entry.get("proposal_id"),
         "module_set": entry.get("module_set", []),
         "artifact_refs": entry.get("artifact_refs", {}),
+        "campaign_id": entry.get("campaign_id"),
     }
     with open(check_file, "w") as f:
         json.dump(check_data, f, indent=2)
     print(f"  30-day check scheduled: {check_file}")
+    return check_file
 
 
 def main():
@@ -150,6 +300,7 @@ def main():
     parser.add_argument("--notes")
     parser.add_argument("--source-run")
     parser.add_argument("--proposal-id")
+    parser.add_argument("--campaign-id", help="Shared campaign join key (cmp-YYYYMMDD-<slug>)")
     args = parser.parse_args()
 
     brief = {}
@@ -178,6 +329,9 @@ def main():
         "proposal_id": args.proposal_id,
         "module_set": [],
         "artifact_refs": {},
+        "content_hash": None,
+        "status": "published",  # CLI path requires --url, so it is live
+        "campaign_id": args.campaign_id,
     }
 
     log = load_log()

--- a/scripts/content/engine.py
+++ b/scripts/content/engine.py
@@ -58,6 +58,75 @@ def _find_bracket_placeholders(content: str) -> list[str]:
     return find_placeholders(content)
 
 
+def _slugify(keyword: str) -> str:
+    """URL slug for a keyword: lowercase, alphanumerics joined by hyphens."""
+    return re.sub(r"[^a-z0-9]+", "-", keyword.lower()).strip("-")
+
+
+def _publish_if_configured(
+    site: str,
+    title: str,
+    body: str,
+    content_hash: str,
+    keyword: str,
+    log_file: str | None = None,
+) -> dict:
+    """Publish an approved draft when publishing is explicitly enabled + configured.
+
+    NEVER fabricates URLs. Publishing is opt-in twice over: the operator must
+    enable it (config `publishing.enabled` or KAI_PUBLISH_ENABLED env — default
+    OFF) AND configure a platform for the site (`publishing.sites.<site>`).
+    Idempotent: skips the publish call when the same (site, content_hash) was
+    already published, returning the previously logged real URL.
+
+    Returns a dict:
+      published: bool — True only when a real URL/post exists
+      url: str | None — REAL url from the publisher or the prior log entry
+      skipped: str | None — why nothing was pushed
+        ("publishing_disabled" | "site_not_configured" | "already_published"
+         | "publish_failed")
+      result: raw publisher response when a publish was attempted
+    """
+    from scripts.harness_config import get_site_publishing_config, publishing_enabled
+    from scripts.content.content_log import find_entry_by_hash
+
+    if not publishing_enabled():
+        return {"published": False, "url": None, "skipped": "publishing_disabled"}
+
+    site_cfg = get_site_publishing_config(site)
+    platform = site_cfg.get("platform")
+    if not platform:
+        return {"published": False, "url": None, "skipped": "site_not_configured"}
+
+    prior = find_entry_by_hash(site, content_hash, log_file=log_file)
+    if prior and prior.get("url") and prior.get("status", "published") == "published":
+        return {
+            "published": True,
+            "url": prior["url"],
+            "skipped": "already_published",
+            "entry_id": prior.get("id"),
+        }
+
+    from scripts.publish import publish as publish_dispatch
+
+    kwargs = {key: value for key, value in site_cfg.items() if key != "platform"}
+    kwargs.setdefault("status", "draft")
+    kwargs.setdefault("slug", _slugify(keyword))
+    kwargs["title"] = title
+    kwargs["body"] = body
+
+    result = publish_dispatch(platform, **kwargs)
+    if result.get("success"):
+        return {
+            "published": True,
+            "url": result.get("url") or None,
+            "post_id": result.get("id"),
+            "result": result,
+        }
+    log.warning("Publish to %s failed for %s: %s", platform, site, result.get("message"))
+    return {"published": False, "url": None, "skipped": "publish_failed", "result": result}
+
+
 @dataclass
 class GenerateResult:
     """Result of a content generation run."""
@@ -239,6 +308,7 @@ async def generate(
     surface: str = "local",
     run_id: str | None = None,
     parent_run_id: str | None = None,
+    campaign_id: str | None = None,
 ) -> GenerateResult:
     """Generate content from 3 inputs: format, site, keyword.
 
@@ -255,6 +325,9 @@ async def generate(
         hook_options: Override hook options.
         dry_run: If True, generate brief only (no content/gates).
         skip_gates: If True, skip quality gates.
+        campaign_id: Shared campaign join key (``cmp-YYYYMMDD-<slug>``
+            minted by campaign_planner); threaded into the run record,
+            the content_log entry, and the 30-day pending-check file.
 
     Returns:
         GenerateResult with content, brief, gate report, and status.
@@ -289,6 +362,7 @@ async def generate(
                 "hook_options": hook_options or [],
                 "dry_run": dry_run,
                 "skip_gates": skip_gates,
+                "campaign_id": campaign_id,
             },
             "metadata": {
                 "product_mode": workspace_profile.product_mode,
@@ -549,10 +623,14 @@ async def generate(
         )
         artifact_refs["gate_proposal"] = gate_artifact["artifact_id"]
 
-        # 10. Log if approved
+        # 10. Publish (only if explicitly enabled+configured) and log if approved.
+        # Never fabricate URLs: unpublished approvals log url=None with status
+        # "approved_unpublished" and get NO 30-day check — mark_published()
+        # backfills the real URL when a human/skill ships it.
+        publish_info = {"published": False, "url": None, "skipped": "not_approved"}
         if final_status == "approved":
             try:
-                from scripts.content.content_log import log_entry
+                from scripts.content.content_log import compute_content_hash, log_entry
 
                 approved_artifact = runtime_store.record_artifact(
                     {
@@ -571,8 +649,17 @@ async def generate(
                     parent_artifact_id=gate_artifact["artifact_id"],
                 )
                 artifact_refs["approved_asset"] = approved_artifact["artifact_id"]
+                content_hash = compute_content_hash(draft)
+                publish_info = _publish_if_configured(
+                    site=site,
+                    title=brief.get("angle", keyword),
+                    body=draft,
+                    content_hash=content_hash,
+                    keyword=keyword,
+                )
+                published = bool(publish_info.get("published"))
                 log_record = log_entry(
-                    url=f"https://{site}.com/{keyword.replace(' ', '-').lower()}",
+                    url=publish_info.get("url"),
                     keyword=keyword,
                     site=site,
                     format=format,
@@ -583,22 +670,28 @@ async def generate(
                     proposal_id=proposal_id,
                     module_set=brand.module_ids,
                     artifact_refs=artifact_refs,
+                    content_hash=content_hash,
+                    status="published" if published else "approved_unpublished",
+                    campaign_id=campaign_id,
                 )
-                published_artifact = runtime_store.record_artifact(
-                    {
-                        "artifact_type": "published_asset",
-                        "brand_id": site,
-                        "workflow": workflow,
-                        "module_set": brand.module_ids,
-                        "parent_artifact_id": approved_artifact["artifact_id"],
-                        "data": {
-                            "log_entry": log_record,
+                if published:
+                    published_artifact = runtime_store.record_artifact(
+                        {
+                            "artifact_type": "published_asset",
+                            "brand_id": site,
+                            "workflow": workflow,
+                            "module_set": brand.module_ids,
+                            "parent_artifact_id": approved_artifact["artifact_id"],
+                            "data": {
+                                "log_entry": log_record,
+                                "publish_result": publish_info.get("result"),
+                                "content_hash": content_hash,
+                            },
                         },
-                    },
-                    run_id=run_id,
-                    parent_artifact_id=approved_artifact["artifact_id"],
-                )
-                artifact_refs["published_asset"] = published_artifact["artifact_id"]
+                        run_id=run_id,
+                        parent_artifact_id=approved_artifact["artifact_id"],
+                    )
+                    artifact_refs["published_asset"] = published_artifact["artifact_id"]
             except Exception as e:
                 log.warning("Failed to log content entry: %s", e)
         runtime_store.complete_run(
@@ -631,6 +724,12 @@ async def generate(
                 "site": site,
                 "keyword": keyword,
                 "persona": brief.get("persona"),
+                "campaign_id": campaign_id,
+                "publish": {
+                    "published": bool(publish_info.get("published")),
+                    "url": publish_info.get("url"),
+                    "skipped": publish_info.get("skipped"),
+                },
                 "approval_policy": policy,
                 "word_count": len(draft.split()),
                 "workspace": workspace_profile.model_dump(),

--- a/scripts/content/harness_discord.py
+++ b/scripts/content/harness_discord.py
@@ -27,13 +27,25 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from dotenv import load_dotenv
-load_dotenv("/opt/cmo-analytics/.env")
+# Allow direct invocation (python3 harness_discord.py ...) from any cwd.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
 
-VENV_PYTHON = "/opt/cmo-analytics/venv/bin/python3"
-HARNESS = "/opt/cmo-analytics/scripts/kai_harness.py"
-CONTENT_LOG = "/opt/cmo-analytics/data/content_log.json"
-PENDING_DIR = "/opt/cmo-analytics/data/pending_checks"
+# harness_config loads .env (CMO_BASE_DIR/.env, then repo root) on import.
+from scripts.harness_config import get_config, get_harness_script
+from scripts.self_improvement.grades import get_grade
+
+_CFG = get_config()
+
+# All paths come from centralized config — override via env for deployed
+# installs (CMO_BASE_DIR, VENV_PYTHON, CMO_DATA_DIR, KAI_HARNESS_SCRIPT).
+# Defaults are repo-relative so a fresh clone works with no setup.
+BASE_DIR = str(_CFG.cmo_base_dir)
+VENV_PYTHON = _CFG.venv_python
+HARNESS = str(get_harness_script())
+CONTENT_LOG = str(_CFG.content_log)
+PENDING_DIR = str(_CFG.pending_checks_dir)
 
 FORMATS = ["blog", "linkedin", "email-lifecycle", "cold-email", "tiktok", "meta-ads", "google-ads", "press", "seo"]
 SITES = ["kaicalls", "buildwithkai", "abp", "meetkai", "connorgallic", "vocalscribe"]
@@ -59,7 +71,7 @@ def format_status() -> str:
     pending = list(Path(PENDING_DIR).glob("*.json")) if Path(PENDING_DIR).exists() else []
     pending_count = sum(1 for f in pending if json.loads(f.read_text()).get("status") == "pending")
 
-    winners = [e for e in log if e.get("performance_30d", {}).get("grade") == "winner"]
+    winners = [e for e in log if get_grade(e) == "winner"]
     total = len(log)
 
     lines = [
@@ -85,8 +97,10 @@ def format_report(site: str = "all", days: int = 30) -> str:
 
     by_grade: dict[str, list] = {"winner": [], "average": [], "underperformer": [], "pending": []}
     for e in log:
-        perf = e.get("performance_30d")
-        grade = perf.get("grade", "average") if perf else "pending"
+        # get_grade tolerates dict/legacy-str/None performance_30d.
+        grade = get_grade(e) or ("average" if e.get("performance_30d") else "pending")
+        if grade not in by_grade:
+            grade = "average"
         by_grade[grade].append(e)
 
     lines = [f"**📊 Content Report** — {site} ({days}d)\n"]
@@ -240,8 +254,8 @@ def parse_and_respond(command_str: str, channel_id: str) -> str:
         # Run in background — spawn subprocess
         log_file = f"/tmp/harness_run_{datetime.now(timezone.utc).strftime('%H%M%S')}.log"
         bg_cmd = (
-            f"cd /opt/cmo-analytics && source venv/bin/activate && "
-            f"python3 {HARNESS} run --task {fmt} --site {site} --keyword \"{keyword}\" "
+            f"cd {BASE_DIR} && "
+            f"{VENV_PYTHON} {HARNESS} run --task {fmt} --site {site} --keyword \"{keyword}\" "
             f"--skip-approval > {log_file} 2>&1 && "
             f"openclaw message send --channel discord --target {channel_id} "
             f"--message \"✅ Harness done: {fmt}/{site}/{keyword}. Draft at /tmp/harness_draft.md. "
@@ -293,8 +307,8 @@ def parse_kai_command(command_str: str, channel_id: str) -> str:
     # Spawn engine in background
     log_file = f"/tmp/kai_generate_{datetime.now(timezone.utc).strftime('%H%M%S')}.log"
     bg_cmd = (
-        f"cd /opt/cmo-analytics && source venv/bin/activate && "
-        f"python3 -c \""
+        f"cd {BASE_DIR} && "
+        f"{VENV_PYTHON} -c \""
         f"import asyncio; from scripts.content.engine import generate; "
         f"r = asyncio.run(generate('{fmt}', '{site}', '{keyword}')); "
         f"print(f'Status: {{r.status}}, Score: {{r.gate_report.get(\"score\", \"?\") if r.gate_report else \"?\"}}')"

--- a/scripts/content/migrate_legacy_log.py
+++ b/scripts/content/migrate_legacy_log.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""
+Legacy Content Log Migration — Kai Harness
+
+Merges the legacy skill-chain log (``~/.kai-marketing/content-log.jsonl``,
+written by the /content-write → /content-gate chain and read by tracker_cli)
+into the CANONICAL content log (``data/content_log.json``) that the learning
+loop actually consumes (performance_check, pattern_extract, weekly_report).
+
+Why: two logs with different schemas meant winners recorded by the skill
+chain never reached the learning loop. ``data/content_log.json`` is canonical;
+this script folds the legacy JSONL in and is safe to re-run (idempotent).
+
+Mapping / rules:
+  - ``publish_date`` -> ``published_at`` (existing ``published_at`` wins)
+  - dedupe by ``id`` first, then by non-empty ``url``
+  - performance data (``performance_30d``) is preserved; when the canonical
+    entry has none and the legacy entry does, it is backfilled. Legacy
+    STRING-form grades are normalized to the canonical dict schema
+    (``{"grade": ..., "migrated": True}``, "loser" -> "underperformer") so
+    canonical-log readers never crash on a str
+  - legacy-only fields (``hook_type``, ``draft_path``) are carried over
+  - entries without a url become status "approved_unpublished" (no URL ⇒
+    nothing measurable; see content_log.py lifecycle doctrine); entries with
+    a url become "published"
+  - NO pending checks are written here — run
+    ``python -m scripts.self_improvement.performance_check --reconcile-only``
+    afterwards; it rebuilds missing check files from the canonical log
+    (EC-12) and correctly skips url-less entries.
+  - the legacy file is never modified or deleted; the orphaned
+    ``~/.kai-marketing/pending/*.json`` files (nothing reads them) can be
+    removed by hand once you're satisfied with the merge.
+
+Usage:
+  python -m scripts.content.migrate_legacy_log [--legacy PATH] [--log-file PATH]
+                                               [--dry-run] [--json]
+"""
+
+import argparse
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.content.content_log import load_log, save_log
+from scripts.harness_config import get_config
+from scripts.self_improvement.grades import get_grade
+
+DEFAULT_LEGACY_PATH = Path.home() / ".kai-marketing" / "content-log.jsonl"
+
+# Legacy fields backfilled onto an existing canonical entry when missing there.
+_BACKFILL_FIELDS = (
+    "keyword",
+    "title",
+    "four_us_score",
+    "persona",
+    "hook_type",
+    "draft_path",
+    "notes",
+)
+
+
+def load_legacy(path: str | Path) -> list[dict]:
+    """Load the legacy JSONL log, skipping blank/corrupt lines."""
+    path = Path(path)
+    if not path.exists():
+        return []
+    entries: list[dict] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            raw = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(raw, dict):
+            entries.append(raw)
+    return entries
+
+
+def _normalize_perf(perf):
+    """Coerce ``performance_30d`` into the canonical DICT schema (or None).
+
+    Legacy JSONL entries sometimes stored a bare string grade; canonical-log
+    readers (pattern_extract.is_winner, weekly_report, ceo_deck) expect the
+    dict schema and must never see a str here. Routes through
+    ``grades.get_grade`` so the legacy "loser" grade lands as
+    "underperformer".
+    """
+    if isinstance(perf, dict):
+        return perf
+    if isinstance(perf, str):
+        grade = get_grade({"performance_30d": perf})
+        if grade is None:
+            return None
+        return {"grade": grade, "migrated": True}
+    return None
+
+
+def normalize_legacy_entry(raw: dict) -> dict | None:
+    """Map a legacy JSONL entry onto the canonical content_log schema.
+
+    Returns None when the entry is unusable (no id and no url to key on).
+    """
+    entry_id = raw.get("id")
+    url = raw.get("url") or None
+    if not entry_id and not url:
+        return None
+
+    published_at = raw.get("published_at") or raw.get("publish_date")
+    status = raw.get("status")
+    if status not in ("published", "approved_unpublished"):
+        status = "published" if url else "approved_unpublished"
+
+    fmt = raw.get("format") or raw.get("platform") or "blog"
+    if not entry_id:
+        # Deterministic fallback id so re-runs match the same entry.
+        entry_id = f"legacy-{hashlib.sha1(url.encode('utf-8')).hexdigest()[:12]}"
+    entry = {
+        "id": entry_id,
+        "url": url,
+        "keyword": raw.get("keyword", ""),
+        "title": raw.get("title") or raw.get("keyword", ""),
+        "platform": raw.get("platform") or fmt,
+        "site": raw.get("site", ""),
+        "format": fmt,
+        "published_at": published_at,
+        "four_us_score": raw.get("four_us_score"),
+        "persona": raw.get("persona"),
+        "angle": raw.get("angle"),
+        "notes": raw.get("notes", ""),
+        "performance_30d": _normalize_perf(raw.get("performance_30d")),
+        "source_run": raw.get("source_run"),
+        "proposal_id": raw.get("proposal_id"),
+        "module_set": raw.get("module_set") or [],
+        "artifact_refs": raw.get("artifact_refs") or {},
+        "content_hash": raw.get("content_hash"),
+        "status": status,
+        "campaign_id": raw.get("campaign_id"),
+        "migrated_from": "kai-marketing-jsonl",
+    }
+    # Legacy-only fields worth keeping (drop empty values to stay tidy).
+    for key in ("hook_type", "draft_path"):
+        if raw.get(key):
+            entry[key] = raw[key]
+    return entry
+
+
+def _backfill(canonical: dict, legacy: dict) -> bool:
+    """Copy legacy data into an existing canonical entry without downgrades.
+
+    Never touches url/status/published_at when canonical already has them
+    (canonical is the source of truth for the publish lifecycle). Returns
+    True when anything changed.
+    """
+    changed = False
+    canon_perf = canonical.get("performance_30d")
+    if isinstance(canon_perf, str):
+        # Heal string-form grades left in the canonical log by earlier merges
+        # — dict schema only, so downstream readers never crash on a str.
+        canonical["performance_30d"] = _normalize_perf(canon_perf)
+        canon_perf = canonical["performance_30d"]
+        changed = True
+    legacy_perf = _normalize_perf(legacy.get("performance_30d"))
+    if canon_perf is None and legacy_perf is not None:
+        canonical["performance_30d"] = legacy_perf
+        changed = True
+    for key in _BACKFILL_FIELDS:
+        if not canonical.get(key) and legacy.get(key):
+            canonical[key] = legacy[key]
+            changed = True
+    if not canonical.get("published_at") and legacy.get("published_at"):
+        canonical["published_at"] = legacy["published_at"]
+        changed = True
+    if changed:
+        canonical["migrated_backfill"] = "kai-marketing-jsonl"
+    return changed
+
+
+def migrate(
+    legacy_path: str | Path | None = None,
+    log_file: str | None = None,
+    dry_run: bool = False,
+) -> dict:
+    """Merge the legacy JSONL into the canonical log. Idempotent.
+
+    Returns a summary dict: {added, updated, unchanged, skipped_invalid,
+    legacy_total, canonical_total, log_file, legacy_path}.
+    """
+    legacy_path = Path(legacy_path or os.environ.get("KAI_LEGACY_CONTENT_LOG", DEFAULT_LEGACY_PATH))
+    log_file = log_file or str(get_config().content_log)
+
+    legacy_entries = load_legacy(legacy_path)
+    canonical = load_log(log_file)
+
+    by_id = {e.get("id"): e for e in canonical if isinstance(e, dict) and e.get("id")}
+    by_url = {e.get("url"): e for e in canonical if isinstance(e, dict) and e.get("url")}
+
+    added = updated = unchanged = skipped_invalid = 0
+
+    for raw in legacy_entries:
+        entry = normalize_legacy_entry(raw)
+        if entry is None:
+            skipped_invalid += 1
+            continue
+
+        existing = by_id.get(entry["id"])
+        if existing is None and entry.get("url"):
+            existing = by_url.get(entry["url"])
+
+        if existing is not None:
+            if _backfill(existing, entry):
+                updated += 1
+            else:
+                unchanged += 1
+            continue
+
+        entry["migrated_at"] = datetime.now(timezone.utc).isoformat()
+        canonical.append(entry)
+        by_id[entry["id"]] = entry
+        if entry.get("url"):
+            by_url[entry["url"]] = entry
+        added += 1
+
+    if not dry_run and (added or updated):
+        save_log(canonical, log_file)
+
+    return {
+        "added": added,
+        "updated": updated,
+        "unchanged": unchanged,
+        "skipped_invalid": skipped_invalid,
+        "legacy_total": len(legacy_entries),
+        "canonical_total": len(canonical),
+        "log_file": str(log_file),
+        "legacy_path": str(legacy_path),
+        "dry_run": dry_run,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Merge the legacy ~/.kai-marketing/content-log.jsonl into the canonical data/content_log.json"
+    )
+    parser.add_argument("--legacy", help=f"Legacy JSONL path (default: {DEFAULT_LEGACY_PATH})")
+    parser.add_argument("--log-file", help="Canonical log path (default: <data_dir>/content_log.json)")
+    parser.add_argument("--dry-run", action="store_true", help="Report what would change without writing")
+    parser.add_argument("--json", action="store_true", help="Print the summary as JSON")
+    args = parser.parse_args()
+
+    summary = migrate(legacy_path=args.legacy, log_file=args.log_file, dry_run=args.dry_run)
+
+    if args.json:
+        print(json.dumps(summary, indent=2))
+        return
+
+    prefix = "[dry-run] " if summary["dry_run"] else ""
+    print(f"{prefix}Legacy log:    {summary['legacy_path']} ({summary['legacy_total']} entries)")
+    print(f"{prefix}Canonical log: {summary['log_file']} ({summary['canonical_total']} entries after merge)")
+    print(f"{prefix}  added:           {summary['added']}")
+    print(f"{prefix}  updated:         {summary['updated']}")
+    print(f"{prefix}  unchanged:       {summary['unchanged']}")
+    print(f"{prefix}  skipped_invalid: {summary['skipped_invalid']}")
+    if summary["added"] or summary["updated"]:
+        print(
+            "\nNext: python -m scripts.self_improvement.performance_check --reconcile-only\n"
+            "      (rebuilds missing 30-day pending checks from the canonical log; EC-12)"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/content/report_cli.py
+++ b/scripts/content/report_cli.py
@@ -15,6 +15,8 @@ from pathlib import Path
 _ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(_ROOT))
 
+from scripts.self_improvement.grades import get_grade, get_published_at  # noqa: E402
+
 KAI_DIR = Path.home() / ".kai-marketing"
 
 
@@ -76,23 +78,24 @@ def main():
     except ImportError:
         # If performance_check unavailable, just list content
         results = [{"id": e.get("id", "?"), "site": e.get("site"), "keyword": e.get("keyword"),
-                     "format": e.get("format"), "publish_date": e.get("publish_date"),
+                     "format": e.get("format"), "published_at": get_published_at(e),
                      "four_us_score": e.get("four_us_score"), "performance_30d": e.get("performance_30d")}
                     for e in entries]
 
     if args.format == "json":
         print(json.dumps(results, indent=2, default=str))
     else:
-        winners = [r for r in results if r.get("performance_30d") == "winner"]
-        avg = [r for r in results if r.get("performance_30d") == "average"]
-        under = [r for r in results if r.get("performance_30d") == "underperformer"]
-        pending = [r for r in results if r.get("performance_30d") is None]
+        # get_grade tolerates performance_30d as dict, legacy string, or None
+        winners = [r for r in results if get_grade(r) == "winner"]
+        avg = [r for r in results if get_grade(r) == "average"]
+        under = [r for r in results if get_grade(r) == "underperformer"]
+        pending = [r for r in results if get_grade(r) is None]
 
         print(f"Content Report — {len(entries)} pieces")
         print(f"  Winners: {len(winners)}  |  Average: {len(avg)}  |  Under: {len(under)}  |  Pending: {len(pending)}")
         print()
         for r in results[:20]:
-            status = r.get("performance_30d", "pending") or "pending"
+            status = get_grade(r) or "pending"
             icon = {"winner": "+", "average": "~", "underperformer": "-", "pending": "?"}
             print(f"  [{icon.get(status, '?')}] {r.get('id', '?')}  {r.get('keyword', '')}  ({status})")
 

--- a/scripts/content/tracker_cli.py
+++ b/scripts/content/tracker_cli.py
@@ -24,6 +24,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from scripts.self_improvement.grades import get_grade  # noqa: E402
+
 KAI_DIR = Path.home() / ".kai-marketing"
 METRICS_DIR = KAI_DIR / "metrics"
 CITATIONS_DIR = KAI_DIR / "citations"
@@ -231,17 +237,18 @@ def cmd_report(args: argparse.Namespace) -> int:
         print(json.dumps(results, indent=2, default=str))
         return 0
 
-    winners = [r for r in results if r.get("performance_30d") == "winner"]
-    avg = [r for r in results if r.get("performance_30d") == "average"]
-    under = [r for r in results if r.get("performance_30d") == "underperformer"]
-    pending = [r for r in results if r.get("performance_30d") is None]
+    # get_grade tolerates performance_30d as dict, legacy string, or None
+    winners = [r for r in results if get_grade(r) == "winner"]
+    avg = [r for r in results if get_grade(r) == "average"]
+    under = [r for r in results if get_grade(r) == "underperformer"]
+    pending = [r for r in results if get_grade(r) is None]
 
     print(f"Content Performance Report — {len(results)} pieces")
     print(f"  Winners: {len(winners)}  |  Average: {len(avg)}  |  Under: {len(under)}  |  Pending: {len(pending)}")
     print()
     for r in results[-20:]:
         icon_map = {"winner": "+", "average": "~", "underperformer": "-"}
-        icon = icon_map.get(r.get("performance_30d") or "", "?")
+        icon = icon_map.get(get_grade(r) or "", "?")
         plat = r.get("platforms", {})
         devto = plat.get("devto") or {}
         li = (plat.get("linkedin") or {}).get("latest") or {}

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -22,6 +22,7 @@ import argparse
 import importlib.util
 import os
 import py_compile
+import re
 import sys
 from pathlib import Path
 
@@ -75,6 +76,41 @@ REQUIRED_PATHS = [
     "docs/system/governance-and-quality.md",
     "docs/system/learning-loop.md",
     "docs/OPENCLAW_SETUP.md",
+]
+
+# The instruction chain: files that CLAUDE.md/AGENTS.md tell every agent to
+# read (load-on-demand pointers, workspace core files, the memory layer).
+# If one of these is missing, agents get instructed to load files that do not
+# exist — which silently happened when .claude/rules/ was dropped in the
+# 2026-06-18 slimming. To update: when AGENTS.md or CLAUDE.md gains a new
+# pointer target (a "read this file" instruction outside the Framework Map),
+# add it here.
+INSTRUCTION_CHAIN_PATHS = [
+    "AGENTS.md",
+    "CLAUDE.md",
+    ".claude/rules/architecture-and-memory.md",
+    ".claude/rules/scripts-and-tools.md",
+    "memory/MEMORY.md",
+    "memory/lessons.md",
+    "memory/edge-cases.md",
+    "memory/what-doesnt-work.md",
+    "workspace/AGENTS.md",
+    "workspace/HEARTBEAT.md",
+    "workspace/IDENTITY.md",
+    "workspace/MARKETING.md",
+    "workspace/SOUL.md",
+    "workspace/TOOLS.md",
+    "workspace/USER.md",
+]
+
+# Markdown docs whose inline `path` references (Framework Map table, skill
+# contracts, checklists, rules files) are parsed and existence-checked by
+# check_instruction_chain(). Paths under data/ are runtime artifacts and are
+# skipped; so are globs, ellipses, and command arguments.
+REFERENCED_DOCS = [
+    "AGENTS.md",
+    ".claude/rules/architecture-and-memory.md",
+    ".claude/rules/scripts-and-tools.md",
 ]
 
 # Scripts that must at least compile on a fresh clone (no credentials needed).
@@ -141,6 +177,80 @@ def check_required_paths(report: Report) -> None:
         for p in missing:
             report.fail(f"missing referenced file: {p}")
     report.ok(f"{len(REQUIRED_PATHS) - len(missing)}/{len(REQUIRED_PATHS)} referenced files present")
+
+
+_PATH_TOKEN_RE = re.compile(r"[A-Za-z0-9_.\-/]+/?")
+
+
+def extract_repo_paths(markdown_text: str) -> list[str]:
+    """Extract repo-relative file/dir paths from inline-code spans in markdown.
+
+    Rules (kept deliberately conservative to avoid false failures):
+      - fenced code blocks are stripped (inline backticks only)
+      - a token counts as a path when it contains "/" and is made purely of
+        path characters (no spaces, globs, angle brackets, or "..." ellipses)
+      - `python <script>.py ...` command tokens contribute their script path
+      - absolute paths and data/ runtime artifacts are skipped
+    """
+    lines: list[str] = []
+    in_fence = False
+    for line in markdown_text.splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            lines.append(line)
+
+    paths: set[str] = set()
+    for line in lines:
+        for token in re.findall(r"`([^`\n]+)`", line):
+            token = token.strip()
+            candidate = ""
+            if token.startswith(("python ", "python3 ")):
+                words = token.split()
+                if len(words) > 1 and words[1].endswith(".py"):
+                    candidate = words[1]
+            elif " " not in token and _PATH_TOKEN_RE.fullmatch(token):
+                candidate = token
+            if not candidate or "/" not in candidate:
+                continue
+            if ".." in candidate or "*" in candidate:
+                continue
+            if candidate.startswith(("/", "data/")):
+                continue
+            paths.add(candidate)
+    return sorted(paths)
+
+
+def check_instruction_chain(report: Report, root: Path = REPO_ROOT) -> None:
+    """Verify every file the instruction chain tells agents to load exists.
+
+    Covers the CLAUDE.md/AGENTS.md load-on-demand pointers (.claude/rules/*),
+    the workspace core files, the memory layer, and every path referenced in
+    the AGENTS.md Framework Map + the .claude/rules docs themselves.
+    """
+    missing_chain = [p for p in INSTRUCTION_CHAIN_PATHS if not (root / p).exists()]
+    for p in missing_chain:
+        report.fail(f"instruction chain broken: {p} is referenced by CLAUDE.md/AGENTS.md but missing")
+
+    checked = 0
+    for doc in REFERENCED_DOCS:
+        doc_path = root / doc
+        if not doc_path.exists():
+            continue  # already failed above (or not part of this tree)
+        try:
+            text = doc_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            report.fail(f"cannot read {doc}: {exc}")
+            continue
+        for rel in extract_repo_paths(text):
+            checked += 1
+            if not (root / rel).exists():
+                report.fail(f"{doc} references missing path: {rel}")
+    report.ok(
+        f"instruction chain intact ({len(INSTRUCTION_CHAIN_PATHS) - len(missing_chain)}"
+        f"/{len(INSTRUCTION_CHAIN_PATHS)} core files, {checked} doc-referenced paths checked)"
+    )
 
 
 def check_compiles(report: Report) -> None:
@@ -225,6 +335,7 @@ def main() -> int:
     report = Report()
     check_python(report)
     check_required_paths(report)
+    check_instruction_chain(report)
     check_compiles(report)
     check_golden_corpus(report)
     if not args.ci:

--- a/scripts/harness_cli.py
+++ b/scripts/harness_cli.py
@@ -9,6 +9,9 @@ Usage:
   kai-harness brief --site kaicalls --keyword "law firm answering service"
   kai-harness report [--days 30] [--site kaicalls]
   kai-harness patterns [--site all]
+  kai-harness goals add --brand kaicalls --name "Q3 organic" --kpi organic_clicks --target 5000 --deadline 2026-09-30
+  kai-harness goals list [--brand kaicalls] [--json]
+  kai-harness goals update goal_ab12cd34 --current 1200
   kai-harness status
 
 Three laws:
@@ -29,6 +32,13 @@ from pathlib import Path
 
 import yaml
 
+# Allow direct invocation (python3 scripts/harness_cli.py ...) from any cwd —
+# the Discord handler shells out to this file by path (get_harness_script()).
+# Module form (python -m scripts.harness_cli) works either way.
+_BOOTSTRAP_ROOT = Path(__file__).resolve().parents[1]
+if str(_BOOTSTRAP_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BOOTSTRAP_ROOT))
+
 from scripts.harness_config import get_config
 from scripts.content._writer import (
     FORMAT_INSTRUCTIONS as _WRITER_FORMAT_INSTRUCTIONS,
@@ -42,7 +52,12 @@ from scripts.content._writer import (
 
 _CFG = get_config()
 
-from google import genai as google_genai
+# Optional dependency: only the generation commands need Gemini. Registry
+# commands (goals, report, status) must work without it installed.
+try:
+    from google import genai as google_genai
+except ImportError:
+    google_genai = None
 
 # ── Paths (derived from centralized config) ───────────────────────────────
 _REPO_ROOT   = _CFG.repo_root
@@ -285,6 +300,11 @@ def gemini(prompt: str, model: str | None = None) -> str:
     Raises RuntimeError after api_max_retries consecutive failures.
     """
     global _CONSECUTIVE_FAILURES
+    if google_genai is None:
+        raise RuntimeError(
+            "google-genai is not installed — content generation commands need it "
+            "(pip install google-genai)"
+        )
     model = model or _CFG.gemini_model
     timeout = _CFG.api_timeout
 
@@ -948,6 +968,93 @@ def cmd_weekly_report(args):
     print(out)
 
 
+def cmd_goals(args):
+    """Goal registry CRUD — kai-harness goals add|list|update.
+
+    Writes through kai.runtime.goals.GoalRegistry (files under
+    <KAI_RUNTIME_DIR|data/runtime>/goals/). The weekly CMO review task
+    (agent/tasks/cmo_review.py) reads these goals, refreshes KPI values,
+    and decomposes behind-pace goals into task graphs.
+    """
+    from kai.runtime.goals import GoalRegistry, compute_goal_pace
+
+    registry = GoalRegistry()
+
+    if args.goals_command == "add":
+        metadata = {"baseline_value": args.current}
+        if args.site:
+            metadata["site"] = args.site
+        goal = registry.create_goal(
+            brand_id=args.brand,
+            name=args.name,
+            kpi_name=args.kpi,
+            target_value=args.target,
+            current_value=args.current,
+            target_direction=args.direction,
+            deadline=args.deadline or "",
+            metadata=metadata,
+        )
+        print(f"Created goal {goal.goal_id}")
+        print(json.dumps(goal.model_dump(), indent=2, sort_keys=True))
+        return
+
+    if args.goals_command == "list":
+        goals = registry.list_goals(brand_id=args.brand)
+        if not args.all:
+            goals = [g for g in goals if g.status == "active"]
+        if args.json:
+            print(json.dumps(
+                [g.model_dump() for g in sorted(goals, key=lambda g: g.goal_id)],
+                indent=2, sort_keys=True,
+            ))
+            return
+        if not goals:
+            print("No goals found.")
+            return
+        header("Kai Harness — Goals")
+        for g in sorted(goals, key=lambda g: (g.brand_id, g.goal_id)):
+            pace = compute_goal_pace(g)
+            if pace["achieved"]:
+                flag = "achieved"
+            elif pace["behind_pace"]:
+                flag = "BEHIND PACE"
+            else:
+                flag = "on pace"
+            if pace["overdue"]:
+                flag += ", overdue"
+            deadline = g.deadline or "no deadline"
+            print(
+                f"  {g.goal_id}  [{g.brand_id}] {g.name}\n"
+                f"      {g.kpi_name}: {g.current_value:g} / {g.target_value:g} "
+                f"({g.target_direction}, due {deadline}) — {flag} — status={g.status}"
+            )
+        return
+
+    if args.goals_command == "update":
+        goal = registry.get_goal(args.id)
+        if goal is None:
+            print(f"Goal not found: {args.id}")
+            sys.exit(1)
+        if args.current is not None:
+            if goal.metadata is None:
+                goal.metadata = {}
+            # Anchor pace math to the original starting value.
+            goal.metadata.setdefault("baseline_value", goal.current_value)
+            goal.current_value = args.current
+        if args.target is not None:
+            goal.target_value = args.target
+        if args.deadline is not None:
+            goal.deadline = args.deadline
+        if args.status is not None:
+            goal.status = args.status
+        if args.name is not None:
+            goal.name = args.name
+        registry.save_goal(goal)
+        print(f"Updated goal {goal.goal_id}")
+        print(json.dumps(goal.model_dump(), indent=2, sort_keys=True))
+        return
+
+
 def cmd_dashboard(_args):
     header("Kai Harness — Dashboard")
     dashboard_path = SCRIPTS / "reporting" / "dashboard.html"
@@ -1046,6 +1153,34 @@ def main():
     # dashboard
     sub.add_parser("dashboard", help="Open marketing dashboard in browser")
 
+    # goals
+    gl = sub.add_parser("goals", help="Track brand goals / KPI targets (GoalRegistry)")
+    glsub = gl.add_subparsers(dest="goals_command", required=True)
+
+    gla = glsub.add_parser("add", help="Create a goal")
+    gla.add_argument("--brand",     required=True, help="Brand id the goal belongs to")
+    gla.add_argument("--name",      required=True, help="Human-readable goal name")
+    gla.add_argument("--kpi",       required=True,
+                     help="KPI name (auto-refreshable: content_published, content_winners, organic_clicks, organic_impressions)")
+    gla.add_argument("--target",    required=True, type=float, help="Target KPI value")
+    gla.add_argument("--current",   type=float, default=0.0, help="Current KPI value (default 0)")
+    gla.add_argument("--direction", choices=["increase", "decrease"], default="increase")
+    gla.add_argument("--deadline",  default="", help="ISO date, e.g. 2026-12-31")
+    gla.add_argument("--site",      help="Content-log site key if it differs from --brand")
+
+    gll = glsub.add_parser("list", help="List goals with pace vs deadline")
+    gll.add_argument("--brand", help="Filter by brand id")
+    gll.add_argument("--all",   action="store_true", help="Include non-active goals")
+    gll.add_argument("--json",  action="store_true", help="Machine-readable output")
+
+    glu = glsub.add_parser("update", help="Update a goal's value/target/status")
+    glu.add_argument("id", help="Goal id (goal_xxxxxxxx)")
+    glu.add_argument("--current",  type=float, help="New current KPI value")
+    glu.add_argument("--target",   type=float, help="New target KPI value")
+    glu.add_argument("--deadline", help="New ISO deadline")
+    glu.add_argument("--status",   choices=["active", "achieved", "failed"])
+    glu.add_argument("--name",     help="New goal name")
+
     args = p.parse_args()
     {
         "run":            cmd_run,
@@ -1060,6 +1195,7 @@ def main():
         "intel":          cmd_intel,
         "weekly-report":  cmd_weekly_report,
         "dashboard":      cmd_dashboard,
+        "goals":          cmd_goals,
     }[args.command](args)
 
 

--- a/scripts/harness_config.py
+++ b/scripts/harness_config.py
@@ -283,3 +283,80 @@ def get_config() -> HarnessConfig:
     if _config is None:
         _config = load_config()
     return _config
+
+
+# ── Publishing + calendar path accessors ────────────────────────────────────
+# Appended accessors (kept module-level so they re-read config.yaml/env at call
+# time — tests and long-running agents can flip these without a restart).
+
+
+def get_publishing_config() -> dict:
+    """Return the raw `publishing:` section of config.yaml (empty dict if absent)."""
+    raw = _load_config_yaml().get("publishing") or {}
+    return raw if isinstance(raw, dict) else {}
+
+
+def publishing_enabled() -> bool:
+    """Whether auto-publishing is enabled. Default OFF.
+
+    KAI_PUBLISH_ENABLED env var overrides config.yaml `publishing.enabled`.
+    Accepted truthy values: 1/true/yes/on; falsy: 0/false/no/off.
+    """
+    env = os.environ.get("KAI_PUBLISH_ENABLED", "").strip().lower()
+    if env in ("1", "true", "yes", "on"):
+        return True
+    if env in ("0", "false", "no", "off"):
+        return False
+    return bool(get_publishing_config().get("enabled", False))
+
+
+def get_site_publishing_config(site: str) -> dict:
+    """Per-site publishing target from config.yaml (`publishing.sites.<site>`).
+
+    Returns {} when the site has no publishing target configured. Expected keys:
+    `platform` (wordpress|ghost|webflow|markdown, required to publish) plus any
+    platform kwargs (status, categories, tags, output_dir, ...).
+    """
+    sites = get_publishing_config().get("sites") or {}
+    site_cfg = sites.get(site) or {}
+    return site_cfg if isinstance(site_cfg, dict) else {}
+
+
+def get_content_calendar_path() -> Path:
+    """Path to the content calendar markdown file.
+
+    KAI_CONTENT_CALENDAR_PATH env var overrides; default is
+    <data_dir>/content-calendar.md under the repo data dir.
+    """
+    env = os.environ.get("KAI_CONTENT_CALENDAR_PATH", "").strip()
+    if env:
+        return Path(env)
+    return get_config().data_dir / "content-calendar.md"
+
+
+def get_harness_script() -> Path:
+    """Path to the harness pipeline CLI the Discord handler shells out to.
+
+    KAI_HARNESS_SCRIPT env var overrides; default is
+    ``<cmo_base_dir>/scripts/harness_cli.py`` (repo-relative on a fresh
+    clone — deployed installs point CMO_BASE_DIR at their checkout).
+    Read at call time so tests and long-running agents can redirect it
+    without a restart.
+    """
+    env = os.environ.get("KAI_HARNESS_SCRIPT", "").strip()
+    if env:
+        return Path(env)
+    return get_config().cmo_base_dir / "scripts" / "harness_cli.py"
+
+
+def get_calendar_dir() -> Path:
+    """Directory holding the structured editorial calendar store (JSONL).
+
+    Defaults to ``<data_dir>/calendar`` (i.e. ``data/calendar``).
+    KAI_CALENDAR_DIR env var overrides — read at call time so tests and
+    long-running agents can redirect it without a restart.
+    """
+    env = os.environ.get("KAI_CALENDAR_DIR", "").strip()
+    if env:
+        return Path(env)
+    return get_config().data_dir / "calendar"

--- a/scripts/publish/wordpress.py
+++ b/scripts/publish/wordpress.py
@@ -202,16 +202,69 @@ def publish(
         except Exception:
             pass  # Non-critical — proceed without featured image
 
-    # Create post
+    # Idempotency: if a post with this slug already exists, update it in
+    # place instead of creating a duplicate on re-runs.
+    existing_id = None
+    existing_status = None
+    existing_link = ""
+    if slug:
+        try:
+            lookup = requests.get(
+                f"{site_url}/wp-json/wp/v2/posts",
+                params={"slug": slug, "status": "any"},
+                auth=auth,
+                timeout=10,
+            )
+            if lookup.ok:
+                matches = lookup.json()
+                if isinstance(matches, list) and matches:
+                    existing_id = matches[0].get("id")
+                    existing_status = matches[0].get("status")
+                    existing_link = matches[0].get("link", "")
+        except Exception:
+            existing_id = None  # lookup failure falls back to create
+
+    # Create (or update) post
+    endpoint = f"{site_url}/wp-json/wp/v2/posts"
+    if existing_id:
+        # Approval doctrine: a human may have published (and edited) this post
+        # in WP admin since the draft was created. Overwriting a LIVE post's
+        # content — or demoting it back to draft via the status field — is a
+        # live-channel mutation without approval. Refuse unless the caller
+        # explicitly asked for status=publish (that explicit ask IS the
+        # human approval, e.g. the CLI --publish path).
+        if existing_status == "publish" and status != "publish":
+            return {
+                "success": True,
+                "platform": "wordpress",
+                "id": existing_id,
+                "url": existing_link,
+                "edit_url": f"{site_url}/wp-admin/post.php?post={existing_id}&action=edit",
+                "status": "publish",
+                "updated": False,
+                "skipped": "existing_live_post",
+                "message": (
+                    f"Post with slug '{slug}' is already live — left untouched. "
+                    "Edit or unpublish it in WP admin if you need changes."
+                ),
+            }
+        endpoint = f"{site_url}/wp-json/wp/v2/posts/{existing_id}"
+        if status != "publish":
+            # Preserve the existing post's status on re-runs: never let the
+            # engine's default status=draft demote a post whose status we
+            # could not confirm from the lookup.
+            post_data.pop("status", None)
+
     try:
         resp = requests.post(
-            f"{site_url}/wp-json/wp/v2/posts",
+            endpoint,
             json=post_data,
             auth=auth,
             timeout=30,
         )
         resp.raise_for_status()
         result = resp.json()
+        action = "Updated existing" if existing_id else "Published as"
         return {
             "success": True,
             "platform": "wordpress",
@@ -219,7 +272,8 @@ def publish(
             "url": result.get("link", ""),
             "edit_url": f"{site_url}/wp-admin/post.php?post={result.get('id')}&action=edit",
             "status": result.get("status"),
-            "message": f"Published as {result.get('status')} — {result.get('link', '')}",
+            "updated": bool(existing_id),
+            "message": f"{action} {result.get('status')} — {result.get('link', '')}",
         }
     except requests.HTTPError as e:
         error_body = ""

--- a/scripts/reporting/ceo_deck.py
+++ b/scripts/reporting/ceo_deck.py
@@ -26,6 +26,14 @@ load_dotenv()
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
+# Allow direct invocation (python3 scripts/reporting/ceo_deck.py) from any cwd.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# performance_30d drifted across writers (dict | legacy str | None) — always
+# read grades through this helper (see scripts/self_improvement/grades.py).
+from scripts.self_improvement.grades import get_grade  # noqa: E402
+
 
 def _load_config() -> dict:
     config_path = REPO_ROOT / "config.yaml"
@@ -54,7 +62,7 @@ def _gather_data(site_key: str) -> dict:
     if content_log.exists():
         log = json.loads(content_log.read_text())
         data["content_total"] = len(log)
-        data["content_winners"] = len([e for e in log if e.get("performance_30d", {}).get("grade") == "winner"])
+        data["content_winners"] = len([e for e in log if get_grade(e) == "winner"])
     else:
         data["content_total"] = 0
         data["content_winners"] = 0

--- a/scripts/reporting/weekly_report.py
+++ b/scripts/reporting/weekly_report.py
@@ -31,6 +31,14 @@ DATA_DIR = REPO_ROOT / "data"
 INTEL_DIR = DATA_DIR / "intel"
 CONTENT_LOG = DATA_DIR / "content_log.json"
 
+# Allow direct invocation (python3 scripts/reporting/weekly_report.py) from any cwd.
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# performance_30d drifted across writers (dict | legacy str | None) — always
+# read grades through this helper (see scripts/self_improvement/grades.py).
+from scripts.self_improvement.grades import get_grade  # noqa: E402
+
 
 def _load_config() -> dict:
     config_path = REPO_ROOT / "config.yaml"
@@ -99,7 +107,7 @@ def gather_content_data() -> dict:
 
     log = json.loads(CONTENT_LOG.read_text())
     this_week = [e for e in log if e.get("created", "") > datetime.now(timezone.utc).strftime("%Y-%m-%d")]
-    winners = [e for e in log if e.get("performance_30d", {}).get("grade") == "winner"]
+    winners = [e for e in log if get_grade(e) == "winner"]
 
     return {
         "available": True,

--- a/scripts/self_improvement/grades.py
+++ b/scripts/self_improvement/grades.py
@@ -1,0 +1,60 @@
+"""Shared grade/schema helpers for the learning loop.
+
+``performance_30d`` has drifted across writers over time:
+
+  - dict ``{"gsc": ..., "ga4": ..., "grade": ..., "checked_at": ...}``
+    (current schema, written by performance_check.py)
+  - bare string grade (legacy readers/writers stored just the grade)
+  - ``None`` / missing (not yet measured)
+
+The grade vocabulary is ``winner | average | underperformer`` — the bottom
+grade is "underperformer" everywhere. Some legacy entries used "loser";
+normalize it here so readers never have to know it existed.
+
+Publish timestamps drifted the same way: the content log writes
+``published_at``, but some legacy entries carry ``publish_date``.
+
+Every reader of the content log should go through these helpers instead of
+poking at the raw fields.
+"""
+
+from __future__ import annotations
+
+GRADE_WINNER = "winner"
+GRADE_AVERAGE = "average"
+GRADE_UNDERPERFORMER = "underperformer"
+
+_LEGACY_GRADE_ALIASES = {"loser": GRADE_UNDERPERFORMER}
+
+
+def get_grade(entry) -> str | None:
+    """Return the 30-day grade for a content-log entry, or None if ungraded.
+
+    Tolerates ``performance_30d`` as a dict (current schema), a bare string
+    (legacy), or None/missing. Normalizes the legacy "loser" grade to
+    "underperformer".
+    """
+    if not isinstance(entry, dict):
+        return None
+    perf = entry.get("performance_30d")
+    if isinstance(perf, dict):
+        grade = perf.get("grade")
+    elif isinstance(perf, str):
+        grade = perf
+    else:
+        return None
+    if not grade or not isinstance(grade, str):
+        return None
+    grade = grade.strip().lower()
+    return _LEGACY_GRADE_ALIASES.get(grade, grade)
+
+
+def get_published_at(entry) -> str | None:
+    """Return the publish timestamp for a content-log entry, or None.
+
+    Prefers ``published_at`` (current field) with fallback to the legacy
+    ``publish_date`` field.
+    """
+    if not isinstance(entry, dict):
+        return None
+    return entry.get("published_at") or entry.get("publish_date") or None

--- a/scripts/self_improvement/lesson_capture.py
+++ b/scripts/self_improvement/lesson_capture.py
@@ -12,8 +12,9 @@ Three commands:
          at least --min-count times. --write appends them to
          memory/lessons.md as (candidate) entries.
 
-  losers Read the content log and list published pieces graded "loser"
-         that are not yet diagnosed in memory/what-doesnt-work.md.
+  losers Read the content log and list published pieces graded
+         "underperformer" (the bottom 30-day grade) that are not yet
+         diagnosed in memory/what-doesnt-work.md.
 
 Usage:
   python scripts/self_improvement/lesson_capture.py add \
@@ -39,6 +40,15 @@ from datetime import date
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.self_improvement.grades import (  # noqa: E402
+    GRADE_UNDERPERFORMER,
+    get_grade,
+    get_published_at,
+)
+
 LESSONS_PATH = REPO_ROOT / "memory" / "lessons.md"
 ANTIPATTERNS_PATH = REPO_ROOT / "memory" / "what-doesnt-work.md"
 LEARNED_HEADER = "## Learned lessons"
@@ -223,22 +233,27 @@ def cmd_losers(args: argparse.Namespace) -> int:
         e
         for e in entries
         if isinstance(e, dict)
-        and (e.get("performance_30d") or {}).get("grade") == "loser"
+        and get_grade(e) == GRADE_UNDERPERFORMER
         and str(e.get("id", "")) not in diagnosed
     ]
     if not losers:
-        print("No undiagnosed losers in the content log.")
+        print("No undiagnosed underperformers in the content log.")
         return 0
 
-    print(f"{len(losers)} published piece(s) graded 'loser' with no diagnosis yet:\n")
+    print(f"{len(losers)} published piece(s) graded 'underperformer' with no diagnosis yet:\n")
     for e in losers:
-        perf = e.get("performance_30d", {})
+        perf = e.get("performance_30d")
+        gsc = perf.get("gsc", {}) if isinstance(perf, dict) else {}
         print(
             f"  id={e.get('id')} format={e.get('format')} keyword={e.get('keyword')!r} "
-            f"published={e.get('publish_date')} perf={json.dumps(perf.get('gsc', {}))}"
+            f"published={get_published_at(e)} perf={json.dumps(gsc)}"
         )
+    try:
+        antipatterns_display = ANTIPATTERNS_PATH.relative_to(REPO_ROOT)
+    except ValueError:
+        antipatterns_display = ANTIPATTERNS_PATH
     print(
-        f"\nDiagnose each and add an entry to {ANTIPATTERNS_PATH.relative_to(REPO_ROOT)} "
+        f"\nDiagnose each and add an entry to {antipatterns_display} "
         "under 'Measured losers' (include the id so it isn't re-flagged)."
     )
     return 0
@@ -260,7 +275,9 @@ def main() -> int:
     p_mine.add_argument("--write", action="store_true", help="Append candidates to lessons.md")
     p_mine.set_defaults(func=cmd_mine)
 
-    p_losers = sub.add_parser("losers", help="List undiagnosed losers from the content log")
+    p_losers = sub.add_parser(
+        "losers", help="List undiagnosed underperformers from the content log"
+    )
     p_losers.set_defaults(func=cmd_losers)
 
     args = parser.parse_args()

--- a/scripts/self_improvement/pattern_extract.py
+++ b/scripts/self_improvement/pattern_extract.py
@@ -26,6 +26,7 @@ from google import genai as google_genai
 
 # Use centralized config
 from scripts.harness_config import get_config
+from scripts.self_improvement.grades import get_grade
 
 _CFG = get_config()
 
@@ -84,12 +85,12 @@ def is_winner(entry: dict) -> bool:
 
     # Social content: check social_metrics directly
     if platform in ("tiktok", "instagram") and entry.get("social_metrics"):
-        perf = entry.get("performance_30d", {})
-        return perf.get("grade") == "winner"
+        return get_grade(entry) == "winner"
 
-    # Web content: check GSC/GA4
+    # Web content: check GSC/GA4. performance_30d can be a legacy string
+    # grade (see scripts/self_improvement/grades.py) — never assume dict.
     perf = entry.get("performance_30d")
-    if not perf:
+    if not isinstance(perf, dict):
         return False
     gsc = perf.get("gsc", {})
     ga4 = perf.get("ga4", {})
@@ -107,7 +108,9 @@ def is_winner(entry: dict) -> bool:
 def analyze_winner(entry: dict) -> str:
     """Use Gemini to extract what made this piece win."""
     platform = entry.get("platform", "web")
-    perf = entry.get("performance_30d", {})
+    perf = entry.get("performance_30d")
+    if not isinstance(perf, dict):
+        perf = {}  # legacy string grade or unmeasured — no sub-metrics
 
     # Build performance section based on platform type
     if platform in ("tiktok", "instagram") and entry.get("social_metrics"):

--- a/scripts/self_improvement/performance_check.py
+++ b/scripts/self_improvement/performance_check.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 # Use centralized config
 from scripts.harness_config import get_config
+from scripts.self_improvement.grades import get_grade
 
 _CFG = get_config()
 
@@ -80,7 +81,10 @@ def reconcile_pending_checks(dry_run: bool = False) -> int:
         if entry.get("performance_30d"):
             continue  # already measured
         if not (entry.get("url") and entry.get("keyword") and entry.get("site")):
-            continue  # not checkable (e.g. social entries graded separately)
+            # Not checkable: social entries are graded separately, and
+            # approved-but-unpublished entries carry url=None — never
+            # schedule a GSC/GA4 pull for either.
+            continue
         check_file = checks_dir / f"{entry['id']}.json"
         if check_file.exists():
             continue
@@ -122,6 +126,10 @@ def get_pending_checks() -> list:
     for f in Path(PENDING_CHECKS_DIR).glob("*.json"):
         with open(f) as fh:
             check = json.load(fh)
+        if not check.get("url"):
+            # Approved-but-unpublished entries carry url=None — there is no
+            # live page to measure, so never schedule a GSC/GA4 pull for them.
+            continue
         due = datetime.fromisoformat(check["check_due"])
         if check["status"] == "pending" and due <= now:
             checks.append((f, check))
@@ -502,8 +510,8 @@ def check_social_entries(dry_run: bool = False) -> list:
             continue
         if not entry.get("social_metrics"):
             continue
-        # Skip if already graded
-        if entry.get("performance_30d", {}).get("grade"):
+        # Skip if already graded (tolerates legacy string-form performance_30d)
+        if get_grade(entry):
             continue
 
         evaluation = evaluate_social_performance(entry)

--- a/tests/test_campaign_identity.py
+++ b/tests/test_campaign_identity.py
@@ -1,0 +1,609 @@
+"""Campaign identity + unified content log tests (Workstream D).
+
+Covers:
+  - campaign_id minting (cmp-YYYYMMDD-<slug>) and the planner --save flow:
+    manifest.json carries the id, a campaign_tracker row is auto-created,
+    and a campaign_plan artifact (the declared-but-never-used type in
+    kai/runtime/models.py) is recorded in the RuntimeStore.
+  - campaign_id threading: engine.generate(campaign_id=...) ->
+    content_log.log_entry -> data/pending_checks/<id>.json.
+  - migrate_legacy_log: ~/.kai-marketing/content-log.jsonl folded into the
+    canonical data/content_log.json (publish_date -> published_at, dedupe by
+    id/url, performance preserved, idempotent re-runs).
+  - gateway job retention: 45-day configurable default that floors legacy
+    days=7 callers so learning-loop lineage survives past the 30-day check.
+"""
+
+import asyncio
+import json
+import re
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import scripts.campaigns.campaign_planner as planner
+import scripts.campaigns.campaign_tracker as tracker
+import scripts.content.content_log as cl
+from scripts.content.content_log import (
+    compute_content_hash,
+    load_log,
+    log_entry,
+    mark_published,
+)
+from scripts.content.migrate_legacy_log import migrate, normalize_legacy_entry
+
+BODY = "Rodriguez Air missed 19 calls a week between 6pm and 8am. Each cost $410."
+
+CAMPAIGN_ID_RE = re.compile(r"^cmp-\d{8}-[a-z0-9-]+$")
+
+
+@pytest.fixture()
+def sandbox(tmp_path, monkeypatch):
+    """Isolate content log, pending checks, and calendar under tmp_path."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    log_file = data_dir / "content_log.json"
+    calendar = data_dir / "content-calendar.md"
+    monkeypatch.setattr(cl._CFG, "data_dir", data_dir)
+    monkeypatch.setattr(cl, "LOG_FILE", str(log_file))
+    monkeypatch.setenv("KAI_CONTENT_CALENDAR_PATH", str(calendar))
+    monkeypatch.delenv("KAI_PUBLISH_ENABLED", raising=False)
+    monkeypatch.setenv("CMO_CONFIG_PATH", str(tmp_path / "no-such-config.yaml"))
+    return {
+        "data_dir": data_dir,
+        "log_file": str(log_file),
+        "checks_dir": data_dir / "pending_checks",
+        "calendar": calendar,
+    }
+
+
+def _checks(sandbox) -> list[Path]:
+    checks_dir = sandbox["checks_dir"]
+    return sorted(checks_dir.glob("*.json")) if checks_dir.exists() else []
+
+
+# ---------------------------------------------------------------------------
+# campaign_id minting
+# ---------------------------------------------------------------------------
+
+
+class TestMintCampaignId:
+    def test_format(self):
+        cid = planner.mint_campaign_id("Q3 Product Launch!", "ai receptionist")
+        assert CAMPAIGN_ID_RE.match(cid)
+        assert cid.endswith("-q3-product-launch")
+
+    def test_date_prefix_uses_when(self):
+        when = datetime(2026, 7, 5, tzinfo=timezone.utc)
+        cid = planner.mint_campaign_id("Launch", when=when)
+        assert cid == "cmp-20260705-launch"
+
+    def test_falls_back_to_keyword_then_placeholder(self):
+        when = datetime(2026, 7, 5, tzinfo=timezone.utc)
+        assert planner.mint_campaign_id("", "AI CRM", when=when) == "cmp-20260705-ai-crm"
+        assert planner.mint_campaign_id("", "", when=when) == "cmp-20260705-campaign"
+
+
+# ---------------------------------------------------------------------------
+# planner --save: manifest + tracker row + campaign_plan artifact
+# ---------------------------------------------------------------------------
+
+
+class TestPlannerSaveFlow:
+    @pytest.fixture()
+    def campaign_env(self, tmp_path, monkeypatch):
+        # Never hit Gemini.
+        monkeypatch.setattr(planner, "_gemini", lambda prompt: "stub asset content")
+        # Tracker DB isolated.
+        monkeypatch.setattr(tracker, "DATA_DIR", tmp_path / "campaigns-db")
+        monkeypatch.setattr(tracker, "DB_PATH", tmp_path / "campaigns-db" / "campaigns.db")
+        # Runtime store isolated.
+        from kai.runtime.store import RuntimeStore
+
+        store = RuntimeStore(base_dir=tmp_path / "runtime")
+        monkeypatch.setattr("kai.runtime.get_default_runtime_store", lambda: store)
+        return {"tmp": tmp_path, "store": store}
+
+    def test_save_writes_manifest_tracker_and_artifact(self, campaign_env):
+        save_dir = campaign_env["tmp"] / "camp"
+        planner.generate_campaign(
+            goal="Q3 Launch",
+            product_id="kaicalls",
+            keyword="ai receptionist",
+            campaign_type="launch",
+            save_dir=str(save_dir),
+        )
+
+        manifest = json.loads((save_dir / "manifest.json").read_text())
+        cid = manifest["campaign_id"]
+        assert CAMPAIGN_ID_RE.match(cid)
+
+        # Tracker row auto-created and joinable by campaign_id.
+        row = tracker.find_campaign(cid)
+        assert row is not None
+        assert row["campaign_id"] == cid
+        assert row["name"] == cid
+        assert row["product"] == "kaicalls"
+        assert row["goal"] == "Q3 Launch"
+
+        # campaign_plan artifact recorded with the id in its data payload.
+        artifacts = [
+            json.loads(p.read_text())
+            for p in (campaign_env["tmp"] / "runtime" / "artifacts").glob("*.json")
+        ]
+        plans = [a for a in artifacts if a["artifact_type"] == "campaign_plan"]
+        assert len(plans) == 1
+        assert plans[0]["data"]["campaign_id"] == cid
+        assert plans[0]["brand_id"] == "kaicalls"
+        assert plans[0]["data"]["manifest"]["goal"] == "Q3 Launch"
+
+    def test_explicit_campaign_id_is_respected(self, campaign_env):
+        save_dir = campaign_env["tmp"] / "camp2"
+        planner.generate_campaign(
+            goal="Q3 Launch",
+            product_id="kaicalls",
+            keyword="ai receptionist",
+            campaign_type="awareness",
+            save_dir=str(save_dir),
+            campaign_id="cmp-20260701-custom",
+        )
+        manifest = json.loads((save_dir / "manifest.json").read_text())
+        assert manifest["campaign_id"] == "cmp-20260701-custom"
+        assert tracker.find_campaign("cmp-20260701-custom") is not None
+
+    def test_no_save_still_mints_but_writes_nothing(self, campaign_env, tmp_path):
+        planner.generate_campaign(
+            goal="Ad-hoc",
+            product_id="kaicalls",
+            keyword="k",
+            campaign_type="awareness",
+            save_dir=None,
+        )
+        assert tracker.find_campaign("cmp-nonexistent") is None
+        assert not (tmp_path / "runtime" / "artifacts").exists() or not list(
+            (tmp_path / "runtime" / "artifacts").glob("*.json")
+        )
+
+    def test_tracker_backfills_campaign_id_on_existing_row(self, campaign_env):
+        tracker.create_campaign("legacy-name")
+        tracker.create_campaign("legacy-name", campaign_id="cmp-20260705-late")
+        row = tracker.find_campaign("cmp-20260705-late")
+        assert row is not None and row["name"] == "legacy-name"
+
+    def test_tracker_migrates_legacy_db_schema(self, campaign_env):
+        # Simulate a pre-campaign_id database.
+        tracker.DATA_DIR.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(tracker.DB_PATH))
+        conn.execute("DROP TABLE IF EXISTS campaigns")
+        conn.execute(
+            "CREATE TABLE campaigns (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "name TEXT UNIQUE NOT NULL, campaign_type TEXT, goal TEXT, product TEXT, "
+            "keyword TEXT, start_date TEXT, end_date TEXT, status TEXT DEFAULT 'active', "
+            "assets_dir TEXT, created_at TEXT DEFAULT (datetime('now')))"
+        )
+        conn.execute("INSERT INTO campaigns (name) VALUES ('old-row')")
+        conn.commit()
+        conn.close()
+
+        tracker.create_campaign("new-row", campaign_id="cmp-20260705-new")
+        row = tracker.find_campaign("cmp-20260705-new")
+        assert row is not None
+        # Old row survives the ALTER with a NULL campaign_id.
+        conn = sqlite3.connect(str(tracker.DB_PATH))
+        old = conn.execute(
+            "SELECT campaign_id FROM campaigns WHERE name = 'old-row'"
+        ).fetchone()
+        conn.close()
+        assert old == (None,)
+
+
+# ---------------------------------------------------------------------------
+# content_log threading
+# ---------------------------------------------------------------------------
+
+
+class TestContentLogCampaignId:
+    def test_entry_and_pending_check_carry_campaign_id(self, sandbox):
+        entry = log_entry(
+            url="https://kaicalls.com/blog/x",
+            keyword="k",
+            site="kaicalls",
+            format="blog",
+            content_hash=compute_content_hash(BODY),
+            campaign_id="cmp-20260705-q3-launch",
+            log_file=sandbox["log_file"],
+        )
+        assert entry["campaign_id"] == "cmp-20260705-q3-launch"
+        check = json.loads(_checks(sandbox)[0].read_text())
+        assert check["campaign_id"] == "cmp-20260705-q3-launch"
+
+    def test_mark_published_preserves_campaign_id_into_check(self, sandbox):
+        entry = log_entry(
+            url=None,
+            keyword="k",
+            site="kaicalls",
+            format="blog",
+            content_hash=compute_content_hash(BODY),
+            campaign_id="cmp-20260705-q3-launch",
+            log_file=sandbox["log_file"],
+        )
+        assert _checks(sandbox) == []
+        mark_published(entry["id"], "https://kaicalls.com/blog/live", log_file=sandbox["log_file"])
+        check = json.loads(_checks(sandbox)[0].read_text())
+        assert check["campaign_id"] == "cmp-20260705-q3-launch"
+
+    def test_dedup_update_attaches_campaign_id(self, sandbox):
+        content_hash = compute_content_hash(BODY)
+        log_entry(
+            url=None, keyword="k", site="kaicalls", format="blog",
+            content_hash=content_hash, log_file=sandbox["log_file"],
+        )
+        log_entry(
+            url=None, keyword="k", site="kaicalls", format="blog",
+            content_hash=content_hash, campaign_id="cmp-20260705-late-join",
+            log_file=sandbox["log_file"],
+        )
+        entries = load_log(sandbox["log_file"])
+        assert len(entries) == 1
+        assert entries[0]["campaign_id"] == "cmp-20260705-late-join"
+
+    def test_absent_campaign_id_stays_none(self, sandbox):
+        entry = log_entry(
+            url=None, keyword="k", site="kaicalls", format="blog",
+            content_hash=compute_content_hash(BODY), log_file=sandbox["log_file"],
+        )
+        assert entry["campaign_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# engine threading (mocked run — no Gemini, no publishing)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBrand:
+    id = "kaicalls"
+    module_ids: list = []
+
+    def model_dump(self):
+        return {"id": "kaicalls", "module_ids": []}
+
+
+class _FakeWorkspace:
+    product_mode = "local"
+    brands = [_FakeBrand()]
+
+    def get_brand(self, site):
+        return _FakeBrand() if site == "kaicalls" else None
+
+    def model_dump(self):
+        return {"product_mode": "local"}
+
+
+class _FakeStore:
+    def __init__(self):
+        self.runs: dict = {}
+        self.artifacts: list = []
+        self.completed: list = []
+        self.base_dir = Path("/nonexistent-runtime")
+
+    def start_run(self, payload, parent_run_id=None, run_id=None):
+        rid = run_id or "run-test"
+        self.runs[rid] = payload
+        return {"run_id": rid}
+
+    def record_artifact(self, record, run_id=None, parent_artifact_id=None):
+        rec = dict(record)
+        rec["artifact_id"] = f"art-{len(self.artifacts)}"
+        self.artifacts.append(rec)
+        return rec
+
+    def complete_run(self, run_id, status="completed", outputs=None, metadata=None):
+        self.completed.append({"run_id": run_id, "status": status, "outputs": outputs})
+
+
+class TestEngineCampaignThreading:
+    @pytest.fixture()
+    def engine_env(self, sandbox, monkeypatch):
+        import scripts.content.engine as engine
+
+        fake_store = _FakeStore()
+        monkeypatch.setattr(engine, "load_workspace_profile", lambda: _FakeWorkspace())
+        monkeypatch.setattr(engine, "get_default_runtime_store", lambda: fake_store)
+        monkeypatch.setattr(engine, "load_module_manifests", lambda: {})
+        monkeypatch.setattr(engine, "retrieve_memory_entries", lambda *a, **k: [])
+        monkeypatch.setattr(engine, "_make_gemini_fn", lambda: (lambda prompt: "x"))
+        monkeypatch.setattr(engine, "write_content", lambda prompt, fn: BODY)
+        monkeypatch.setattr(engine, "resolve_policy", lambda fmt, site: {"mode": "auto"})
+        monkeypatch.setattr(engine, "apply_approval", lambda status, policy: "approved")
+
+        async def fake_brief(**kwargs):
+            return {"persona": "Shock Absorber", "angle": "Missed calls cost $410"}
+
+        monkeypatch.setattr(engine.brief_generator, "generate_brief", fake_brief)
+
+        async def fake_propose(content, file_path, policy_name):
+            return {
+                "proposal_id": "prop-1",
+                "score": 14,
+                "grade": "A",
+                "status": "approved",
+                "top_fixes": [],
+                "violation_count": 0,
+            }
+
+        monkeypatch.setattr("scripts.quality.gate.propose", fake_propose)
+        return {"engine": engine, "store": fake_store}
+
+    def test_campaign_id_reaches_run_log_and_metadata(self, engine_env, sandbox):
+        engine = engine_env["engine"]
+        result = asyncio.run(
+            engine.generate(
+                "blog", "kaicalls", "ai receptionist",
+                campaign_id="cmp-20260705-q3-launch",
+            )
+        )
+        assert result.status == "approved"
+        assert result.metadata["campaign_id"] == "cmp-20260705-q3-launch"
+
+        # Run inputs carry the id.
+        run_payload = engine_env["store"].runs["run-test"]
+        assert run_payload["inputs"]["campaign_id"] == "cmp-20260705-q3-launch"
+
+        # Canonical log entry carries the id; publishing disabled -> no URL,
+        # no fabricated pending check.
+        entries = load_log(sandbox["log_file"])
+        assert len(entries) == 1
+        assert entries[0]["campaign_id"] == "cmp-20260705-q3-launch"
+        assert entries[0]["url"] is None
+        assert entries[0]["status"] == "approved_unpublished"
+        assert _checks(sandbox) == []
+
+    def test_campaign_id_defaults_to_none(self, engine_env, sandbox):
+        engine = engine_env["engine"]
+        result = asyncio.run(engine.generate("blog", "kaicalls", "ai receptionist"))
+        assert result.metadata["campaign_id"] is None
+        entries = load_log(sandbox["log_file"])
+        assert entries[0]["campaign_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# legacy log migration
+# ---------------------------------------------------------------------------
+
+
+LEGACY_WINNER = {
+    "id": "kaicalls-blog-20260316",
+    "site": "kaicalls",
+    "keyword": "ai receptionists",
+    "format": "blog",
+    "publish_date": "2026-03-16",
+    "four_us_score": 14,
+    "hook_type": "data",
+    "persona": "Shock Absorber",
+    "draft_path": "~/.kai-marketing/drafts/2026-03-16-ai.md",
+    "performance_30d": {"grade": "winner", "position": 3},
+    "url": "https://kaicalls.com/blog/ai-receptionists",
+}
+
+LEGACY_DRAFT_ONLY = {
+    "id": "abp-linkedin-20260401",
+    "site": "abp",
+    "keyword": "backyard design",
+    "format": "linkedin",
+    "publish_date": "2026-04-01",
+    "four_us_score": 11,
+    "performance_30d": None,
+}
+
+
+class TestLegacyLogMigration:
+    def _write_legacy(self, tmp_path, entries, extra_lines=()):
+        legacy = tmp_path / "content-log.jsonl"
+        lines = [json.dumps(e) for e in entries]
+        lines.extend(extra_lines)
+        legacy.write_text("\n".join(lines) + "\n")
+        return legacy
+
+    def test_merge_maps_fields_and_grades_survive(self, sandbox, tmp_path):
+        legacy = self._write_legacy(
+            tmp_path,
+            [LEGACY_WINNER, LEGACY_DRAFT_ONLY],
+            extra_lines=["{not json", json.dumps({"keyword": "no id or url"})],
+        )
+        summary = migrate(legacy_path=legacy, log_file=sandbox["log_file"])
+        assert summary["added"] == 2
+        assert summary["skipped_invalid"] == 1
+
+        entries = {e["id"]: e for e in load_log(sandbox["log_file"])}
+        winner = entries["kaicalls-blog-20260316"]
+        assert winner["published_at"] == "2026-03-16"  # publish_date mapped
+        assert "publish_date" not in winner
+        assert winner["performance_30d"] == {"grade": "winner", "position": 3}
+        assert winner["status"] == "published"
+        assert winner["hook_type"] == "data"
+        assert winner["migrated_from"] == "kai-marketing-jsonl"
+
+        draft = entries["abp-linkedin-20260401"]
+        assert draft["url"] is None
+        assert draft["status"] == "approved_unpublished"
+
+    def test_idempotent_rerun_changes_nothing(self, sandbox, tmp_path):
+        legacy = self._write_legacy(tmp_path, [LEGACY_WINNER, LEGACY_DRAFT_ONLY])
+        migrate(legacy_path=legacy, log_file=sandbox["log_file"])
+        before = Path(sandbox["log_file"]).read_text()
+        summary = migrate(legacy_path=legacy, log_file=sandbox["log_file"])
+        assert summary["added"] == 0
+        assert summary["updated"] == 0
+        assert summary["unchanged"] == 2
+        assert Path(sandbox["log_file"]).read_text() == before
+
+    def test_dedupe_by_url_and_performance_backfill(self, sandbox, tmp_path):
+        # Canonical already tracks the same URL under a different id with no
+        # performance data — migration must NOT duplicate, only backfill.
+        canonical = [{
+            "id": "kaicalls-20260316-090000",
+            "url": "https://kaicalls.com/blog/ai-receptionists",
+            "keyword": "ai receptionists",
+            "site": "kaicalls",
+            "format": "blog",
+            "published_at": "2026-03-16T09:00:00+00:00",
+            "performance_30d": None,
+            "status": "published",
+        }]
+        Path(sandbox["log_file"]).write_text(json.dumps(canonical))
+        legacy = self._write_legacy(tmp_path, [LEGACY_WINNER])
+
+        summary = migrate(legacy_path=legacy, log_file=sandbox["log_file"])
+        assert summary["added"] == 0
+        assert summary["updated"] == 1
+
+        entries = load_log(sandbox["log_file"])
+        assert len(entries) == 1
+        assert entries[0]["id"] == "kaicalls-20260316-090000"  # canonical id kept
+        assert entries[0]["performance_30d"]["grade"] == "winner"
+        assert entries[0]["published_at"] == "2026-03-16T09:00:00+00:00"  # not clobbered
+
+    def test_dry_run_writes_nothing(self, sandbox, tmp_path):
+        legacy = self._write_legacy(tmp_path, [LEGACY_WINNER])
+        summary = migrate(legacy_path=legacy, log_file=sandbox["log_file"], dry_run=True)
+        assert summary["added"] == 1
+        assert not Path(sandbox["log_file"]).exists()
+
+    def test_missing_legacy_file_is_noop(self, sandbox, tmp_path):
+        summary = migrate(
+            legacy_path=tmp_path / "nope.jsonl", log_file=sandbox["log_file"]
+        )
+        assert summary["legacy_total"] == 0
+        assert summary["added"] == 0
+
+    def test_normalize_entry_without_key_is_rejected(self):
+        assert normalize_legacy_entry({"keyword": "x"}) is None
+
+    def test_string_grades_normalized_to_dict_schema(self, sandbox, tmp_path):
+        """Legacy STRING-form grades must land in the canonical log as the
+        dict schema — canonical readers (pattern_extract.is_winner,
+        weekly_report, ceo_deck) crash on a bare str."""
+        legacy = self._write_legacy(tmp_path, [
+            {**LEGACY_WINNER, "performance_30d": "winner"},
+            {**LEGACY_DRAFT_ONLY, "id": "abp-str-loser",
+             "url": "https://abp.com/blog/x", "performance_30d": "loser"},
+        ])
+        migrate(legacy_path=legacy, log_file=sandbox["log_file"])
+
+        entries = {e["id"]: e for e in load_log(sandbox["log_file"])}
+        winner = entries["kaicalls-blog-20260316"]
+        assert winner["performance_30d"] == {"grade": "winner", "migrated": True}
+        loser = entries["abp-str-loser"]
+        # Legacy "loser" vocabulary normalizes to "underperformer".
+        assert loser["performance_30d"] == {"grade": "underperformer", "migrated": True}
+
+        # is_winner must tolerate the migrated entries without AttributeError.
+        from scripts.self_improvement.grades import get_grade
+        assert get_grade(winner) == "winner"
+        assert get_grade(loser) == "underperformer"
+
+    def test_rerun_heals_canonical_string_grade(self, sandbox, tmp_path):
+        """A canonical log poisoned by an earlier merge (string grade) is
+        healed to the dict schema when the migration re-runs."""
+        canonical = [{
+            "id": "kaicalls-blog-20260316",
+            "url": "https://kaicalls.com/blog/ai-receptionists",
+            "keyword": "ai receptionists",
+            "site": "kaicalls",
+            "format": "blog",
+            "published_at": "2026-03-16T09:00:00+00:00",
+            "performance_30d": "winner",
+            "status": "published",
+        }]
+        Path(sandbox["log_file"]).write_text(json.dumps(canonical))
+        legacy = self._write_legacy(tmp_path, [LEGACY_WINNER])
+
+        summary = migrate(legacy_path=legacy, log_file=sandbox["log_file"])
+        assert summary["added"] == 0
+        assert summary["updated"] == 1
+        entries = load_log(sandbox["log_file"])
+        assert len(entries) == 1
+        assert entries[0]["performance_30d"] == {"grade": "winner", "migrated": True}
+
+    def test_migration_never_schedules_pending_checks(self, sandbox, tmp_path):
+        legacy = self._write_legacy(tmp_path, [LEGACY_WINNER])
+        migrate(legacy_path=legacy, log_file=sandbox["log_file"])
+        # Checks are reconcile_pending_checks' job (EC-12), not the migration's.
+        assert _checks(sandbox) == []
+
+
+# ---------------------------------------------------------------------------
+# gateway job retention
+# ---------------------------------------------------------------------------
+
+
+class TestJobRetention:
+    @pytest.fixture()
+    def queue(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("KAI_JOB_RETENTION_DAYS", raising=False)
+        from gateway.jobs import JobQueue
+
+        q = JobQueue(db_path=tmp_path / "jobs.db", max_workers=1)
+        yield q
+        q.shutdown()
+
+    def _age_job(self, queue, job_id, days_old):
+        stamp = (datetime.utcnow() - timedelta(days=days_old)).isoformat()
+        with sqlite3.connect(queue.db_path) as conn:
+            conn.execute("UPDATE jobs SET created_at = ? WHERE job_id = ?", (stamp, job_id))
+            conn.execute("UPDATE runs SET created_at = ? WHERE job_id = ?", (stamp, job_id))
+            conn.commit()
+
+    def _job_ids(self, queue):
+        with sqlite3.connect(queue.db_path) as conn:
+            return {row[0] for row in conn.execute("SELECT job_id FROM jobs")}
+
+    def test_default_retention_is_45_days(self, queue):
+        fresh = queue.create_job("cmd", client="c")
+        mid = queue.create_job("cmd", client="c")
+        old = queue.create_job("cmd", client="c")
+        self._age_job(queue, mid, 40)   # inside the 30-day learning window's buffer
+        self._age_job(queue, old, 50)
+
+        queue.cleanup_old_jobs()
+        ids = self._job_ids(queue)
+        assert fresh in ids
+        assert mid in ids       # 40 days < 45 — must survive
+        assert old not in ids   # 50 days > 45 — deleted
+        # Run rows follow the same retention.
+        with sqlite3.connect(queue.db_path) as conn:
+            runs = {row[0] for row in conn.execute("SELECT job_id FROM runs")}
+        assert old not in runs and mid in runs
+
+    def test_legacy_days_7_caller_is_floored(self, queue):
+        mid = queue.create_job("cmd", client="c")
+        self._age_job(queue, mid, 40)
+        # gateway/main.py still calls cleanup_old_jobs(days=7) — the configured
+        # retention (45) is a floor, so the 40-day job must survive.
+        queue.cleanup_old_jobs(days=7)
+        assert mid in self._job_ids(queue)
+
+    def test_explicit_longer_window_is_honored(self, queue):
+        old = queue.create_job("cmd", client="c")
+        self._age_job(queue, old, 50)
+        queue.cleanup_old_jobs(days=90)
+        assert old in self._job_ids(queue)
+
+    def test_env_override_shortens_retention(self, queue, monkeypatch):
+        monkeypatch.setenv("KAI_JOB_RETENTION_DAYS", "7")
+        mid = queue.create_job("cmd", client="c")
+        self._age_job(queue, mid, 10)
+        queue.cleanup_old_jobs()
+        assert mid not in self._job_ids(queue)
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        from gateway.jobs import DEFAULT_JOB_RETENTION_DAYS, get_job_retention_days
+
+        monkeypatch.setenv("KAI_JOB_RETENTION_DAYS", "banana")
+        assert get_job_retention_days() == DEFAULT_JOB_RETENTION_DAYS
+        monkeypatch.setenv("KAI_JOB_RETENTION_DAYS", "-3")
+        assert get_job_retention_days() == DEFAULT_JOB_RETENTION_DAYS
+        monkeypatch.setenv("KAI_JOB_RETENTION_DAYS", "60")
+        assert get_job_retention_days() == 60

--- a/tests/test_cmo_review.py
+++ b/tests/test_cmo_review.py
@@ -1,0 +1,534 @@
+"""Tests for Workstream E — the closed goal loop.
+
+Covers:
+- goals CLI round-trip (kai-harness goals add|list|update)
+- pace helpers in kai/runtime/goals.py
+- CMOReviewTask: KPI refresh from the content log (data gaps never zeroed),
+  graph creation only for behind-pace goals without active graphs,
+  needs_replan re-decomposition with failure context, snapshot writing,
+  and graceful no-LLM degradation
+- scheduler seeding of the Weekly CMO Review task
+- agent loop: needs_replan preserved by _update_graph_status_if_done
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import agent.models
+from agent.models import AgentDatabase
+from agent.scheduler import Scheduler
+from agent.tasks import get_task_handler
+from agent.tasks.cmo_review import CMOReviewTask, LLM_KEY_ENV_VARS
+from kai.runtime.goals import (
+    GoalRegistry,
+    compute_goal_pace,
+    is_goal_achieved,
+    parse_goal_datetime,
+)
+from kai.runtime.models import KaiGoal, TaskGraph, TaskNode
+
+
+def _utc(offset_days: float = 0) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(days=offset_days)
+
+
+def _make_goal(
+    registry: GoalRegistry,
+    *,
+    brand_id: str = "brandx",
+    kpi: str = "organic_clicks",
+    target: float = 100.0,
+    current: float = 10.0,
+    deadline: str | None = None,
+    metadata: dict | None = None,
+) -> KaiGoal:
+    return registry.create_goal(
+        brand_id=brand_id,
+        name=f"{kpi} goal",
+        kpi_name=kpi,
+        target_value=target,
+        current_value=current,
+        target_direction="increase",
+        deadline=deadline if deadline is not None else _utc(-1).isoformat(),
+        metadata=metadata or {"baseline_value": current},
+    )
+
+
+def _make_graph(db: AgentDatabase, goal_id: str, status: str, graph_id: str,
+                nodes: dict | None = None, edges: list | None = None) -> TaskGraph:
+    graph = TaskGraph(
+        graph_id=graph_id,
+        goal_id=goal_id,
+        brand_id="brandx",
+        status=status,  # type: ignore[arg-type]
+        nodes=nodes or {
+            "n1": TaskNode(node_id="n1", task_type="seo_optimization", status="pending"),
+        },
+        edges=edges or [],
+        created_at=datetime.utcnow().isoformat(),
+        updated_at=datetime.utcnow().isoformat(),
+    )
+    db.create_task_graph(graph)
+    return graph
+
+
+MOCK_DECOMPOSE_RESPONSE = """
+{
+  "nodes": [
+    {"node_id": "step_1", "task_type": "content_pipeline", "inputs": {"k": "v"}}
+  ],
+  "edges": []
+}
+"""
+
+
+@pytest.fixture
+def review_env(tmp_path, monkeypatch):
+    """Isolated GoalRegistry (via env), agent db, notifications, content log."""
+    runtime_dir = tmp_path / "runtime"
+    monkeypatch.setenv("KAI_RUNTIME_DIR", str(runtime_dir))
+
+    db = AgentDatabase(db_path=tmp_path / "agent.db")
+    monkeypatch.setattr(agent.models, "agent_db", db)
+
+    # Deterministic LLM availability: one key set by default.
+    for var in LLM_KEY_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    # No content log unless a test provides one.
+    monkeypatch.setattr(CMOReviewTask, "_load_content_log", lambda self: [])
+
+    notifications: list[str] = []
+
+    async def capture_notification(self, message, task=None):
+        notifications.append(message)
+
+    monkeypatch.setattr(CMOReviewTask, "send_notification", capture_notification)
+
+    registry = GoalRegistry(base_dir=runtime_dir)
+    return {
+        "registry": registry,
+        "db": db,
+        "runtime_dir": runtime_dir,
+        "notifications": notifications,
+    }
+
+
+def _mock_llm(monkeypatch, response: str = MOCK_DECOMPOSE_RESPONSE):
+    from agent.decomposer import llm_router
+
+    captured: list[str] = []
+
+    async def mock_complete(prompt, **kwargs):
+        captured.append(prompt)
+        return response
+
+    monkeypatch.setattr(llm_router, "complete", mock_complete)
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# Pace helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPaceHelpers:
+    def test_parse_goal_datetime_tolerant(self):
+        assert parse_goal_datetime("") is None
+        assert parse_goal_datetime(None) is None
+        assert parse_goal_datetime("not-a-date") is None
+        dt = parse_goal_datetime("2026-12-31")
+        assert dt is not None and dt.tzinfo is not None
+        dt_z = parse_goal_datetime("2026-12-31T10:00:00Z")
+        assert dt_z is not None and dt_z.utcoffset().total_seconds() == 0
+
+    def test_achieved_direction_aware(self):
+        inc = KaiGoal("g1", "b", "n", "k", 100.0, 100.0, "increase")
+        dec = KaiGoal("g2", "b", "n", "k", 10.0, 9.0, "decrease")
+        assert is_goal_achieved(inc) is True
+        assert is_goal_achieved(dec) is True
+        assert is_goal_achieved(KaiGoal("g3", "b", "n", "k", 100.0, 99.0, "increase")) is False
+
+    def test_achieved_goal_never_behind(self):
+        goal = KaiGoal("g", "b", "n", "k", 100.0, 150.0, "increase",
+                       deadline=_utc(-10).isoformat())
+        pace = compute_goal_pace(goal)
+        assert pace["achieved"] is True
+        assert pace["behind_pace"] is False
+
+    def test_overdue_unachieved_is_behind(self):
+        goal = KaiGoal("g", "b", "n", "k", 100.0, 10.0, "increase",
+                       deadline=_utc(-1).isoformat(),
+                       created_at=_utc(-30).isoformat())
+        pace = compute_goal_pace(goal)
+        assert pace["overdue"] is True
+        assert pace["behind_pace"] is True
+
+    def test_early_goal_on_pace(self):
+        goal = KaiGoal("g", "b", "n", "k", 100.0, 5.0, "increase",
+                       deadline=_utc(365).isoformat(),
+                       created_at=_utc(0).isoformat())
+        pace = compute_goal_pace(goal)
+        assert pace["behind_pace"] is False
+        assert pace["time_fraction"] is not None and pace["time_fraction"] < 0.05
+
+    def test_mid_deadline_lagging_is_behind(self):
+        goal = KaiGoal("g", "b", "n", "k", 100.0, 10.0, "increase",
+                       deadline=_utc(10).isoformat(),
+                       created_at=_utc(-90).isoformat(),
+                       metadata={"baseline_value": 0.0})
+        pace = compute_goal_pace(goal)
+        assert pace["time_fraction"] > 0.8
+        assert pace["progress_fraction"] == pytest.approx(0.1)
+        assert pace["behind_pace"] is True
+        assert pace["expected_value"] > 80.0
+
+    def test_no_deadline_unachieved_is_behind(self):
+        goal = KaiGoal("g", "b", "n", "k", 100.0, 10.0, "increase", deadline="")
+        assert compute_goal_pace(goal)["behind_pace"] is True
+
+
+# ---------------------------------------------------------------------------
+# Goals CLI round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestGoalsCli:
+    def _run_cli(self, monkeypatch, capsys, argv: list[str]) -> str:
+        import scripts.harness_cli as cli
+
+        monkeypatch.setattr(sys, "argv", ["kai-harness"] + argv)
+        cli.main()
+        return capsys.readouterr().out
+
+    def test_add_list_update_round_trip(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("KAI_RUNTIME_DIR", str(tmp_path / "runtime"))
+
+        out = self._run_cli(monkeypatch, capsys, [
+            "goals", "add",
+            "--brand", "brandx",
+            "--name", "Q3 organic clicks",
+            "--kpi", "organic_clicks",
+            "--target", "5000",
+            "--current", "100",
+            "--deadline", "2027-01-01",
+            "--site", "brandx-site",
+        ])
+        m = re.search(r"Created goal (goal_\w+)", out)
+        assert m, out
+        goal_id = m.group(1)
+
+        out = self._run_cli(monkeypatch, capsys, ["goals", "list", "--json"])
+        goals = json.loads(out)
+        assert len(goals) == 1
+        assert goals[0]["goal_id"] == goal_id
+        assert goals[0]["kpi_name"] == "organic_clicks"
+        assert goals[0]["target_value"] == 5000.0
+        assert goals[0]["current_value"] == 100.0
+        assert goals[0]["metadata"]["baseline_value"] == 100.0
+        assert goals[0]["metadata"]["site"] == "brandx-site"
+
+        out = self._run_cli(monkeypatch, capsys, [
+            "goals", "update", goal_id, "--current", "1200", "--status", "achieved",
+        ])
+        assert "Updated goal" in out
+
+        # Achieved goals drop out of the default list, appear with --all.
+        out = self._run_cli(monkeypatch, capsys, ["goals", "list", "--json"])
+        assert json.loads(out) == []
+        out = self._run_cli(monkeypatch, capsys, ["goals", "list", "--all", "--json"])
+        goals = json.loads(out)
+        assert goals[0]["current_value"] == 1200.0
+        assert goals[0]["status"] == "achieved"
+
+        # And the registry on disk agrees (round trip through GoalRegistry).
+        registry = GoalRegistry(base_dir=tmp_path / "runtime")
+        stored = registry.get_goal(goal_id)
+        assert stored is not None
+        assert stored.current_value == 1200.0
+        assert stored.status == "achieved"
+
+    def test_update_unknown_goal_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("KAI_RUNTIME_DIR", str(tmp_path / "runtime"))
+        with pytest.raises(SystemExit):
+            self._run_cli(monkeypatch, capsys, [
+                "goals", "update", "goal_nope", "--current", "1",
+            ])
+
+    def test_human_list_flags_behind_pace(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("KAI_RUNTIME_DIR", str(tmp_path / "runtime"))
+        self._run_cli(monkeypatch, capsys, [
+            "goals", "add", "--brand", "b", "--name", "Late goal",
+            "--kpi", "clicks", "--target", "100", "--current", "1",
+            "--deadline", "2026-01-01",
+        ])
+        out = self._run_cli(monkeypatch, capsys, ["goals", "list"])
+        assert "BEHIND PACE" in out
+        assert "overdue" in out
+
+
+# ---------------------------------------------------------------------------
+# CMOReviewTask — KPI refresh
+# ---------------------------------------------------------------------------
+
+
+class TestKpiRefresh:
+    def test_refreshes_derivable_kpi_and_records_delta(self, review_env, monkeypatch):
+        registry = review_env["registry"]
+        goal = _make_goal(registry, kpi="organic_clicks", current=10.0,
+                          deadline=_utc(300).isoformat())
+
+        entries = [
+            {"site": "brandx", "performance_30d": {"gsc": {"clicks": 100}, "grade": "winner"}},
+            {"site": "brandx", "performance_30d": {"gsc": {"clicks": 50}, "grade": "average"}},
+            {"site": "other", "performance_30d": {"gsc": {"clicks": 999}, "grade": "winner"}},
+            {"site": "brandx"},  # unmeasured — ignored, not zeroed
+        ]
+        monkeypatch.setattr(CMOReviewTask, "_load_content_log", lambda self: entries)
+
+        result = asyncio.run(CMOReviewTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert result["values_refreshed"] == 1
+
+        stored = registry.get_goal(goal.goal_id)
+        assert stored.current_value == 150.0
+        # Baseline stays anchored at the original value.
+        assert stored.metadata["baseline_value"] == 10.0
+
+    def test_missing_data_is_gap_not_zero(self, review_env, monkeypatch):
+        registry = review_env["registry"]
+        goal = _make_goal(registry, kpi="organic_clicks", current=42.0,
+                          deadline=_utc(300).isoformat())
+        # Entries exist but none has measured GSC data.
+        entries = [{"site": "brandx"}, {"site": "brandx", "performance_30d": None}]
+        monkeypatch.setattr(CMOReviewTask, "_load_content_log", lambda self: entries)
+
+        result = asyncio.run(CMOReviewTask().execute(MagicMock()))
+        assert result["values_refreshed"] == 0
+        assert registry.get_goal(goal.goal_id).current_value == 42.0
+
+    def test_derivers_tolerate_legacy_grade_shapes(self, review_env):
+        handler = CMOReviewTask()
+        goal = KaiGoal("g", "brandx", "n", "content_winners", 10.0, 0.0, "increase")
+        entries = [
+            {"site": "brandx", "performance_30d": {"grade": "winner"}},   # dict schema
+            {"site": "brandx", "performance_30d": "loser"},               # legacy string
+            {"site": "brandx", "performance_30d": "winner"},              # legacy string
+        ]
+        assert handler._derive_kpi_value(goal, entries) == 2.0
+
+    def test_non_derivable_kpi_left_alone(self, review_env):
+        handler = CMOReviewTask()
+        goal = KaiGoal("g", "brandx", "n", "demo_bookings", 10.0, 3.0, "increase")
+        assert handler._derive_kpi_value(goal, [{"site": "brandx", "url": "x"}]) is None
+
+
+# ---------------------------------------------------------------------------
+# CMOReviewTask — planning decisions
+# ---------------------------------------------------------------------------
+
+
+class TestReviewPlanning:
+    def test_creates_graph_only_for_behind_pace_goal_without_active_graph(
+        self, review_env, monkeypatch
+    ):
+        registry, db = review_env["registry"], review_env["db"]
+        behind = _make_goal(registry, kpi="organic_clicks")              # overdue → behind
+        on_pace = _make_goal(registry, kpi="content_winners",
+                             deadline=_utc(365).isoformat())             # just created → on pace
+        covered = _make_goal(registry, kpi="organic_impressions")        # behind but has graph
+        _make_graph(db, covered.goal_id, "running", "graph_active_1")
+
+        captured = _mock_llm(monkeypatch)
+
+        result = asyncio.run(CMOReviewTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert len(result["graphs_created"]) == 1
+        assert len(captured) == 1  # decomposer called exactly once
+
+        decisions = {d["goal_id"]: d for d in result["decisions"]}
+        assert decisions[behind.goal_id]["decision"] == "decomposed"
+        assert decisions[on_pace.goal_id]["decision"] == "on_pace"
+        assert decisions[covered.goal_id]["decision"] == "active_graph_exists"
+
+        # The new graph is persisted, pending, and bound to the behind goal —
+        # the existing agent loop will pick it up from list_active_task_graphs.
+        active = db.list_active_task_graphs()
+        goal_ids = {g.goal_id for g in active}
+        assert behind.goal_id in goal_ids
+        new_graph = next(g for g in active if g.goal_id == behind.goal_id)
+        assert new_graph.status == "pending"
+        assert "step_1" in new_graph.nodes
+
+    def test_needs_replan_graph_is_replanned_with_failure_context(
+        self, review_env, monkeypatch
+    ):
+        registry, db = review_env["registry"], review_env["db"]
+        goal = _make_goal(registry, kpi="organic_clicks")
+        _make_graph(
+            db, goal.goal_id, "needs_replan", "graph_dead_1",
+            nodes={
+                "audit": TaskNode(node_id="audit", task_type="seo_optimization",
+                                  status="failed", error="GSC quota exceeded"),
+                "write": TaskNode(node_id="write", task_type="content_pipeline",
+                                  status="skipped"),
+            },
+            edges=[["audit", "write"]],
+        )
+
+        captured = _mock_llm(monkeypatch)
+
+        result = asyncio.run(CMOReviewTask().execute(MagicMock()))
+        assert len(result["graphs_created"]) == 1
+
+        decision = next(d for d in result["decisions"] if d["goal_id"] == goal.goal_id)
+        assert decision["decision"] == "replanned"
+        assert decision["replanned_graphs"] == ["graph_dead_1"]
+
+        # Failure context reached the decomposer prompt via goal metadata.
+        prompt = captured[0]
+        assert "replan_context" in prompt
+        assert "GSC quota exceeded" in prompt
+        assert "graph_dead_1" in prompt
+
+        # Old graph retired; new one active.
+        assert db.get_task_graph("graph_dead_1").status == "replanned"
+        active = db.list_active_task_graphs()
+        assert len(active) == 1 and active[0].goal_id == goal.goal_id
+
+    def test_no_llm_key_degrades_gracefully(self, review_env, monkeypatch):
+        registry = review_env["registry"]
+        goal = _make_goal(registry, kpi="organic_clicks")
+        for var in LLM_KEY_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+
+        def fail_decompose(*args, **kwargs):
+            raise AssertionError("decomposer must not be called without an LLM key")
+
+        monkeypatch.setattr(CMOReviewTask, "_decompose_and_persist", fail_decompose)
+
+        result = asyncio.run(CMOReviewTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert result["graphs_created"] == []
+        assert result["llm_available"] is False
+        decision = next(d for d in result["decisions"] if d["goal_id"] == goal.goal_id)
+        assert decision["decision"] == "decomposition_skipped_no_llm"
+        assert decision["data_gap"] is True
+        # Snapshot + notification still happen.
+        assert result["snapshot"] and Path(result["snapshot"]).exists()
+        assert len(review_env["notifications"]) == 1
+        assert "no LLM key" in review_env["notifications"][0]
+
+    def test_decomposition_failure_contained(self, review_env, monkeypatch):
+        registry = review_env["registry"]
+        goal = _make_goal(registry, kpi="organic_clicks")
+
+        from agent.decomposer import llm_router
+
+        async def boom(prompt, **kwargs):
+            raise RuntimeError("provider down")
+
+        monkeypatch.setattr(llm_router, "complete", boom)
+
+        result = asyncio.run(CMOReviewTask().execute(MagicMock()))
+        assert result["success"] is True  # review completed; planning failed
+        decision = next(d for d in result["decisions"] if d["goal_id"] == goal.goal_id)
+        assert decision["decision"] == "decomposition_failed"
+        assert "provider down" in decision["error"]
+
+    def test_snapshot_written_with_goals_deltas_decisions(self, review_env, monkeypatch):
+        registry = review_env["registry"]
+        runtime_dir = review_env["runtime_dir"]
+        _make_goal(registry, kpi="organic_clicks", current=10.0)
+        entries = [{"site": "brandx", "performance_30d": {"gsc": {"clicks": 75}, "grade": "average"}}]
+        monkeypatch.setattr(CMOReviewTask, "_load_content_log", lambda self: entries)
+        _mock_llm(monkeypatch)
+
+        result = asyncio.run(CMOReviewTask().execute(MagicMock()))
+
+        date_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        snapshot_path = runtime_dir / "goals" / "reviews" / f"{date_str}.json"
+        assert str(snapshot_path) == result["snapshot"]
+        snapshot = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        assert snapshot["task"] == "cmo_review"
+        assert len(snapshot["goals"]) == 1
+        assert snapshot["goals"][0]["current_value"] == 75.0
+        assert snapshot["deltas"][0]["previous_value"] == 10.0
+        assert snapshot["decisions"]
+        assert snapshot["graphs_created"] == result["graphs_created"]
+        # The reviews subdir must not confuse the goal registry.
+        assert len(registry.list_goals()) == 1
+
+    def test_no_active_goals_still_snapshots_and_notifies(self, review_env):
+        result = asyncio.run(CMOReviewTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert result["goals_reviewed"] == 0
+        assert result["snapshot"] and Path(result["snapshot"]).exists()
+        assert len(review_env["notifications"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Scheduler + handler registration
+# ---------------------------------------------------------------------------
+
+
+class TestScheduling:
+    def test_default_task_seeded_monday_7am(self, tmp_path):
+        sched = Scheduler()
+        sched.db = AgentDatabase(db_path=tmp_path / "sched.db")
+        sched.create_default_tasks()
+        tasks = {t.name: t for t in sched.db.list_scheduled_tasks(enabled_only=False)}
+        assert "Weekly CMO Review" in tasks
+        task = tasks["Weekly CMO Review"]
+        assert task.cron_expression == "0 7 * * 1"
+        assert task.task_type == "cmo_review"
+        assert task.enabled is True
+
+        # Idempotent reseed.
+        sched.create_default_tasks()
+        names = [t.name for t in sched.db.list_scheduled_tasks(enabled_only=False)]
+        assert names.count("Weekly CMO Review") == 1
+
+    def test_handler_registered(self):
+        handler = get_task_handler("cmo_review")
+        assert handler is not None
+        assert handler.task_type == "cmo_review"
+
+
+# ---------------------------------------------------------------------------
+# Agent loop — needs_replan status handling
+# ---------------------------------------------------------------------------
+
+
+class TestLoopReplanStatus:
+    def test_update_graph_status_preserves_needs_replan(self, tmp_path, monkeypatch):
+        import agent.loop as loop_mod
+        from agent.loop import AgentLoop
+
+        db = AgentDatabase(db_path=tmp_path / "loop.db")
+        monkeypatch.setattr(loop_mod, "agent_db", db)
+
+        graph = _make_graph(
+            db, "goal_x", "needs_replan", "graph_nr",
+            nodes={
+                "a": TaskNode(node_id="a", task_type="t", status="failed", error="boom"),
+                "b": TaskNode(node_id="b", task_type="t", status="skipped"),
+            },
+            edges=[["a", "b"]],
+        )
+        AgentLoop()._update_graph_status_if_done(graph.graph_id)
+        assert db.get_task_graph("graph_nr").status == "needs_replan"
+        # And it is not in the active set the executor polls.
+        assert db.list_active_task_graphs() == []

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,144 @@
+"""Tests for scripts/doctor.py — the trust anchor.
+
+Doctor promises "referenced files exist, gates run, golden corpus passes".
+These tests pin the referenced-files half: the instruction chain
+(CLAUDE.md/AGENTS.md load-on-demand pointers, workspace core files, the
+memory layer, and every path named in the AGENTS.md Framework Map and the
+.claude/rules docs) must exist on the current tree, and doctor must FLAG a
+missing referenced file rather than silently passing.
+"""
+
+from pathlib import Path
+
+from scripts import doctor
+from scripts.doctor import (
+    INSTRUCTION_CHAIN_PATHS,
+    REFERENCED_DOCS,
+    Report,
+    check_instruction_chain,
+    check_required_paths,
+    extract_repo_paths,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ── extract_repo_paths ──────────────────────────────────────────────────────
+
+
+def test_extract_repo_paths_finds_inline_code_paths():
+    md = "Load `knowledge/_index.md` and `harness/brief-schema.md` first."
+    assert extract_repo_paths(md) == [
+        "harness/brief-schema.md",
+        "knowledge/_index.md",
+    ]
+
+
+def test_extract_repo_paths_strips_fenced_code_blocks():
+    md = (
+        "Real: `memory/lessons.md`\n"
+        "```bash\n"
+        "cat fenced/not-a-real-path.md\n"
+        "`fenced/inline.md`\n"
+        "```\n"
+    )
+    assert extract_repo_paths(md) == ["memory/lessons.md"]
+
+
+def test_extract_repo_paths_skips_globs_ellipses_data_and_absolute():
+    md = (
+        "See `harness/references/*-organic-posting-rules.md` and "
+        "`.../aeo-ai-search-playbook-2026.md` and "
+        "`data/learning/gate_runs.jsonl` and `/tmp/draft.md` and `/kai`."
+    )
+    assert extract_repo_paths(md) == []
+
+
+def test_extract_repo_paths_takes_script_path_from_python_commands():
+    md = (
+        "Run: `python scripts/quality_gates/four_us_score.py <file>` then "
+        "`python -m scripts.audit.collect --url <url>` (module form skipped)."
+    )
+    assert extract_repo_paths(md) == ["scripts/quality_gates/four_us_score.py"]
+
+
+# ── current tree passes ─────────────────────────────────────────────────────
+
+
+def test_instruction_chain_passes_on_current_tree():
+    report = Report()
+    check_instruction_chain(report)
+    assert report.failures == [], "\n".join(report.failures)
+    assert any("instruction chain intact" in msg for msg in report.passes)
+
+
+def test_required_paths_pass_on_current_tree():
+    report = Report()
+    check_required_paths(report)
+    assert report.failures == [], "\n".join(report.failures)
+
+
+def test_rules_files_exist_and_are_in_instruction_chain():
+    for rel in (
+        ".claude/rules/architecture-and-memory.md",
+        ".claude/rules/scripts-and-tools.md",
+    ):
+        assert (REPO_ROOT / rel).exists(), f"{rel} missing"
+        assert rel in INSTRUCTION_CHAIN_PATHS
+        assert rel in REFERENCED_DOCS
+
+
+# ── doctor flags missing referenced files ───────────────────────────────────
+
+
+def _minimal_tree(root: Path) -> None:
+    """Build a tree containing every instruction-chain core file."""
+    for rel in INSTRUCTION_CHAIN_PATHS:
+        target = root / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("# stub\n", encoding="utf-8")
+
+
+def test_instruction_chain_flags_missing_core_file(tmp_path):
+    _minimal_tree(tmp_path)
+    (tmp_path / ".claude/rules/scripts-and-tools.md").unlink()
+
+    report = Report()
+    check_instruction_chain(report, root=tmp_path)
+
+    assert any(
+        "instruction chain broken" in msg and ".claude/rules/scripts-and-tools.md" in msg
+        for msg in report.failures
+    ), report.failures
+
+
+def test_instruction_chain_flags_missing_framework_map_path(tmp_path):
+    _minimal_tree(tmp_path)
+    (tmp_path / "AGENTS.md").write_text(
+        "# AGENTS.md\n\n"
+        "| Task | Framework |\n|---|---|\n"
+        "| Blog | `knowledge/frameworks/does-not-exist.md` |\n",
+        encoding="utf-8",
+    )
+
+    report = Report()
+    check_instruction_chain(report, root=tmp_path)
+
+    assert any(
+        "knowledge/frameworks/does-not-exist.md" in msg for msg in report.failures
+    ), report.failures
+
+
+def test_instruction_chain_clean_on_minimal_tree(tmp_path):
+    _minimal_tree(tmp_path)
+    report = Report()
+    check_instruction_chain(report, root=tmp_path)
+    assert report.failures == [], report.failures
+
+
+def test_doctor_main_registers_instruction_chain_check():
+    # main() must actually run the new check — guard against it being wired
+    # up in tests but dropped from the entry point.
+    import inspect
+
+    assert "check_instruction_chain(report)" in inspect.getsource(doctor.main)

--- a/tests/test_editorial_calendar.py
+++ b/tests/test_editorial_calendar.py
@@ -1,0 +1,303 @@
+"""Tests for the structured editorial calendar store + hourly executor task.
+
+Covers:
+- calendar CRUD (add/list/mark) and validation
+- due-item selection with timezone-safe comparisons
+- editorial_calendar_tick handler with generation mocked (drafts only —
+  the handler never publishes and never sets status "published")
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from scripts.campaigns import calendar as cal
+from agent.models import ScheduledTask, ScheduledTaskConfig
+
+
+@pytest.fixture(autouse=True)
+def calendar_dir(tmp_path, monkeypatch):
+    """Redirect the calendar store to a temp dir for every test."""
+    monkeypatch.setenv("KAI_CALENDAR_DIR", str(tmp_path / "calendar"))
+    yield tmp_path / "calendar"
+
+
+def _make_task(extra=None, client=None) -> ScheduledTask:
+    return ScheduledTask(
+        id="tick1",
+        name="Editorial Calendar Tick",
+        cron_expression="0 * * * *",
+        task_type="editorial_calendar_tick",
+        client=client,
+        config=ScheduledTaskConfig(extra=extra or {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Store CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarCrud:
+    def test_add_and_list(self, calendar_dir):
+        item = cal.add_item(
+            site="kaicalls",
+            title="AI receptionist ROI math",
+            publish_at="2026-07-10T14:00:00Z",
+            format="blog",
+            keyword="ai receptionist roi",
+            persona="Admin Martyr",
+            campaign_id="q3-launch",
+            notes="from Q3 plan",
+        )
+        assert item["id"].startswith("cal-")
+        assert item["status"] == "planned"
+        assert item["publish_at"] == "2026-07-10T14:00:00+00:00"
+        assert item["campaign_id"] == "q3-launch"
+
+        items = cal.list_items()
+        assert len(items) == 1
+        assert items[0]["title"] == "AI receptionist ROI math"
+
+        # File is JSONL under the overridden dir
+        store = calendar_dir / "editorial.jsonl"
+        assert store.exists()
+        lines = [l for l in store.read_text().splitlines() if l.strip()]
+        assert len(lines) == 1
+        assert json.loads(lines[0])["site"] == "kaicalls"
+
+    def test_list_filters(self):
+        cal.add_item(site="kaicalls", title="A", publish_at="2026-07-01T00:00:00Z")
+        cal.add_item(site="buildwithkai", title="B", publish_at="2026-07-02T00:00:00Z")
+        b = cal.list_items(site="buildwithkai")
+        assert [i["title"] for i in b] == ["B"]
+        assert cal.list_items(status="ready") == []
+
+    def test_list_sorted_by_publish_at(self):
+        cal.add_item(site="s", title="later", publish_at="2026-07-20T00:00:00Z")
+        cal.add_item(site="s", title="sooner", publish_at="2026-07-01T00:00:00Z")
+        assert [i["title"] for i in cal.list_items()] == ["sooner", "later"]
+
+    def test_mark_status(self):
+        item = cal.add_item(site="s", title="t", publish_at="2026-07-01T00:00:00Z")
+        updated = cal.mark_status(item["id"], "skipped", notes="dropped from plan")
+        assert updated["status"] == "skipped"
+        assert updated["notes"] == "dropped from plan"
+        # Persisted
+        assert cal.get_item(item["id"])["status"] == "skipped"
+
+    def test_mark_unknown_id_returns_none(self):
+        assert cal.mark_status("cal-nope", "ready") is None
+
+    def test_mark_invalid_status_raises(self):
+        item = cal.add_item(site="s", title="t", publish_at="2026-07-01T00:00:00Z")
+        with pytest.raises(ValueError):
+            cal.mark_status(item["id"], "live")  # not a valid status
+
+    def test_add_invalid_inputs(self):
+        with pytest.raises(ValueError):
+            cal.add_item(site="", title="t", publish_at="2026-07-01T00:00:00Z")
+        with pytest.raises(ValueError):
+            cal.add_item(site="s", title="", publish_at="2026-07-01T00:00:00Z")
+        with pytest.raises(ValueError):
+            cal.add_item(site="s", title="t", publish_at="not-a-date")
+        with pytest.raises(ValueError):
+            cal.add_item(site="s", title="t", publish_at="2026-07-01T00:00:00Z",
+                         status="live")
+
+    def test_corrupt_line_skipped(self, calendar_dir):
+        cal.add_item(site="s", title="good", publish_at="2026-07-01T00:00:00Z")
+        store = calendar_dir / "editorial.jsonl"
+        with open(store, "a") as f:
+            f.write("{not json\n")
+        items = cal.list_items()
+        assert len(items) == 1
+        assert items[0]["title"] == "good"
+
+
+# ---------------------------------------------------------------------------
+# Due-item selection (timezone-safe)
+# ---------------------------------------------------------------------------
+
+
+class TestDueItems:
+    def test_due_selection(self):
+        now = datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc)
+        past = cal.add_item(site="s", title="past", publish_at="2026-07-05T11:00:00Z")
+        cal.add_item(site="s", title="future", publish_at="2026-07-05T13:00:00Z")
+        due = cal.due_items(now=now)
+        assert [i["id"] for i in due] == [past["id"]]
+
+    def test_naive_publish_at_treated_as_utc(self):
+        # Naive timestamp — must be interpreted as UTC, not local time.
+        cal.add_item(site="s", title="naive", publish_at="2026-07-05T11:30:00")
+        assert cal.due_items(now=datetime(2026, 7, 5, 11, 0, tzinfo=timezone.utc)) == []
+        due = cal.due_items(now=datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc))
+        assert len(due) == 1
+
+    def test_offset_publish_at_normalized(self):
+        # 14:00 at UTC+2 == 12:00 UTC
+        cal.add_item(site="s", title="offset", publish_at="2026-07-05T14:00:00+02:00")
+        assert cal.due_items(now=datetime(2026, 7, 5, 11, 59, tzinfo=timezone.utc)) == []
+        assert len(cal.due_items(now=datetime(2026, 7, 5, 12, 0, tzinfo=timezone.utc))) == 1
+
+    def test_naive_now_treated_as_utc(self):
+        cal.add_item(site="s", title="x", publish_at="2026-07-05T11:00:00Z")
+        due = cal.due_items(now=datetime(2026, 7, 5, 12, 0))  # naive now
+        assert len(due) == 1
+
+    def test_only_planned_items_are_due(self):
+        item = cal.add_item(site="s", title="x", publish_at="2026-07-01T00:00:00Z")
+        cal.mark_status(item["id"], "ready")
+        assert cal.due_items(now=datetime(2026, 7, 5, tzinfo=timezone.utc)) == []
+
+    def test_due_sorted_oldest_first(self):
+        cal.add_item(site="s", title="newer", publish_at="2026-07-04T00:00:00Z")
+        cal.add_item(site="s", title="older", publish_at="2026-07-01T00:00:00Z")
+        due = cal.due_items(now=datetime(2026, 7, 5, tzinfo=timezone.utc))
+        assert [i["title"] for i in due] == ["older", "newer"]
+
+
+# ---------------------------------------------------------------------------
+# editorial_calendar_tick handler
+# ---------------------------------------------------------------------------
+
+
+class TestEditorialCalendarTick:
+    def _patch_pipeline(self, monkeypatch, draft=None, saved=None, calls=None):
+        """Mock the ContentPipelineTask generation path."""
+        from agent.tasks.content_pipeline import ContentPipelineTask
+        from agent.tasks.editorial_calendar import EditorialCalendarTickTask
+
+        calls = calls if calls is not None else []
+
+        async def fake_generate(self, client, opportunity):
+            calls.append({"client": client, "opportunity": opportunity})
+            return draft
+
+        def fake_save(self, client_id, drafts):
+            return saved if saved is not None else []
+
+        monkeypatch.setattr(ContentPipelineTask, "_generate_draft", fake_generate)
+        monkeypatch.setattr(ContentPipelineTask, "_save_drafts", fake_save)
+        monkeypatch.setattr(
+            EditorialCalendarTickTask,
+            "_resolve_client",
+            lambda self, task, item: {"id": item.get("site", "x"), "name": item.get("site", "x")},
+        )
+        return calls
+
+    def test_no_due_items(self):
+        from agent.tasks.editorial_calendar import EditorialCalendarTickTask
+        result = asyncio.run(EditorialCalendarTickTask().execute(_make_task()))
+        assert result["success"] is True
+        assert result["generated"] == 0
+
+    def test_generates_draft_and_marks_ready(self, monkeypatch):
+        from agent.tasks.editorial_calendar import EditorialCalendarTickTask
+
+        item = cal.add_item(
+            site="kaicalls",
+            title="Missed calls cost math",
+            publish_at="2020-01-01T00:00:00Z",  # long due
+            keyword="missed call cost",
+            persona="Admin Martyr",
+        )
+        calls = self._patch_pipeline(
+            monkeypatch,
+            draft={"topic": "Missed calls cost math", "content": "...", "status": "draft"},
+            saved=["/tmp/draft.md"],
+        )
+
+        result = asyncio.run(EditorialCalendarTickTask().execute(_make_task()))
+
+        assert result["success"] is True
+        assert result["generated"] == 1
+        # Same generation path as content_pipeline, with calendar metadata
+        opp = calls[0]["opportunity"]
+        assert opp["topic"] == "Missed calls cost math"
+        assert opp["keywords"] == ["missed call cost"]
+        assert opp["type"] == "blog"
+        assert opp["calendar_item_id"] == item["id"]
+
+        stored = cal.get_item(item["id"])
+        assert stored["status"] == "ready"
+        assert "human approval" in stored["notes"]
+        # Approval doctrine: the tick NEVER publishes
+        assert stored["status"] != "published"
+        assert "nothing published" in result["summary"]
+
+    def test_failed_generation_reverts_to_planned(self, monkeypatch):
+        from agent.tasks.editorial_calendar import EditorialCalendarTickTask
+
+        item = cal.add_item(site="s", title="t", publish_at="2020-01-01T00:00:00Z")
+        self._patch_pipeline(monkeypatch, draft={"topic": "t", "error": "LLM down"})
+
+        result = asyncio.run(EditorialCalendarTickTask().execute(_make_task()))
+
+        assert result["success"] is False
+        assert result["generated"] == 0
+        assert any("LLM down" in e for e in result["errors"])
+        stored = cal.get_item(item["id"])
+        assert stored["status"] == "planned"  # retried on next tick
+        assert "generation failed" in stored["notes"]
+
+    def test_exception_during_generation_is_contained(self, monkeypatch):
+        from agent.tasks.content_pipeline import ContentPipelineTask
+        from agent.tasks.editorial_calendar import EditorialCalendarTickTask
+
+        item = cal.add_item(site="s", title="t", publish_at="2020-01-01T00:00:00Z")
+
+        async def boom(self, client, opportunity):
+            raise RuntimeError("kaput")
+
+        monkeypatch.setattr(ContentPipelineTask, "_generate_draft", boom)
+        monkeypatch.setattr(
+            EditorialCalendarTickTask,
+            "_resolve_client",
+            lambda self, task, item: {"id": "s", "name": "s"},
+        )
+
+        result = asyncio.run(EditorialCalendarTickTask().execute(_make_task()))
+        assert result["success"] is False
+        assert any("kaput" in e for e in result["errors"])
+        assert cal.get_item(item["id"])["status"] == "planned"
+
+    def test_respects_max_items_per_run(self, monkeypatch):
+        from agent.tasks.editorial_calendar import EditorialCalendarTickTask
+
+        ids = [
+            cal.add_item(site="s", title=f"t{i}",
+                         publish_at=f"2020-01-0{i+1}T00:00:00Z")["id"]
+            for i in range(4)
+        ]
+        calls = self._patch_pipeline(
+            monkeypatch,
+            draft={"topic": "t", "content": "...", "status": "draft"},
+            saved=["/tmp/d.md"],
+        )
+
+        result = asyncio.run(
+            EditorialCalendarTickTask().execute(_make_task(extra={"max_items": 2}))
+        )
+        assert result["generated"] == 2
+        assert len(calls) == 2
+        # Oldest two were processed; the rest remain planned
+        assert cal.get_item(ids[0])["status"] == "ready"
+        assert cal.get_item(ids[1])["status"] == "ready"
+        assert cal.get_item(ids[2])["status"] == "planned"
+        assert cal.get_item(ids[3])["status"] == "planned"
+
+    def test_handler_registered(self):
+        from agent.tasks import get_task_handler
+        handler = get_task_handler("editorial_calendar_tick")
+        assert handler is not None
+        assert handler.task_type == "editorial_calendar_tick"

--- a/tests/test_harness_cli_direct.py
+++ b/tests/test_harness_cli_direct.py
@@ -1,0 +1,101 @@
+"""Regression tests for cross-agent seams around harness_cli/harness_discord.
+
+1. The Discord handler shells out to scripts/harness_cli.py BY PATH
+   (get_harness_script()), from an arbitrary cwd. harness_cli must therefore
+   bootstrap sys.path for direct invocation — without it every `!harness run`
+   died at import time with ModuleNotFoundError: No module named 'scripts'.
+
+2. Discord report/status formatters read the canonical content log, whose
+   performance_30d field drifted (dict | legacy str | None). They must never
+   crash on a legacy string grade.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HARNESS_CLI = REPO_ROOT / "scripts" / "harness_cli.py"
+
+
+class TestHarnessCliDirectInvocation:
+    def test_direct_path_invocation_from_foreign_cwd(self, tmp_path):
+        """python3 <abs path>/scripts/harness_cli.py --help must work from any
+        cwd — this is exactly how harness_discord.run_harness and the
+        `!harness run` background command invoke it."""
+        result = subprocess.run(
+            [sys.executable, str(HARNESS_CLI), "--help"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "No module named 'scripts'" not in result.stderr
+
+    def test_module_form_still_works(self):
+        """kai-start SKILL.md documents `python -m scripts.harness_cli` —
+        the direct-path bootstrap must not break the module form."""
+        result = subprocess.run(
+            [sys.executable, "-m", "scripts.harness_cli", "--help"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+
+
+class TestDiscordFormattersTolerateLegacyGrades:
+    def _log_with_string_grade(self, tmp_path):
+        log_file = tmp_path / "content_log.json"
+        log_file.write_text(json.dumps([
+            {
+                "id": "kaicalls-legacy-1",
+                "url": "https://kaicalls.com/blog/a",
+                "keyword": "answering service",
+                "title": "Legacy string winner",
+                "site": "kaicalls",
+                "format": "blog",
+                "performance_30d": "winner",  # legacy string form
+                "status": "published",
+            },
+            {
+                "id": "kaicalls-unmeasured-2",
+                "url": "https://kaicalls.com/blog/b",
+                "keyword": "after hours calls",
+                "title": "Not yet measured",
+                "site": "kaicalls",
+                "format": "blog",
+                "performance_30d": None,
+                "status": "published",
+            },
+        ]))
+        return log_file
+
+    def test_format_report_handles_string_and_none_grades(self, tmp_path, monkeypatch):
+        import scripts.content.harness_discord as hd
+
+        monkeypatch.setattr(hd, "CONTENT_LOG", str(self._log_with_string_grade(tmp_path)))
+        report = hd.format_report(site="kaicalls")
+        assert "WINNER" in report
+        assert "PENDING" in report
+
+    def test_is_winner_tolerates_string_grade(self):
+        """pattern_extract.is_winner aborts the whole weekly winner loop on
+        the first AttributeError — a legacy str grade must just be non-win."""
+        grades_mod = __import__(
+            "scripts.self_improvement.grades", fromlist=["get_grade"]
+        )
+        # is_winner lives in pattern_extract, which imports google.genai at
+        # module level (unavailable in some CI environments) — exercise the
+        # shared helper it now routes through, plus the module when possible.
+        assert grades_mod.get_grade({"performance_30d": "winner"}) == "winner"
+        assert grades_mod.get_grade({"performance_30d": "loser"}) == "underperformer"
+        try:
+            from scripts.self_improvement.pattern_extract import is_winner
+        except ImportError:
+            return  # google.genai missing here; covered by helper assertions
+        assert is_winner({"platform": "web", "performance_30d": "winner"}) is False
+        assert is_winner({"platform": "web", "performance_30d": None}) is False

--- a/tests/test_learning_loop_repair.py
+++ b/tests/test_learning_loop_repair.py
@@ -1,0 +1,360 @@
+"""Learning-loop repair tests: grade vocabulary + schema drift.
+
+The 30-day grader (performance_check.py) writes performance_30d as a dict
+{"gsc": ..., "ga4": ..., "grade": "winner|average|underperformer", ...},
+but several readers historically compared it as a string, filtered on a
+"loser" grade that was never produced, or read a publish_date field the
+content log never writes. These tests pin the repaired behavior:
+
+- get_grade() tolerates performance_30d as dict, legacy string, legacy
+  "loser" alias, or None/missing.
+- get_published_at() falls back to the legacy publish_date field.
+- `lesson_capture.py losers` surfaces entries graded "underperformer".
+- get_pending_checks()/reconcile_pending_checks() skip url-less entries
+  (approved_unpublished), keeping EC-12 reconciliation otherwise intact.
+- performance_dashboard / report_cli / tracker_cli count dict-shaped grades.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.self_improvement.grades import (
+    GRADE_AVERAGE,
+    GRADE_UNDERPERFORMER,
+    GRADE_WINNER,
+    get_grade,
+    get_published_at,
+)
+
+
+# ---------------------------------------------------------------------------
+# get_grade / get_published_at
+# ---------------------------------------------------------------------------
+
+
+class TestGetGrade:
+    def test_dict_schema(self):
+        entry = {"performance_30d": {"gsc": {}, "ga4": {}, "grade": "winner",
+                                     "checked_at": "2026-07-01T00:00:00+00:00"}}
+        assert get_grade(entry) == GRADE_WINNER
+
+    def test_legacy_string_schema(self):
+        assert get_grade({"performance_30d": "average"}) == GRADE_AVERAGE
+
+    def test_none_and_missing(self):
+        assert get_grade({"performance_30d": None}) is None
+        assert get_grade({}) is None
+
+    def test_legacy_loser_alias_normalized(self):
+        assert get_grade({"performance_30d": {"grade": "loser"}}) == GRADE_UNDERPERFORMER
+        assert get_grade({"performance_30d": "loser"}) == GRADE_UNDERPERFORMER
+
+    def test_dict_without_grade(self):
+        assert get_grade({"performance_30d": {"gsc": {"clicks": 5}}}) is None
+
+    def test_non_dict_entry(self):
+        assert get_grade(None) is None
+        assert get_grade("winner") is None
+
+    def test_case_and_whitespace_normalized(self):
+        assert get_grade({"performance_30d": {"grade": " Winner "}}) == GRADE_WINNER
+
+    def test_non_string_grade_ignored(self):
+        assert get_grade({"performance_30d": {"grade": 3}}) is None
+
+
+class TestGetPublishedAt:
+    def test_published_at_preferred(self):
+        entry = {"published_at": "2026-06-01T00:00:00+00:00",
+                 "publish_date": "2020-01-01"}
+        assert get_published_at(entry) == "2026-06-01T00:00:00+00:00"
+
+    def test_falls_back_to_legacy_publish_date(self):
+        assert get_published_at({"publish_date": "2026-05-05"}) == "2026-05-05"
+
+    def test_missing_returns_none(self):
+        assert get_published_at({}) is None
+        assert get_published_at(None) is None
+
+
+# ---------------------------------------------------------------------------
+# lesson_capture losers — must surface "underperformer", the grade the
+# checker actually writes (never "loser")
+# ---------------------------------------------------------------------------
+
+
+class TestLessonCaptureLosers:
+    @pytest.fixture
+    def lc(self, tmp_path, monkeypatch):
+        from scripts.self_improvement import lesson_capture as mod
+
+        content_log = tmp_path / "content_log.json"
+        antipatterns = tmp_path / "what-doesnt-work.md"
+        monkeypatch.setenv("KAI_CONTENT_LOG", str(content_log))
+        monkeypatch.setattr(mod, "ANTIPATTERNS_PATH", antipatterns)
+        return mod, content_log, antipatterns
+
+    def _entry(self, entry_id, grade, **overrides):
+        entry = {
+            "id": entry_id,
+            "format": "blog",
+            "keyword": "ai receptionist",
+            "published_at": "2026-06-01T00:00:00+00:00",
+            "performance_30d": {"gsc": {"clicks": 1}, "ga4": {}, "grade": grade,
+                                "checked_at": "2026-07-01T00:00:00+00:00"},
+        }
+        entry.update(overrides)
+        return entry
+
+    def _run(self, mod, capsys):
+        rc = mod.cmd_losers(argparse.Namespace())
+        out = capsys.readouterr().out
+        return rc, out
+
+    def test_underperformer_entries_surface(self, lc, capsys):
+        mod, content_log, _ = lc
+        content_log.write_text(json.dumps([
+            self._entry("under-1", "underperformer"),
+            self._entry("win-1", "winner"),
+            self._entry("avg-1", "average"),
+        ]))
+        rc, out = self._run(mod, capsys)
+        assert rc == 0
+        assert "1 published piece(s) graded 'underperformer'" in out
+        assert "under-1" in out
+        assert "win-1" not in out
+        assert "avg-1" not in out
+
+    def test_legacy_loser_grades_still_surface(self, lc, capsys):
+        mod, content_log, _ = lc
+        content_log.write_text(json.dumps([
+            self._entry("legacy-dict", "loser"),
+            {"id": "legacy-str", "format": "blog", "keyword": "k",
+             "published_at": "2026-06-01T00:00:00+00:00",
+             "performance_30d": "loser"},
+        ]))
+        _, out = self._run(mod, capsys)
+        assert "legacy-dict" in out
+        assert "legacy-str" in out
+
+    def test_diagnosed_entries_excluded(self, lc, capsys):
+        mod, content_log, antipatterns = lc
+        content_log.write_text(json.dumps([
+            self._entry("under-1", "underperformer"),
+            self._entry("under-2", "underperformer"),
+        ]))
+        antipatterns.write_text("## Measured losers\n- [2026-07-01] blog/all: under-1 diagnosed\n")
+        _, out = self._run(mod, capsys)
+        assert "under-1" not in out
+        assert "under-2" in out
+
+    def test_published_at_printed_with_publish_date_fallback(self, lc, capsys):
+        mod, content_log, _ = lc
+        current = self._entry("under-1", "underperformer")
+        legacy = self._entry("under-2", "underperformer")
+        del legacy["published_at"]
+        legacy["publish_date"] = "2026-04-04"
+        content_log.write_text(json.dumps([current, legacy]))
+        _, out = self._run(mod, capsys)
+        assert "published=2026-06-01T00:00:00+00:00" in out
+        assert "published=2026-04-04" in out
+        assert "published=None" not in out
+
+    def test_no_underperformers_message(self, lc, capsys):
+        mod, content_log, _ = lc
+        content_log.write_text(json.dumps([self._entry("win-1", "winner")]))
+        rc, out = self._run(mod, capsys)
+        assert rc == 0
+        assert "No undiagnosed underperformers" in out
+
+
+# ---------------------------------------------------------------------------
+# performance_check — url-less entries must never be scheduled or pulled
+# ---------------------------------------------------------------------------
+
+
+class TestPendingChecksSkipNullUrl:
+    @pytest.fixture
+    def perf(self, tmp_path, monkeypatch):
+        from scripts.self_improvement import performance_check as pc
+
+        content_log = tmp_path / "content_log.json"
+        checks_dir = tmp_path / "pending_checks"
+        checks_dir.mkdir()
+        monkeypatch.setattr(pc, "CONTENT_LOG", str(content_log))
+        monkeypatch.setattr(pc, "PENDING_CHECKS_DIR", str(checks_dir))
+        return pc, content_log, checks_dir
+
+    @staticmethod
+    def _check(checks_dir, name, **fields):
+        data = {
+            "id": name,
+            "url": f"https://example.com/{name}",
+            "keyword": "k",
+            "site": "kaicalls",
+            "check_due": "2020-01-01T00:00:00+00:00",  # long past due
+            "status": "pending",
+        }
+        data.update(fields)
+        (checks_dir / f"{name}.json").write_text(json.dumps(data))
+
+    def test_get_pending_checks_skips_null_or_missing_url(self, perf):
+        pc, _, checks_dir = perf
+        self._check(checks_dir, "live")
+        self._check(checks_dir, "null-url", url=None)
+        no_url = {"id": "no-url-key", "keyword": "k", "site": "kaicalls",
+                  "check_due": "2020-01-01T00:00:00+00:00", "status": "pending"}
+        (checks_dir / "no-url-key.json").write_text(json.dumps(no_url))
+
+        due = pc.get_pending_checks()
+        assert [c["id"] for _, c in due] == ["live"]
+
+    def test_get_pending_checks_still_honors_status_and_due(self, perf):
+        pc, _, checks_dir = perf
+        self._check(checks_dir, "done", status="done")
+        self._check(checks_dir, "future", check_due="2999-01-01T00:00:00+00:00")
+        self._check(checks_dir, "due")
+        due = pc.get_pending_checks()
+        assert [c["id"] for _, c in due] == ["due"]
+
+    def test_reconcile_skips_approved_unpublished_null_url(self, perf):
+        pc, content_log, checks_dir = perf
+        entries = [
+            {
+                "id": "unpublished-1",
+                "url": None,
+                "status": "approved_unpublished",
+                "keyword": "k",
+                "site": "kaicalls",
+                "published_at": "2026-06-01T00:00:00+00:00",
+                "performance_30d": None,
+            },
+            {
+                "id": "live-1",
+                "url": "https://example.com/live",
+                "keyword": "k",
+                "site": "kaicalls",
+                "published_at": "2026-06-01T00:00:00+00:00",
+            },
+        ]
+        content_log.write_text(json.dumps(entries))
+        assert pc.reconcile_pending_checks() == 1
+        assert sorted(f.stem for f in checks_dir.glob("*.json")) == ["live-1"]
+
+
+# ---------------------------------------------------------------------------
+# performance_dashboard — dict-shaped grades + published_at
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceDashboard:
+    @pytest.fixture
+    def dash(self, tmp_path, monkeypatch):
+        from scripts.analytics import performance_dashboard as pd_mod
+
+        log_path = tmp_path / "content-log.jsonl"
+        monkeypatch.setattr(pd_mod, "CONTENT_LOG", log_path)
+        monkeypatch.setattr(pd_mod, "QUALITY_LOG", tmp_path / "content-quality.jsonl")
+        return pd_mod, log_path
+
+    @staticmethod
+    def _write_jsonl(path, entries):
+        path.write_text("\n".join(json.dumps(e) for e in entries) + "\n")
+
+    def test_weekly_summary_counts_dict_grades(self, dash):
+        pd_mod, log_path = dash
+        self._write_jsonl(log_path, [
+            {"id": "w", "published_at": "2026-06-01T00:00:00+00:00",
+             "performance_30d": {"grade": "winner", "gsc": {}}},
+            {"id": "a", "published_at": "2026-06-01T00:00:00+00:00",
+             "performance_30d": "average"},  # legacy string still counted
+            {"id": "u", "published_at": "2026-06-01T00:00:00+00:00",
+             "performance_30d": {"grade": "underperformer"}},
+            {"id": "p", "published_at": "2026-06-01T00:00:00+00:00"},
+        ])
+        perf = pd_mod.weekly_summary()["performance"]
+        assert perf["winners"] == 1
+        assert perf["average"] == 1
+        assert perf["underperformers"] == 1
+        assert perf["pending"] == 1
+        assert perf["win_rate"] == "33%"
+
+    def test_weekly_summary_uses_published_at(self, dash):
+        from datetime import datetime, timedelta, timezone
+
+        pd_mod, log_path = dash
+        recent = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        self._write_jsonl(log_path, [
+            {"id": "new", "published_at": recent},
+            {"id": "old", "published_at": "2020-01-01T00:00:00+00:00"},
+            {"id": "legacy", "publish_date": recent},  # legacy field counts too
+        ])
+        summary = pd_mod.weekly_summary()
+        assert summary["content_published_this_week"] == 2
+
+    def test_trend_analysis_counts_dict_grades(self, dash):
+        pd_mod, log_path = dash
+        self._write_jsonl(log_path, [
+            {"id": "w", "published_at": "2026-06-01T00:00:00+00:00",
+             "performance_30d": {"grade": "winner"}},
+            {"id": "u", "published_at": "2026-06-01T00:00:00+00:00",
+             "performance_30d": {"grade": "underperformer"}},
+        ])
+        trends = pd_mod.trend_analysis(weeks=520)
+        assert trends["total_published"] == 2
+        assert trends["total_winners"] == 1
+        week = trends["weekly_trend"][-1]
+        assert week["graded"] == 2
+        assert week["win_rate"] == "50%"
+
+
+# ---------------------------------------------------------------------------
+# report_cli / tracker_cli — dict-shaped grades in report buckets
+# ---------------------------------------------------------------------------
+
+
+class TestReportCli:
+    def test_text_report_counts_dict_grades(self, monkeypatch, capsys):
+        from scripts.content import report_cli as rc
+
+        entries = [
+            # No url/keyword → the CLI never attempts a live GSC/GA4 pull.
+            {"id": "w1", "keyword": "", "url": "",
+             "performance_30d": {"grade": "winner", "gsc": {}}},
+            {"id": "u1", "keyword": "", "url": "",
+             "performance_30d": "loser"},  # legacy alias → underperformer
+            {"id": "p1", "keyword": "", "url": ""},
+        ]
+        monkeypatch.setattr(rc, "_load_content_log", lambda: entries)
+        monkeypatch.setattr(sys, "argv", ["report_cli.py"])
+        rc.main()
+        out = capsys.readouterr().out
+        assert "Winners: 1" in out
+        assert "Under: 1" in out
+        assert "Pending: 1" in out
+        assert "[+] w1" in out
+        assert "(underperformer)" in out
+
+
+class TestTrackerCli:
+    def test_report_counts_dict_grades(self, monkeypatch, capsys):
+        from scripts.content import tracker_cli as tc
+
+        entries = [
+            {"id": "learning-loop-test-w1", "keyword": "", "url": "",
+             "performance_30d": {"grade": "winner", "gsc": {}}},
+            {"id": "learning-loop-test-u1", "keyword": "", "url": "",
+             "performance_30d": {"grade": "underperformer"}},
+            {"id": "learning-loop-test-p1", "keyword": "", "url": ""},
+        ]
+        monkeypatch.setattr(tc, "_load_log", lambda: entries)
+        rc = tc.cmd_report(argparse.Namespace(site=None, format="text"))
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert "Winners: 1" in out
+        assert "Under: 1" in out
+        assert "Pending: 1" in out

--- a/tests/test_phase2.py
+++ b/tests/test_phase2.py
@@ -308,9 +308,14 @@ async def test_failed_graph_execution_skips_descendants(use_test_db):
     # Sleep briefly to let the database updates and descendant skipping finish
     await asyncio.sleep(0.1)
 
-    # Verify that the parent is failed, child and grandchild are skipped, and graph is failed
+    # Verify that the parent is failed, child and grandchild are skipped, and
+    # the graph is flagged needs_replan (replan-instead-of-dead-end: the
+    # weekly CMO review re-decomposes remaining work instead of abandoning it)
     retrieved = use_test_db.get_task_graph(graph_id)
-    assert retrieved.status == "failed"
+    assert retrieved.status == "needs_replan"
     assert retrieved.nodes["node_parent"].status == "failed"
     assert retrieved.nodes["node_child"].status == "skipped"
     assert retrieved.nodes["node_grandchild"].status == "skipped"
+
+    # needs_replan graphs must drop out of the active set — execution stops.
+    assert all(g.graph_id != graph_id for g in use_test_db.list_active_task_graphs())

--- a/tests/test_profile_overlay.py
+++ b/tests/test_profile_overlay.py
@@ -1,0 +1,385 @@
+"""Tests for the durable business-profile overlay store.
+
+Covers: round-trip persistence, deep-merge precedence (overlay wins over
+config, defaults only fill gaps), cache invalidation after save, and
+onboarding answers persisting into the overlay.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from kai.runtime.business_profile import (
+    build_business_profile,
+    build_business_profile_from_brand,
+    clear_profile_overlay,
+    deep_merge_profile,
+    invalidate_profile_overlay_cache,
+    load_local_service_fixture,
+    load_profile_overlay,
+    load_profile_overlay_record,
+    profile_overlay_path,
+    save_profile_overlay,
+)
+from kai.runtime.loader import load_workspace_profile
+from kai.runtime.models import KaiBrandProfile
+from kai.runtime.onboarding import OnboardingFlow, extract_profile_facts
+
+
+@pytest.fixture()
+def runtime_dir(tmp_path, monkeypatch):
+    """Point KAI_RUNTIME_DIR at an isolated temp dir for each test."""
+    target = tmp_path / "runtime"
+    monkeypatch.setenv("KAI_RUNTIME_DIR", str(target))
+    invalidate_profile_overlay_cache()
+    load_workspace_profile.cache_clear()
+    yield target
+    invalidate_profile_overlay_cache()
+    load_workspace_profile.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Deep merge semantics
+# ---------------------------------------------------------------------------
+
+def test_deep_merge_nested_dicts_merge_lists_replace():
+    base = {
+        "identity": {"name": "Old", "tagline": "Keep me"},
+        "offers": {"upsells": ["a", "b"]},
+        "archetype": "local-service",
+    }
+    updates = {
+        "identity": {"name": "New"},
+        "offers": {"upsells": ["c"]},
+    }
+    merged = deep_merge_profile(base, updates)
+    assert merged["identity"]["name"] == "New"
+    assert merged["identity"]["tagline"] == "Keep me"
+    assert merged["offers"]["upsells"] == ["c"]  # lists replaced
+    assert merged["archetype"] == "local-service"
+    # Inputs not mutated
+    assert base["identity"]["name"] == "Old"
+    assert updates["offers"]["upsells"] == ["c"]
+
+
+# ---------------------------------------------------------------------------
+# Round trip
+# ---------------------------------------------------------------------------
+
+def test_save_and_load_round_trip(runtime_dir):
+    record = save_profile_overlay("test-brand", {"identity": {"tagline": "Learned in session"}})
+    assert record["brand_id"] == "test-brand"
+    assert record["updated_at"]
+
+    loaded = load_profile_overlay("test-brand")
+    assert loaded == {"identity": {"tagline": "Learned in session"}}
+
+    path = profile_overlay_path("test-brand")
+    assert path == runtime_dir / "profile" / "test-brand.json"
+    assert path.exists()
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["profile"]["identity"]["tagline"] == "Learned in session"
+
+
+def test_save_deep_merges_into_existing_overlay(runtime_dir):
+    save_profile_overlay("test-brand", {
+        "identity": {"tagline": "First"},
+        "trust": {"review_platforms": ["Google"]},
+    })
+    first_record = load_profile_overlay_record("test-brand")
+
+    save_profile_overlay("test-brand", {
+        "identity": {"year_founded": 2020},
+        "trust": {"review_platforms": ["Google", "Yelp"]},
+    })
+    payload = load_profile_overlay("test-brand")
+    assert payload["identity"] == {"tagline": "First", "year_founded": 2020}
+    assert payload["trust"]["review_platforms"] == ["Google", "Yelp"]  # lists replaced
+
+    second_record = load_profile_overlay_record("test-brand")
+    assert second_record["updated_at"] >= first_record["updated_at"]
+
+
+def test_save_strips_reserved_keys(runtime_dir):
+    save_profile_overlay("test-brand", {
+        "brand_id": "spoofed",
+        "updated_at": "1999-01-01T00:00:00",
+        "identity": {"name": "Real"},
+    })
+    payload = load_profile_overlay("test-brand")
+    assert "brand_id" not in payload
+    assert "updated_at" not in payload
+    record = load_profile_overlay_record("test-brand")
+    assert record["brand_id"] == "test-brand"
+    assert record["updated_at"] != "1999-01-01T00:00:00"
+
+
+def test_load_missing_overlay_returns_empty(runtime_dir):
+    assert load_profile_overlay("nobody-here") == {}
+    assert load_profile_overlay_record("nobody-here") == {}
+
+
+def test_save_requires_brand_id(runtime_dir):
+    with pytest.raises(ValueError):
+        save_profile_overlay("", {"identity": {"name": "x"}})
+    with pytest.raises(TypeError):
+        save_profile_overlay("test-brand", ["not", "a", "dict"])
+
+
+def test_brand_id_sanitized_for_filesystem(runtime_dir):
+    save_profile_overlay("weird/../brand id", {"identity": {"name": "Weird"}})
+    path = profile_overlay_path("weird/../brand id")
+    assert path.parent == runtime_dir / "profile"  # no traversal
+    assert path.exists()
+    assert load_profile_overlay("weird/../brand id")["identity"]["name"] == "Weird"
+
+
+def test_clear_profile_overlay(runtime_dir):
+    save_profile_overlay("test-brand", {"identity": {"name": "X"}})
+    assert clear_profile_overlay("test-brand") is True
+    assert load_profile_overlay("test-brand") == {}
+    assert clear_profile_overlay("test-brand") is False
+
+
+def test_corrupt_overlay_file_treated_as_empty(runtime_dir):
+    path = profile_overlay_path("test-brand")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not json", encoding="utf-8")
+    invalidate_profile_overlay_cache()
+    assert load_profile_overlay("test-brand") == {}
+    # A save recovers the file
+    save_profile_overlay("test-brand", {"identity": {"name": "Recovered"}})
+    assert load_profile_overlay("test-brand")["identity"]["name"] == "Recovered"
+
+
+# ---------------------------------------------------------------------------
+# Merge precedence in profile building
+# ---------------------------------------------------------------------------
+
+_RAW = {
+    "brand_id": "merge-brand",
+    "archetype": "local-service",
+    "identity": {"name": "Merge Co", "tagline": "From config"},
+    "offers": {"pricing_model": "hourly", "upsells": ["config upsell"]},
+}
+
+
+def test_overlay_wins_over_config_values(runtime_dir):
+    save_profile_overlay("merge-brand", {
+        "identity": {"tagline": "From overlay"},
+        "offers": {"pricing_model": "subscription"},
+    })
+    profile = build_business_profile(dict(_RAW))
+    assert profile.identity.tagline == "From overlay"
+    assert profile.offers.pricing_model == "subscription"
+    # Config siblings not named in the overlay survive
+    assert profile.identity.name == "Merge Co"
+    assert profile.offers.upsells == ["config upsell"]
+
+
+def test_overlay_lists_replace_config_lists(runtime_dir):
+    save_profile_overlay("merge-brand", {
+        "offers": {"upsells": ["overlay upsell"]},
+    })
+    profile = build_business_profile(dict(_RAW))
+    assert profile.offers.upsells == ["overlay upsell"]
+
+
+def test_defaults_still_fill_gaps_after_overlay(runtime_dir):
+    save_profile_overlay("merge-brand", {"identity": {"tagline": "From overlay"}})
+    profile = build_business_profile(dict(_RAW), apply_archetype_defaults=True)
+    # Archetype defaults fill fields set by neither config nor overlay
+    assert profile.goals.primary_kpi == "inbound_calls"
+    assert profile.geography.is_mobile is True
+    # ...but never overwrite config values
+    assert profile.offers.pricing_model == "hourly"
+
+
+def test_overlay_values_normalized_like_config(runtime_dir):
+    save_profile_overlay("merge-brand", {
+        "geography": {"primary_location": {"city": "Austin", "state": "Texas"}},
+    })
+    profile = build_business_profile(dict(_RAW))
+    assert profile.geography.primary_location.state == "TX"
+
+
+def test_apply_overlay_false_bypasses_overlay(runtime_dir):
+    save_profile_overlay("merge-brand", {"identity": {"tagline": "From overlay"}})
+    profile = build_business_profile(dict(_RAW), apply_overlay=False)
+    assert profile.identity.tagline == "From config"
+
+
+def test_overlay_applies_when_brand_id_derived_from_name(runtime_dir):
+    save_profile_overlay("my-cool-biz", {"identity": {"tagline": "Persisted"}})
+    profile = build_business_profile({"identity": {"name": "My Cool Biz"}})
+    assert profile.brand_id == "my-cool-biz"
+    assert profile.identity.tagline == "Persisted"
+
+
+def test_overlay_applies_for_brand_profile_builds(runtime_dir):
+    brand = KaiBrandProfile(
+        id="brand-built",
+        name="Brand Built",
+        primary_archetype="local-service",
+    )
+    save_profile_overlay("brand-built", {
+        "trust": {"review_count": 42},
+        "channels": {"phone_number": "(555) 000-1111"},
+    })
+    profile = build_business_profile_from_brand(brand)
+    assert profile.trust.review_count == 42
+    assert profile.channels.phone_number == "(555) 000-1111"
+    # And bypass still works
+    bare = build_business_profile_from_brand(brand, apply_overlay=False)
+    assert bare.trust.review_count is None
+
+
+def test_fixture_loaders_ignore_overlays(runtime_dir):
+    save_profile_overlay("truenorth-hvac", {"identity": {"name": "Hijacked"}})
+    profile = load_local_service_fixture()
+    assert profile.identity.name == "TrueNorth HVAC"
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation
+# ---------------------------------------------------------------------------
+
+def test_session_sees_its_own_writes(runtime_dir):
+    # Prime the read cache with "no overlay"
+    first = build_business_profile(dict(_RAW))
+    assert first.identity.tagline == "From config"
+
+    save_profile_overlay("merge-brand", {"identity": {"tagline": "Fresh write"}})
+    second = build_business_profile(dict(_RAW))
+    assert second.identity.tagline == "Fresh write"
+
+    # And updates to an already-read overlay are visible too
+    save_profile_overlay("merge-brand", {"identity": {"tagline": "Fresher write"}})
+    third = build_business_profile(dict(_RAW))
+    assert third.identity.tagline == "Fresher write"
+
+
+def test_save_busts_workspace_profile_cache(runtime_dir):
+    load_workspace_profile()
+    assert load_workspace_profile.cache_info().currsize == 1
+    save_profile_overlay("merge-brand", {"identity": {"tagline": "x"}})
+    assert load_workspace_profile.cache_info().currsize == 0
+
+
+def test_clear_busts_overlay_cache(runtime_dir):
+    save_profile_overlay("merge-brand", {"identity": {"tagline": "From overlay"}})
+    assert build_business_profile(dict(_RAW)).identity.tagline == "From overlay"
+    clear_profile_overlay("merge-brand")
+    assert build_business_profile(dict(_RAW)).identity.tagline == "From config"
+
+
+# ---------------------------------------------------------------------------
+# Onboarding persistence
+# ---------------------------------------------------------------------------
+
+def test_extract_profile_facts_maps_flat_answers():
+    updates = extract_profile_facts({
+        "business_name": "Facts Co",
+        "website_url": "https://facts.example",
+        "primary_service": "Roof Repair",
+        "service_list": "Roof Repair, Gutter Cleaning",
+        "pricing_model": "per-job",
+        "primary_city": "Denver",
+        "state_province": "Colorado",
+        "service_radius_miles": 25,
+        "phone_number": "(303) 555-0100",
+        "monthly_budget_range": "$1,000/month",
+        "archetype": "local_service",
+        "gbp_verified": True,
+        "_errors": ["ignore me"],
+        "onboarding_stage": "profile",
+        "empty_answer": "  ",
+        "none_answer": None,
+    })
+    assert updates["identity"] == {"name": "Facts Co", "url": "https://facts.example"}
+    assert updates["offers"]["primary_offer"] == "Roof Repair"
+    assert updates["offers"]["pricing_model"] == "per-job"
+    assert updates["offers"]["offer_list"] == [
+        {"name": "Roof Repair", "is_primary": True},
+        {"name": "Gutter Cleaning", "is_primary": False},
+    ]
+    assert updates["geography"]["primary_location"] == {
+        "city": "Denver", "state": "Colorado", "radius_miles": 25,
+    }
+    assert updates["channels"] == {"phone_number": "(303) 555-0100"}
+    assert updates["goals"] == {"monthly_budget_range": "$1,000/month"}
+    assert updates["archetype"] == "local-service"  # normalized
+    # Unknown scalar facts land in metadata; transient/blank keys are dropped
+    assert updates["metadata"] == {"gbp_verified": True}
+    assert "_errors" not in str(updates)
+
+
+def test_extract_profile_facts_passes_sections_through():
+    updates = extract_profile_facts({
+        "trust": {"review_count": 12, "review_platforms": ["Google"]},
+        "constraints": {"budget_ceiling": "$500/month"},
+    })
+    assert updates["trust"]["review_count"] == 12
+    assert updates["constraints"]["budget_ceiling"] == "$500/month"
+
+
+def test_record_profile_answers_persists_to_overlay(runtime_dir):
+    flow = OnboardingFlow()
+    result = flow.record_profile_answers("onboard-co", {
+        "business_name": "Onboard Co",
+        "primary_city": "Tampa",
+        "state_province": "Florida",
+        "phone_number": "(813) 555-0142",
+    })
+    assert result["persisted"] is True
+    assert result["updated_at"]
+
+    # Facts survive into subsequent profile builds (and future processes)
+    profile = build_business_profile({"brand_id": "onboard-co", "identity": {"name": "Onboard Co"}})
+    assert profile.geography.primary_location.city == "Tampa"
+    assert profile.geography.primary_location.state == "FL"
+    assert profile.channels.phone_number == "(813) 555-0142"
+    assert profile_overlay_path("onboard-co").exists()
+
+
+def test_record_profile_answers_with_nothing_durable(runtime_dir):
+    flow = OnboardingFlow()
+    result = flow.record_profile_answers("onboard-co", {"_errors": [], "onboarding_stage": "profile"})
+    assert result["persisted"] is False
+    assert not profile_overlay_path("onboard-co").exists()
+
+
+def test_create_brand_stub_persists_identity(runtime_dir):
+    flow = OnboardingFlow()
+    stub = flow.create_brand_stub(
+        brand_id="stub-co",
+        name="Stub Co",
+        archetype="local_service",
+        url="https://stub.example",
+    )
+    assert stub["onboarding_stage"] == "profile"  # stub shape unchanged
+
+    overlay = load_profile_overlay("stub-co")
+    assert overlay["identity"] == {"name": "Stub Co", "url": "https://stub.example"}
+    assert overlay["archetype"] == "local-service"  # normalized for the builder
+
+    profile = build_business_profile({"brand_id": "stub-co"})
+    assert profile.identity.name == "Stub Co"
+    assert profile.identity.url == "https://stub.example"
+    assert profile.archetype == "local-service"
+    # Normalized archetype means local-service defaults apply
+    assert profile.goals.primary_kpi == "inbound_calls"
+
+
+def test_create_brand_stub_persist_opt_out(runtime_dir):
+    flow = OnboardingFlow()
+    flow.create_brand_stub(brand_id="quiet-co", name="Quiet Co", persist_profile=False)
+    assert not profile_overlay_path("quiet-co").exists()
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_publish_truthfulness.py
+++ b/tests/test_publish_truthfulness.py
@@ -1,0 +1,656 @@
+"""Publish truthfulness + idempotency tests.
+
+Covers the fix for the fabricated-URL bug: the engine used to log
+`https://<site>.com/<keyword-slug>` on approval WITHOUT publishing, which
+scheduled 30-day checks against URLs that never existed and poisoned the
+GSC learning loop (performance_check.py filters by logged url).
+
+Invariants enforced here:
+  - No fabricated URLs: publishing disabled/unconfigured -> url=None,
+    status "approved_unpublished".
+  - No 30-day pending check without a REAL url.
+  - mark_published() backfills the real URL and schedules the check.
+  - log_entry dedupes on (site, content_hash); engine re-runs skip publish
+    when the same hash already shipped for that site.
+  - WordPress publisher updates an existing slug instead of duplicating.
+  - Calendar path is configurable (KAI_CONTENT_CALENDAR_PATH), not hardcoded.
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+import scripts.content.content_log as cl
+from scripts.content.content_log import (
+    compute_content_hash,
+    find_entry_by_hash,
+    load_log,
+    log_entry,
+    mark_published,
+)
+
+
+BODY = "Rodriguez Air missed 19 calls a week between 6pm and 8am. Each cost $410."
+
+
+@pytest.fixture()
+def sandbox(tmp_path, monkeypatch):
+    """Isolate content log, pending checks, and calendar under tmp_path."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    log_file = data_dir / "content_log.json"
+    calendar = data_dir / "content-calendar.md"
+    monkeypatch.setattr(cl._CFG, "data_dir", data_dir)
+    monkeypatch.setattr(cl, "LOG_FILE", str(log_file))
+    monkeypatch.setenv("KAI_CONTENT_CALENDAR_PATH", str(calendar))
+    # Publishing OFF unless a test opts in.
+    monkeypatch.delenv("KAI_PUBLISH_ENABLED", raising=False)
+    monkeypatch.setenv("CMO_CONFIG_PATH", str(tmp_path / "no-such-config.yaml"))
+    return {
+        "data_dir": data_dir,
+        "log_file": str(log_file),
+        "checks_dir": data_dir / "pending_checks",
+        "calendar": calendar,
+    }
+
+
+def _checks(sandbox) -> list[Path]:
+    checks_dir = sandbox["checks_dir"]
+    return sorted(checks_dir.glob("*.json")) if checks_dir.exists() else []
+
+
+# ---------------------------------------------------------------------------
+# content_log: truthfulness
+# ---------------------------------------------------------------------------
+
+
+class TestLogEntryTruthfulness:
+    def test_unpublished_entry_has_no_url_and_no_check(self, sandbox):
+        entry = log_entry(
+            url=None,
+            keyword="ai receptionist",
+            site="kaicalls",
+            format="blog",
+            content_hash=compute_content_hash(BODY),
+            log_file=sandbox["log_file"],
+        )
+        assert entry["url"] is None
+        assert entry["status"] == "approved_unpublished"
+        assert _checks(sandbox) == []
+        # Calendar tracks live content only — no line for unpublished pieces.
+        assert not sandbox["calendar"].exists()
+
+    def test_published_entry_schedules_check_and_calendar(self, sandbox):
+        entry = log_entry(
+            url="https://kaicalls.com/blog/real-post",
+            keyword="ai receptionist",
+            site="kaicalls",
+            format="blog",
+            content_hash=compute_content_hash(BODY),
+            log_file=sandbox["log_file"],
+        )
+        assert entry["status"] == "published"
+        checks = _checks(sandbox)
+        assert len(checks) == 1
+        check = json.loads(checks[0].read_text())
+        assert check["url"] == "https://kaicalls.com/blog/real-post"
+        assert "kaicalls.com" in sandbox["calendar"].read_text()
+
+    def test_schedule_check_refuses_urlless_entry(self, sandbox):
+        assert cl.schedule_30day_check({"id": "x", "url": None}) is None
+        assert _checks(sandbox) == []
+
+    def test_legacy_entries_without_status_or_hash_tolerated(self, sandbox):
+        legacy = {
+            "id": "kaicalls-20250101-000000",
+            "url": "https://kaicalls.com/old-post",
+            "keyword": "old keyword",
+            "site": "kaicalls",
+            "format": "blog",
+            "published_at": "2025-01-01T00:00:00+00:00",
+            "performance_30d": None,
+        }
+        Path(sandbox["log_file"]).write_text(json.dumps([legacy]))
+        # New entries do not dedupe against legacy entries (no content_hash)…
+        entry = log_entry(
+            url=None,
+            keyword="old keyword",
+            site="kaicalls",
+            format="blog",
+            content_hash=compute_content_hash(BODY),
+            log_file=sandbox["log_file"],
+        )
+        entries = load_log(sandbox["log_file"])
+        assert len(entries) == 2
+        assert entry["status"] == "approved_unpublished"
+        # …and hash lookup never matches a legacy entry.
+        assert find_entry_by_hash("kaicalls", "", log_file=sandbox["log_file"]) is None
+
+
+class TestMarkPublished:
+    def test_backfills_url_and_schedules_check(self, sandbox):
+        entry = log_entry(
+            url=None,
+            keyword="ai receptionist",
+            site="kaicalls",
+            format="blog",
+            content_hash=compute_content_hash(BODY),
+            log_file=sandbox["log_file"],
+        )
+        assert _checks(sandbox) == []
+
+        updated = mark_published(
+            entry["id"],
+            "https://kaicalls.com/blog/shipped",
+            log_file=sandbox["log_file"],
+        )
+        assert updated["status"] == "published"
+        assert updated["url"] == "https://kaicalls.com/blog/shipped"
+
+        persisted = load_log(sandbox["log_file"])[0]
+        assert persisted["url"] == "https://kaicalls.com/blog/shipped"
+        checks = _checks(sandbox)
+        assert len(checks) == 1
+        check = json.loads(checks[0].read_text())
+        assert check["url"] == "https://kaicalls.com/blog/shipped"
+        assert "shipped" in sandbox["calendar"].read_text()
+
+    def test_check_due_thirty_days_after_published_at(self, sandbox):
+        entry = log_entry(
+            url=None,
+            keyword="k",
+            site="kaicalls",
+            format="blog",
+            content_hash=compute_content_hash(BODY),
+            log_file=sandbox["log_file"],
+        )
+        published_at = "2026-06-01T12:00:00+00:00"
+        mark_published(
+            entry["id"],
+            "https://kaicalls.com/blog/x",
+            published_at=published_at,
+            log_file=sandbox["log_file"],
+        )
+        check = json.loads(_checks(sandbox)[0].read_text())
+        due = datetime.fromisoformat(check["check_due"])
+        assert due == datetime.fromisoformat(published_at) + timedelta(days=30)
+
+    def test_unknown_id_or_empty_url_returns_none(self, sandbox):
+        assert mark_published("nope", "https://x.com/y", log_file=sandbox["log_file"]) is None
+        assert mark_published("nope", "", log_file=sandbox["log_file"]) is None
+
+
+# ---------------------------------------------------------------------------
+# content_log: idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestContentHashDedup:
+    def test_same_site_and_hash_updates_in_place(self, sandbox):
+        content_hash = compute_content_hash(BODY)
+        first = log_entry(
+            url=None, keyword="k", site="kaicalls", format="blog",
+            content_hash=content_hash, log_file=sandbox["log_file"],
+        )
+        second = log_entry(
+            url=None, keyword="k", site="kaicalls", format="blog",
+            notes="second run", content_hash=content_hash,
+            log_file=sandbox["log_file"],
+        )
+        entries = load_log(sandbox["log_file"])
+        assert len(entries) == 1
+        assert second["id"] == first["id"]
+        assert entries[0]["notes"] == "second run"
+        assert "updated_at" in entries[0]
+
+    def test_different_site_same_hash_appends(self, sandbox):
+        content_hash = compute_content_hash(BODY)
+        log_entry(url=None, keyword="k", site="kaicalls", format="blog",
+                  content_hash=content_hash, log_file=sandbox["log_file"])
+        log_entry(url=None, keyword="k", site="buildwithkai", format="blog",
+                  content_hash=content_hash, log_file=sandbox["log_file"])
+        assert len(load_log(sandbox["log_file"])) == 2
+
+    def test_dedup_never_downgrades_published_entry(self, sandbox):
+        content_hash = compute_content_hash(BODY)
+        log_entry(
+            url="https://kaicalls.com/blog/live", keyword="k", site="kaicalls",
+            format="blog", content_hash=content_hash, log_file=sandbox["log_file"],
+        )
+        # Re-run without a URL must not clobber the real one.
+        log_entry(
+            url=None, keyword="k", site="kaicalls", format="blog",
+            content_hash=content_hash, log_file=sandbox["log_file"],
+        )
+        entry = load_log(sandbox["log_file"])[0]
+        assert entry["url"] == "https://kaicalls.com/blog/live"
+        assert entry["status"] == "published"
+        assert len(_checks(sandbox)) == 1  # not rescheduled
+
+    def test_dedup_update_with_url_publishes_and_schedules(self, sandbox):
+        content_hash = compute_content_hash(BODY)
+        log_entry(url=None, keyword="k", site="kaicalls", format="blog",
+                  content_hash=content_hash, log_file=sandbox["log_file"])
+        assert _checks(sandbox) == []
+        log_entry(
+            url="https://kaicalls.com/blog/now-live", keyword="k",
+            site="kaicalls", format="blog", content_hash=content_hash,
+            log_file=sandbox["log_file"],
+        )
+        entries = load_log(sandbox["log_file"])
+        assert len(entries) == 1
+        assert entries[0]["status"] == "published"
+        assert len(_checks(sandbox)) == 1
+
+    def test_republish_rerun_never_restamps_published_at(self, sandbox):
+        """An engine re-run (already_published -> log_entry(url=prior_url))
+        must not reset published_at: re-stamping re-counts the piece as new
+        and shifts the 30-day measurement window (EC-12 reconciliation
+        rebuilds check_due from published_at)."""
+        content_hash = compute_content_hash(BODY)
+        log_entry(
+            url="https://kaicalls.com/blog/live", keyword="k", site="kaicalls",
+            format="blog", content_hash=content_hash, log_file=sandbox["log_file"],
+        )
+        # Age the entry so a re-stamp would be visible.
+        entries = load_log(sandbox["log_file"])
+        entries[0]["published_at"] = "2026-01-01T00:00:00+00:00"
+        cl.save_log(entries, sandbox["log_file"])
+
+        log_entry(
+            url="https://kaicalls.com/blog/live", keyword="k", site="kaicalls",
+            format="blog", notes="re-run", content_hash=content_hash,
+            log_file=sandbox["log_file"],
+        )
+        entries = load_log(sandbox["log_file"])
+        assert len(entries) == 1
+        assert entries[0]["published_at"] == "2026-01-01T00:00:00+00:00"
+        assert entries[0]["status"] == "published"
+        assert entries[0]["notes"] == "re-run"  # metadata still updates
+        assert len(_checks(sandbox)) == 1  # not rescheduled
+        # Calendar not double-appended either.
+        calendar_text = sandbox["calendar"].read_text()
+        assert calendar_text.count("https://kaicalls.com/blog/live") == 1
+
+
+# ---------------------------------------------------------------------------
+# engine: publish decision (no fabricated URLs, gated by config)
+# ---------------------------------------------------------------------------
+
+
+class TestEnginePublishDecision:
+    def _write_publishing_config(self, tmp_path, monkeypatch, enabled=True, sites=None):
+        cfg = tmp_path / "config.yaml"
+        lines = ["publishing:", f"  enabled: {'true' if enabled else 'false'}"]
+        if sites:
+            lines.append("  sites:")
+            for site, platform in sites.items():
+                lines.append(f"    {site}:")
+                lines.append(f"      platform: {platform}")
+        cfg.write_text("\n".join(lines) + "\n")
+        monkeypatch.setenv("CMO_CONFIG_PATH", str(cfg))
+
+    def test_disabled_by_default_no_fabricated_url(self, sandbox, monkeypatch, tmp_path):
+        from scripts.content.engine import _publish_if_configured
+
+        called = []
+        monkeypatch.setattr("scripts.publish.publish", lambda *a, **k: called.append(1))
+        info = _publish_if_configured(
+            site="kaicalls", title="T", body=BODY,
+            content_hash=compute_content_hash(BODY), keyword="ai receptionist",
+            log_file=sandbox["log_file"],
+        )
+        assert info["published"] is False
+        assert info["url"] is None
+        assert info["skipped"] == "publishing_disabled"
+        assert called == []
+
+    def test_enabled_but_site_unconfigured(self, sandbox, monkeypatch, tmp_path):
+        from scripts.content.engine import _publish_if_configured
+
+        monkeypatch.setenv("KAI_PUBLISH_ENABLED", "1")
+        info = _publish_if_configured(
+            site="kaicalls", title="T", body=BODY,
+            content_hash=compute_content_hash(BODY), keyword="k",
+            log_file=sandbox["log_file"],
+        )
+        assert info["published"] is False
+        assert info["url"] is None
+        assert info["skipped"] == "site_not_configured"
+
+    def test_env_override_wins_over_config(self, sandbox, monkeypatch, tmp_path):
+        from scripts.harness_config import publishing_enabled
+
+        self._write_publishing_config(tmp_path, monkeypatch, enabled=True)
+        monkeypatch.setenv("KAI_PUBLISH_ENABLED", "0")
+        assert publishing_enabled() is False
+        monkeypatch.setenv("KAI_PUBLISH_ENABLED", "1")
+        assert publishing_enabled() is True
+
+    def test_configured_publish_logs_real_url(self, sandbox, monkeypatch, tmp_path):
+        from scripts.content.engine import _publish_if_configured
+
+        self._write_publishing_config(
+            tmp_path, monkeypatch, enabled=True, sites={"kaicalls": "wordpress"}
+        )
+        captured = {}
+
+        def fake_publish(platform, **kwargs):
+            captured["platform"] = platform
+            captured.update(kwargs)
+            return {"success": True, "url": "https://kaicalls.com/?p=99", "id": 99}
+
+        monkeypatch.setattr("scripts.publish.publish", fake_publish)
+        info = _publish_if_configured(
+            site="kaicalls", title="T", body=BODY,
+            content_hash=compute_content_hash(BODY), keyword="AI Receptionist!",
+            log_file=sandbox["log_file"],
+        )
+        assert info["published"] is True
+        assert info["url"] == "https://kaicalls.com/?p=99"  # REAL url from publisher
+        assert captured["platform"] == "wordpress"
+        assert captured["slug"] == "ai-receptionist"
+        assert captured["status"] == "draft"  # safe default: never auto-live
+
+    def test_publish_failure_yields_unpublished(self, sandbox, monkeypatch, tmp_path):
+        from scripts.content.engine import _publish_if_configured
+
+        self._write_publishing_config(
+            tmp_path, monkeypatch, enabled=True, sites={"kaicalls": "wordpress"}
+        )
+        monkeypatch.setattr(
+            "scripts.publish.publish",
+            lambda platform, **k: {"success": False, "message": "boom"},
+        )
+        info = _publish_if_configured(
+            site="kaicalls", title="T", body=BODY,
+            content_hash=compute_content_hash(BODY), keyword="k",
+            log_file=sandbox["log_file"],
+        )
+        assert info["published"] is False
+        assert info["url"] is None
+        assert info["skipped"] == "publish_failed"
+
+    def test_rerun_with_same_hash_skips_publish(self, sandbox, monkeypatch, tmp_path):
+        from scripts.content.engine import _publish_if_configured
+
+        self._write_publishing_config(
+            tmp_path, monkeypatch, enabled=True, sites={"kaicalls": "wordpress"}
+        )
+        content_hash = compute_content_hash(BODY)
+        calls = []
+
+        def fake_publish(platform, **kwargs):
+            calls.append(platform)
+            return {"success": True, "url": "https://kaicalls.com/?p=7", "id": 7}
+
+        monkeypatch.setattr("scripts.publish.publish", fake_publish)
+
+        first = _publish_if_configured(
+            site="kaicalls", title="T", body=BODY, content_hash=content_hash,
+            keyword="k", log_file=sandbox["log_file"],
+        )
+        # Engine logs the entry after publishing — simulate that.
+        log_entry(
+            url=first["url"], keyword="k", site="kaicalls", format="blog",
+            content_hash=content_hash, status="published",
+            log_file=sandbox["log_file"],
+        )
+
+        second = _publish_if_configured(
+            site="kaicalls", title="T", body=BODY, content_hash=content_hash,
+            keyword="k", log_file=sandbox["log_file"],
+        )
+        assert calls == ["wordpress"]  # publisher hit exactly once
+        assert second["published"] is True
+        assert second["skipped"] == "already_published"
+        assert second["url"] == "https://kaicalls.com/?p=7"
+
+    def test_slugify(self):
+        from scripts.content.engine import _slugify
+
+        assert _slugify("AI Receptionist for Law Firms") == "ai-receptionist-for-law-firms"
+        assert _slugify("  weird -- punctuation!! ") == "weird-punctuation"
+
+
+# ---------------------------------------------------------------------------
+# Reader compatibility: reconcile must never rebuild checks for url-less entries
+# ---------------------------------------------------------------------------
+
+
+class TestReaderCompatibility:
+    def test_reconcile_skips_approved_unpublished_entries(self, sandbox, monkeypatch):
+        import scripts.self_improvement.performance_check as pc
+
+        checks_dir = sandbox["data_dir"] / "pending_checks"
+        entries = [
+            {
+                "id": "kaicalls-20260701-000000",
+                "url": None,
+                "status": "approved_unpublished",
+                "keyword": "k",
+                "site": "kaicalls",
+                "format": "blog",
+                "published_at": "2026-07-01T00:00:00+00:00",
+                "performance_30d": None,
+                "content_hash": compute_content_hash(BODY),
+            },
+            {
+                "id": "kaicalls-20260702-000000",
+                "url": "https://kaicalls.com/blog/live",
+                "keyword": "k2",
+                "site": "kaicalls",
+                "published_at": "2026-07-02T00:00:00+00:00",
+                "performance_30d": None,
+            },
+        ]
+        Path(sandbox["log_file"]).write_text(json.dumps(entries))
+        monkeypatch.setattr(pc, "CONTENT_LOG", sandbox["log_file"])
+        monkeypatch.setattr(pc, "PENDING_CHECKS_DIR", str(checks_dir))
+
+        recreated = pc.reconcile_pending_checks()
+        assert recreated == 1  # only the entry with a REAL url
+        files = sorted(checks_dir.glob("*.json"))
+        assert [f.stem for f in files] == ["kaicalls-20260702-000000"]
+
+
+# ---------------------------------------------------------------------------
+# WordPress publisher idempotency (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, json_data, status=200):
+        self._json = json_data
+        self.status_code = status
+        self.ok = status < 400
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        pass
+
+
+class TestWordPressIdempotency:
+    @pytest.fixture(autouse=True)
+    def wp_env(self, monkeypatch):
+        monkeypatch.setenv("WP_URL", "https://test.example.com")
+        monkeypatch.setenv("WP_USERNAME", "admin")
+        monkeypatch.setenv("WP_APP_PASSWORD", "app-pass")
+
+    def test_existing_slug_updates_instead_of_creating(self, monkeypatch):
+        import scripts.publish.wordpress as wp
+
+        posted = {}
+
+        def fake_get(url, **kwargs):
+            assert url.endswith("/wp-json/wp/v2/posts")
+            assert kwargs["params"] == {"slug": "my-post", "status": "any"}
+            return _Resp([{"id": 42, "link": "https://test.example.com/my-post/"}])
+
+        def fake_post(url, **kwargs):
+            posted["url"] = url
+            return _Resp(
+                {"id": 42, "link": "https://test.example.com/my-post/", "status": "draft"}
+            )
+
+        monkeypatch.setattr(wp.requests, "get", fake_get)
+        monkeypatch.setattr(wp.requests, "post", fake_post)
+
+        result = wp.publish(title="T", body="plain body", slug="my-post")
+        assert result["success"] is True
+        assert result["updated"] is True
+        assert posted["url"].endswith("/wp-json/wp/v2/posts/42")  # update, not create
+        assert result["url"] == "https://test.example.com/my-post/"
+
+    def test_no_existing_slug_creates_new_post(self, monkeypatch):
+        import scripts.publish.wordpress as wp
+
+        posted = {}
+        monkeypatch.setattr(wp.requests, "get", lambda url, **k: _Resp([]))
+
+        def fake_post(url, **kwargs):
+            posted["url"] = url
+            return _Resp(
+                {"id": 7, "link": "https://test.example.com/new-post/", "status": "draft"}
+            )
+
+        monkeypatch.setattr(wp.requests, "post", fake_post)
+        result = wp.publish(title="T", body="plain body", slug="new-post")
+        assert result["success"] is True
+        assert result["updated"] is False
+        assert posted["url"].endswith("/wp-json/wp/v2/posts")
+
+    def test_update_omits_status_so_existing_post_is_never_demoted(self, monkeypatch):
+        """Slug-idempotent updates must not send the engine's default
+        status=draft to an existing post — WP preserves current status when
+        the field is absent."""
+        import scripts.publish.wordpress as wp
+
+        posted = {}
+
+        def fake_get(url, **kwargs):
+            return _Resp([{"id": 42, "status": "draft",
+                           "link": "https://test.example.com/my-post/"}])
+
+        def fake_post(url, **kwargs):
+            posted["url"] = url
+            posted["json"] = kwargs["json"]
+            return _Resp(
+                {"id": 42, "link": "https://test.example.com/my-post/", "status": "draft"}
+            )
+
+        monkeypatch.setattr(wp.requests, "get", fake_get)
+        monkeypatch.setattr(wp.requests, "post", fake_post)
+
+        result = wp.publish(title="T", body="plain body", slug="my-post", status="draft")
+        assert result["success"] is True
+        assert result["updated"] is True
+        assert posted["url"].endswith("/wp-json/wp/v2/posts/42")
+        assert "status" not in posted["json"]  # existing status preserved
+
+    def test_live_post_is_never_demoted_or_overwritten(self, monkeypatch):
+        """A human published this post in WP admin. A draft-status re-run
+        must leave it untouched (no unpublish, no content overwrite) — that
+        would be a live-channel mutation without approval."""
+        import scripts.publish.wordpress as wp
+
+        def fake_get(url, **kwargs):
+            return _Resp([{"id": 42, "status": "publish",
+                           "link": "https://test.example.com/my-post/"}])
+
+        def fail_post(url, **kwargs):  # pragma: no cover - must never run
+            raise AssertionError("live post must not be mutated")
+
+        monkeypatch.setattr(wp.requests, "get", fake_get)
+        monkeypatch.setattr(wp.requests, "post", fail_post)
+
+        result = wp.publish(title="T", body="regenerated body", slug="my-post", status="draft")
+        assert result["success"] is True
+        assert result["updated"] is False
+        assert result["skipped"] == "existing_live_post"
+        assert result["status"] == "publish"
+        assert result["url"] == "https://test.example.com/my-post/"
+
+    def test_explicit_publish_can_update_live_post(self, monkeypatch):
+        """status=publish is an explicit human ask (CLI --publish) — that IS
+        the approval, so the update proceeds and keeps status=publish."""
+        import scripts.publish.wordpress as wp
+
+        posted = {}
+
+        def fake_get(url, **kwargs):
+            return _Resp([{"id": 42, "status": "publish",
+                           "link": "https://test.example.com/my-post/"}])
+
+        def fake_post(url, **kwargs):
+            posted["url"] = url
+            posted["json"] = kwargs["json"]
+            return _Resp(
+                {"id": 42, "link": "https://test.example.com/my-post/", "status": "publish"}
+            )
+
+        monkeypatch.setattr(wp.requests, "get", fake_get)
+        monkeypatch.setattr(wp.requests, "post", fake_post)
+
+        result = wp.publish(title="T", body="refreshed body", slug="my-post", status="publish")
+        assert result["success"] is True
+        assert result["updated"] is True
+        assert posted["url"].endswith("/wp-json/wp/v2/posts/42")
+        assert posted["json"]["status"] == "publish"
+
+    def test_lookup_failure_falls_back_to_create(self, monkeypatch):
+        import scripts.publish.wordpress as wp
+
+        def broken_get(url, **kwargs):
+            raise RuntimeError("network down")
+
+        posted = {}
+
+        def fake_post(url, **kwargs):
+            posted["url"] = url
+            return _Resp({"id": 8, "link": "https://test.example.com/p/", "status": "draft"})
+
+        monkeypatch.setattr(wp.requests, "get", broken_get)
+        monkeypatch.setattr(wp.requests, "post", fake_post)
+        result = wp.publish(title="T", body="plain body", slug="p")
+        assert result["success"] is True
+        assert posted["url"].endswith("/wp-json/wp/v2/posts")
+
+
+# ---------------------------------------------------------------------------
+# Calendar path de-hardcoding
+# ---------------------------------------------------------------------------
+
+
+class TestCalendarPath:
+    def test_env_override(self, sandbox):
+        # sandbox sets KAI_CONTENT_CALENDAR_PATH — a published entry lands there.
+        log_entry(
+            url="https://kaicalls.com/blog/a", keyword="k", site="kaicalls",
+            format="blog", content_hash=compute_content_hash(BODY),
+            log_file=sandbox["log_file"],
+        )
+        assert sandbox["calendar"].exists()
+        assert "/opt/meetkai-data" not in str(sandbox["calendar"])
+
+    def test_default_lands_under_data_dir(self, tmp_path, monkeypatch):
+        from scripts.harness_config import get_config, get_content_calendar_path
+
+        monkeypatch.delenv("KAI_CONTENT_CALENDAR_PATH", raising=False)
+        path = get_content_calendar_path()
+        assert path == get_config().data_dir / "content-calendar.md"
+
+    def test_calendar_write_failure_never_crashes(self, sandbox, monkeypatch):
+        monkeypatch.setenv(
+            "KAI_CONTENT_CALENDAR_PATH", "/proc/definitely/not/writable/cal.md"
+        )
+        entry = log_entry(
+            url="https://kaicalls.com/blog/b", keyword="k", site="kaicalls",
+            format="blog", content_hash=compute_content_hash(BODY),
+            log_file=sandbox["log_file"],
+        )
+        assert entry["status"] == "published"  # publish survives calendar failure

--- a/tests/test_scheduler_selfimprovement.py
+++ b/tests/test_scheduler_selfimprovement.py
@@ -1,0 +1,346 @@
+"""Tests for scheduler self-containment: default self-improvement tasks
+seeded into the scheduler, plus the wrapping task handlers.
+
+Verifies:
+- create_default_tasks() seeds performance_check_30d (0 2 * * *),
+  pattern_extract_weekly (0 14 * * 1), harness_defaults_update (30 14 * * 1)
+  and editorial_calendar_tick (hourly), and stays idempotent
+- handlers are registered and degrade gracefully (missing credentials /
+  dependencies are data gaps, never exceptions that crash the loop)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from agent.models import AgentDatabase
+from agent.scheduler import Scheduler
+from agent.tasks import get_task_handler
+import agent.tasks.self_improvement as si
+
+
+NEW_DEFAULT_TASKS = {
+    "30-Day Performance Check": ("0 2 * * *", "performance_check_30d"),
+    "Weekly Pattern Extraction": ("0 14 * * 1", "pattern_extract_weekly"),
+    "Harness Defaults Update": ("30 14 * * 1", "harness_defaults_update"),
+    "Editorial Calendar Tick": ("0 * * * *", "editorial_calendar_tick"),
+}
+
+
+@pytest.fixture
+def scheduler(tmp_path):
+    sched = Scheduler()
+    sched.db = AgentDatabase(db_path=tmp_path / "sched_test.db")
+    return sched
+
+
+# ---------------------------------------------------------------------------
+# Default task seeding
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultTaskSeeding:
+    def test_self_improvement_tasks_seeded(self, scheduler):
+        scheduler.create_default_tasks()
+        tasks = {t.name: t for t in scheduler.db.list_scheduled_tasks(enabled_only=False)}
+
+        for name, (cron, task_type) in NEW_DEFAULT_TASKS.items():
+            assert name in tasks, f"default task missing: {name}"
+            assert tasks[name].cron_expression == cron
+            assert tasks[name].task_type == task_type
+            assert tasks[name].enabled is True
+            assert tasks[name].next_run_at is not None
+
+    def test_seeding_is_idempotent(self, scheduler):
+        scheduler.create_default_tasks()
+        first = scheduler.db.list_scheduled_tasks(enabled_only=False)
+        scheduler.create_default_tasks()
+        second = scheduler.db.list_scheduled_tasks(enabled_only=False)
+        assert len(first) == len(second)
+        # No duplicate names
+        names = [t.name for t in second]
+        assert len(names) == len(set(names))
+
+    def test_every_seeded_task_type_has_new_handlers(self, scheduler):
+        """The four new task types must resolve to registered handlers."""
+        for _, (_, task_type) in NEW_DEFAULT_TASKS.items():
+            handler = get_task_handler(task_type)
+            assert handler is not None, f"no handler registered for {task_type}"
+            assert handler.task_type == task_type
+
+
+# ---------------------------------------------------------------------------
+# performance_check_30d handler
+# ---------------------------------------------------------------------------
+
+
+class TestPerformanceCheck30d:
+    def test_no_pending_checks(self, monkeypatch):
+        import scripts.self_improvement.performance_check as pc
+        monkeypatch.setattr(pc, "reconcile_pending_checks", lambda: 2)
+        monkeypatch.setattr(pc, "get_pending_checks", lambda: [])
+
+        result = asyncio.run(si.PerformanceCheck30dTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert result["checked"] == 0
+        assert result["reconciled"] == 2
+        assert "No 30-day checks due" in result["summary"]
+
+    def test_missing_google_creds_is_data_gap_not_grading(self, monkeypatch, tmp_path):
+        """Without GSC/GA4 creds, due checks are DEFERRED — never graded as
+        zeros (memory/lessons.md 2026-06-09)."""
+        import scripts.self_improvement.performance_check as pc
+        monkeypatch.setattr(pc, "reconcile_pending_checks", lambda: 0)
+        monkeypatch.setattr(
+            pc, "get_pending_checks",
+            lambda: [(tmp_path / "c1.json", {"id": "c1"})],
+        )
+
+        def fail_run_check(*args, **kwargs):
+            raise AssertionError("run_check must not be called without credentials")
+
+        monkeypatch.setattr(pc, "run_check", fail_run_check)
+        monkeypatch.delenv("GOOGLE_CREDENTIALS_PATH", raising=False)
+
+        result = asyncio.run(si.PerformanceCheck30dTask().execute(MagicMock()))
+        assert result["success"] is False
+        assert result["data_gap"] is True
+        assert result["deferred"] == 1
+        assert "GOOGLE_CREDENTIALS_PATH" in result["error"]
+
+    def test_runs_due_checks_with_creds(self, monkeypatch, tmp_path):
+        import scripts.self_improvement.performance_check as pc
+
+        creds = tmp_path / "creds.json"
+        creds.write_text("{}")
+        monkeypatch.setenv("GOOGLE_CREDENTIALS_PATH", str(creds))
+
+        monkeypatch.setattr(pc, "reconcile_pending_checks", lambda: 1)
+        monkeypatch.setattr(
+            pc, "get_pending_checks",
+            lambda: [
+                (tmp_path / "a.json", {"id": "a"}),
+                (tmp_path / "b.json", {"id": "b"}),
+            ],
+        )
+        run_calls = []
+
+        def fake_run_check(check_file, check, **kwargs):
+            run_calls.append(check["id"])
+            return {
+                "entry_id": check["id"],
+                "url": f"https://x.test/{check['id']}",
+                "evaluation": {"is_winner": check["id"] == "a"},
+            }
+
+        monkeypatch.setattr(pc, "run_check", fake_run_check)
+
+        # Winner → pattern extraction via subprocess; stub it out.
+        sub_calls = []
+
+        def fake_subprocess_run(cmd, **kwargs):
+            sub_calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(si.subprocess, "run", fake_subprocess_run)
+
+        result = asyncio.run(si.PerformanceCheck30dTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert result["checked"] == 2
+        assert result["winners"] == 1
+        assert run_calls == ["a", "b"]
+        assert len(sub_calls) == 1
+        assert "--url" in sub_calls[0]
+        assert "https://x.test/a" in sub_calls[0]
+
+    def test_exception_contained_not_raised(self, monkeypatch):
+        import scripts.self_improvement.performance_check as pc
+        monkeypatch.setattr(pc, "reconcile_pending_checks", lambda: 0)
+
+        def boom():
+            raise RuntimeError("db locked")
+
+        monkeypatch.setattr(pc, "get_pending_checks", boom)
+        result = asyncio.run(si.PerformanceCheck30dTask().execute(MagicMock()))
+        assert result["success"] is False
+        assert "db locked" in result["error"]
+
+    def test_import_failure_is_graceful(self, monkeypatch):
+        monkeypatch.setattr(si, "_import_module", lambda dotted: (None, "no module"))
+        result = asyncio.run(si.PerformanceCheck30dTask().execute(MagicMock()))
+        assert result["success"] is False
+        assert "unavailable" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# pattern_extract_weekly handler
+# ---------------------------------------------------------------------------
+
+
+class TestPatternExtractWeekly:
+    def test_import_failure_is_data_gap(self, monkeypatch):
+        """google-genai missing (as in CI) must degrade, never crash."""
+        monkeypatch.setattr(
+            si, "_import_module", lambda dotted: (None, "cannot import genai")
+        )
+        result = asyncio.run(si.PatternExtractWeeklyTask().execute(MagicMock()))
+        assert result["success"] is False
+        assert result["data_gap"] is True
+        assert "genai" in result["error"]
+
+    def test_missing_gemini_key_is_data_gap(self, monkeypatch):
+        fake_mod = SimpleNamespace(_CFG=SimpleNamespace(gemini_api_key=""))
+        monkeypatch.setattr(si, "_import_module", lambda dotted: (fake_mod, None))
+        result = asyncio.run(si.PatternExtractWeeklyTask().execute(MagicMock()))
+        assert result["success"] is False
+        assert result["data_gap"] is True
+        assert "GEMINI_API_KEY" in result["error"]
+
+    def test_runs_winner_mining_and_weekly_aggregation(self, monkeypatch, tmp_path):
+        content_log = tmp_path / "content_log.json"
+        appended = []
+
+        fake_mod = SimpleNamespace(
+            _CFG=SimpleNamespace(gemini_api_key="key"),
+            CONTENT_LOG=str(content_log),
+            load_log=lambda: [
+                {"id": "w1", "url": "https://x.test/w1", "_winner": True},
+                {"id": "n1", "url": "https://x.test/n1", "_winner": False},
+            ],
+            is_winner=lambda e: e.get("_winner", False),
+            analyze_winner=lambda e: f"analysis for {e['id']}",
+            append_to_what_works=lambda e, a: appended.append((e["id"], a)),
+            run_weekly_aggregation=lambda site: "3 patterns surfaced",
+        )
+        monkeypatch.setattr(si, "_import_module", lambda dotted: (fake_mod, None))
+
+        result = asyncio.run(si.PatternExtractWeeklyTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert result["winners_processed"] == 1
+        assert appended == [("w1", "analysis for w1")]
+        assert result["patterns"] == "3 patterns surfaced"
+        assert content_log.exists()  # updated log persisted
+
+    def test_gemini_failure_contained(self, monkeypatch):
+        def raise_gemini(site):
+            raise RuntimeError("Circuit breaker open")
+
+        fake_mod = SimpleNamespace(
+            _CFG=SimpleNamespace(gemini_api_key="key"),
+            CONTENT_LOG="/nonexistent/content_log.json",
+            load_log=lambda: [],
+            is_winner=lambda e: False,
+            run_weekly_aggregation=raise_gemini,
+        )
+        monkeypatch.setattr(si, "_import_module", lambda dotted: (fake_mod, None))
+
+        result = asyncio.run(si.PatternExtractWeeklyTask().execute(MagicMock()))
+        assert result["success"] is False
+        assert any("Circuit breaker" in e for e in result["errors"])
+
+
+# ---------------------------------------------------------------------------
+# harness_defaults_update handler
+# ---------------------------------------------------------------------------
+
+
+class TestHarnessDefaultsUpdate:
+    def test_insufficient_data_is_success_with_data_gap_note(self, monkeypatch):
+        fake_mod = SimpleNamespace(
+            load_log=lambda: [],
+            analyze_patterns=lambda entries: {
+                "insufficient_data": True, "n": 2, "required": 10,
+            },
+        )
+        monkeypatch.setattr(si, "_import_module", lambda dotted: (fake_mod, None))
+
+        result = asyncio.run(si.HarnessDefaultsUpdateTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert result["updated"] == 0
+        assert "Insufficient data" in result["summary"]
+
+    def test_applies_updates_through_guarded_writers(self, monkeypatch):
+        saved = []
+        posted = []
+        patterns = {"best_publish_day": {"day": "Tuesday", "n": 12}}
+
+        fake_mod = SimpleNamespace(
+            load_log=lambda: [{"id": 1}],
+            analyze_patterns=lambda entries: patterns,
+            update_marketing_md=lambda p: ["- best publish day: Tuesday"],
+            update_policy_thresholds=lambda p: {
+                "updates": ["- policy.yaml: approve 85->80"],
+                "drift_alerts": [],
+            },
+            save_defaults=lambda p: saved.append(p),
+            post_discord=lambda updates, p: posted.append(updates),
+            post_drift_alert=lambda alerts: pytest.fail("no drift expected"),
+        )
+        monkeypatch.setattr(si, "_import_module", lambda dotted: (fake_mod, None))
+
+        result = asyncio.run(si.HarnessDefaultsUpdateTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert result["updated"] == 2
+        assert saved == [patterns]
+        assert len(posted) == 1
+
+    def test_drift_alerts_halt_and_are_reported(self, monkeypatch):
+        drift_posts = []
+        fake_mod = SimpleNamespace(
+            load_log=lambda: [{"id": 1}],
+            analyze_patterns=lambda entries: {"best_publish_day": {"day": "Tue"}},
+            update_marketing_md=lambda p: [],
+            update_policy_thresholds=lambda p: {
+                "updates": [],
+                "drift_alerts": ["DRIFT: policy.yaml auto_approve_above 85->40"],
+            },
+            save_defaults=lambda p: pytest.fail("must not save on drift-only run"),
+            post_discord=lambda updates, p: pytest.fail("no digest without updates"),
+            post_drift_alert=lambda alerts: drift_posts.append(alerts),
+        )
+        monkeypatch.setattr(si, "_import_module", lambda dotted: (fake_mod, None))
+
+        result = asyncio.run(si.HarnessDefaultsUpdateTask().execute(MagicMock()))
+        assert result["success"] is True
+        assert result["updated"] == 0
+        assert len(result["drift_alerts"]) == 1
+        assert len(drift_posts) == 1
+
+    def test_analysis_exception_contained(self, monkeypatch):
+        def boom(entries):
+            raise ValueError("corrupt log")
+
+        fake_mod = SimpleNamespace(load_log=lambda: [], analyze_patterns=boom)
+        monkeypatch.setattr(si, "_import_module", lambda dotted: (fake_mod, None))
+
+        result = asyncio.run(si.HarnessDefaultsUpdateTask().execute(MagicMock()))
+        assert result["success"] is False
+        assert "corrupt log" in result["error"]
+
+    def test_import_failure_is_graceful(self, monkeypatch):
+        monkeypatch.setattr(si, "_import_module", lambda dotted: (None, "gone"))
+        result = asyncio.run(si.HarnessDefaultsUpdateTask().execute(MagicMock()))
+        assert result["success"] is False
+        assert "unavailable" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Real-module smoke: pattern_extract import degrades in this environment
+# ---------------------------------------------------------------------------
+
+
+class TestRealModuleDegradation:
+    def test_pattern_extract_handler_never_raises(self):
+        """Whatever this environment has installed, execute() must return a
+        dict — never raise (crash-loop guard)."""
+        result = asyncio.run(si.PatternExtractWeeklyTask().execute(MagicMock()))
+        assert isinstance(result, dict)
+        assert "success" in result

--- a/workspace/HEARTBEAT.md
+++ b/workspace/HEARTBEAT.md
@@ -65,14 +65,20 @@ LOW: [list]
 
 If no suppressed alerts exist, skip this step.
 
-### Step 4 — Proactive Memory Scan (every heartbeat, script self-throttles to 6h)
+### Step 4 — Proactive Memory Scan (OPTIONAL — external deployment tooling)
+
+This step depends on a `proactive_heartbeat.py` script that ships with the deployed OpenClaw analytics stack, **not with this repo**. A fresh clone does not have it — skip this step unless the operator has configured it.
+
+Run it only when the `KAI_PROACTIVE_HEARTBEAT` env var points at the script:
 
 ```bash
-cd /opt/cmo-analytics && source venv/bin/activate
-python3 scripts/proactive_heartbeat.py --json --force
+# Set by the deployment, e.g. KAI_PROACTIVE_HEARTBEAT=/opt/cmo-analytics/scripts/proactive_heartbeat.py
+if [ -n "$KAI_PROACTIVE_HEARTBEAT" ] && [ -f "$KAI_PROACTIVE_HEARTBEAT" ]; then
+    python3 "$KAI_PROACTIVE_HEARTBEAT" --json --force   # script self-throttles to 6h
+fi
 ```
 
-Read `/tmp/proactive_heartbeat_signals.json`. For each signal, post `message` field to `channel_id`.
+If it ran: read `/tmp/proactive_heartbeat_signals.json`. For each signal, post the `message` field to `channel_id`. If `KAI_PROACTIVE_HEARTBEAT` is unset or the script is absent, treat the memory scan as clean and continue to Step 5.
 
 ### Step 5 — Acknowledge
 


### PR DESCRIPTION
# What this does

Turns the harness from a per-session content shop into a machine that operates across weeks and months. An audit of the repo found that nearly every long-horizon primitive existed (goals, mandates, task graphs, 30-day checks, lessons ladder) but the connective tissue was missing at seven joints. This PR wires all seven.

## 1. Publish truthfulness
`engine.py` no longer logs a fabricated `https://{site}.com/{slug}` URL when a piece passes gates. Approved content either publishes for real — double-opt-in via `publishing.enabled` + `publishing.sites.<site>` (default **off**), logging the CMS-returned URL — or is logged `approved_unpublished` with `url: null` and **no 30-day check** until `content_log.mark_published(id, url)` backfills the real URL. Content-hash dedup on log + publish; the WordPress publisher looks up by slug (update-not-duplicate) and never demotes a live post to draft.

## 2. Scheduler self-containment
`agent/scheduler.py` now seeds the self-improvement crons it previously omitted — `performance_check` (daily 02:00), `pattern_extract` + `harness_defaults_update` (Mondays) — so the 30-day learning loop fires on a stock deployment with no external crontab. Handlers degrade gracefully without Google/Gemini credentials (data gap, never a crash loop). New: a structured editorial calendar (`scripts/campaigns/calendar.py`, `data/calendar/editorial.jsonl`) with an hourly `editorial_calendar_tick` task that turns dated items into content-pipeline runs. Drafts still flow through gate + approval; the tick never publishes.

## 3. Learning-loop repair
The `"loser"` grade that `lesson_capture`, `/kai-retro`, and `what-doesnt-work.md` filtered on was never produced by `performance_check` — the negative half of the flywheel could never fire. Standardized on `underperformer` end to end; new shared `grades.py` tolerates dict / legacy-string `performance_30d`; `published_at`/`publish_date` drift fixed; pending-check reconcile skips url-less entries.

## 4. Instruction chain
Recreated `.claude/rules/architecture-and-memory.md` and `scripts-and-tools.md` — referenced by CLAUDE.md/AGENTS.md but missing from the repo (and gitignored; `.gitignore` now un-ignores `.claude/rules/`). `doctor.py` gained a referenced-files check (45 core files + 187 doc-referenced paths) and fails on dangling references. Hardcoded `/opt/cmo-analytics`, `/opt/meetkai-data`, and `E:\Dev2` paths moved to config/env with repo-relative defaults.

## 5. Business-profile persistence
`BusinessProfile` was rebuilt from `config.yaml` on every call with no write path. New overlay store at `data/runtime/profile/<brand>.json`, deep-merged over config-derived values (with lru_cache invalidation); onboarding answers now persist.

## 6. Campaign identity
`campaign_id` minted at plan time and threaded planner → tracker DB → RuntimeStore `campaign_plan` artifact (the enum type finally used) → content log → pending checks. `migrate_legacy_log.py` merges the legacy `~/.kai-marketing/content-log.jsonl` into the canonical `data/content_log.json`; skill docs updated to the canonical paths. Gateway job retention extended 7 → 45 days (configurable) so job history outlives the 30-day loop.

## 7. Goal loop (plan → act → measure → replan)
The goal pipeline existed unwired: `GoalDecomposer` and the graph executor had zero production callers. Now: `kai-harness goals add|list|update` writes `GoalRegistry`; a weekly `cmo_review` task refreshes goal progress from graded 30-day results, computes pace vs deadline, and calls the decomposer for behind-pace goals — persisting task graphs the existing loop executor already runs, plus a review snapshot to `data/runtime/goals/reviews/`. Failed graphs are flagged `needs_replan` and re-decomposed with failure context. All resulting actions still flow through ActionStore approval + mandate validation.

# Verification

- Full suite: **575 → 758 passing** (183 new tests, 0 failures)
- `python scripts/doctor.py`: PASS ("Harness intact")
- `python scripts/quality_gates/golden_check.py`: 4/4 golden cases intact
- Adversarial review round on the combined diff; both high-severity findings (gitignored rules files, WordPress live-post demotion) fixed and re-verified

# Notes for review

- Auto-publish is **off by default** everywhere; the approval doctrine is unchanged.
- `data/calendar/`, `data/runtime/profile/`, and goal review snapshots are runtime data (gitignored) — only code + docs ship here.
- Known follow-ups: legacy string-form grades copied by the migration are normalized by readers but not rewritten in place; calendar items stuck in `generating` after a crash rely on the next tick's planned-only selection (no sweep yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GAGSAwCugeZduc5qc7u2PY

---
_Generated by [Claude Code](https://claude.ai/code/session_01GAGSAwCugeZduc5qc7u2PY)_