### PR TITLE
fix: replace hardcoded E:\Dev2 dev paths across all harness skills

### DIFF
--- a/harness/skills/kai-abm/SKILL.md
+++ b/harness/skills/kai-abm/SKILL.md
@@ -31,7 +31,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 6. **Sales alignment** — Is sales involved? What's the handoff point?
 7. **Channels available** — Email, LinkedIn, ads, direct mail, events, phone?
 8. **Budget** — Per-account spend range
-9. **Persona alignment** — Which harness persona(s) map to the buying committee? Load from `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
+9. **Persona alignment** — Which harness persona(s) map to the buying committee? Load from `knowledge/personas/_persona-index.md`
 
 ---
 
@@ -39,7 +39,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 Build the ABM campaign architecture:
 
-1. **Load ABM playbook**: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\account-based-MARKETING.md`
+1. **Load ABM playbook**: `knowledge/playbooks/account-based-marketing.md`
 2. **Tier accounts by fit and intent**:
    - **Tier 1** (1:1): Top 10-25 accounts. Fully personalized. High-touch.
    - **Tier 2** (1:few): 25-100 accounts. Cluster by industry/use case. Semi-personalized.
@@ -85,16 +85,16 @@ Apply harness writing rules:
 
 Validate before launch:
 
-1. **Four U's Score**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+1. **Four U's Score**: `python scripts/quality_gates/four_us_score.py <file>`
    - Minimum: **10/16** for emails and outreach
    - Minimum: **12/16** for content and landing pages
-2. **Banned Word Check**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
+2. **Banned Word Check**: `python scripts/quality_gates/banned_word_check.py <file>`
 3. **AI Slop Check** — Zero filler. ABM demands precision.
 4. **Personalization depth check** — Does each Tier 1 message reference something specific to the account?
 5. **Platform policy compliance** — Check ad copy against platform rules:
-   - LinkedIn: `E:\Dev2\kai-cmo-harness-work\harness\references\linkedin-ads-rules.md`
-   - Google Display: `E:\Dev2\kai-cmo-harness-work\harness\references\google-ads-policy-reference.md`
-6. **CAN-SPAM / cold email compliance**: `E:\Dev2\kai-cmo-harness-work\harness\references\cold-email-rules.md`
+   - LinkedIn: `harness/references/linkedin-ads-rules.md`
+   - Google Display: `harness/references/google-ads-policy-reference.md`
+6. **CAN-SPAM / cold email compliance**: `harness/references/cold-email-rules.md`
 
 Max 2 auto-retry cycles on gate failures.
 
@@ -114,4 +114,4 @@ Deliver the ABM campaign package:
 - **Measurement framework** (engagement score, pipeline influence, deal velocity)
 - **Gate pass/fail summary**
 
-Write output to `E:\Dev2\kai-cmo-harness-work\workspace\` with filename pattern: `abm-campaign-YYYY-MM-DD.md`
+Write output to `workspace/` with filename pattern: `abm-campaign-YYYY-MM-DD.md`

--- a/harness/skills/kai-ad-campaign/SKILL.md
+++ b/harness/skills/kai-ad-campaign/SKILL.md
@@ -214,7 +214,7 @@ Before writing any ad, load the platform's policy reference and skill contract. 
 | Amazon | `harness/references/amazon-ads-policy-reference.md` | — | — | 18-month claim evidence rule |
 | X/Twitter | `harness/references/x-ads-policy-reference.md` | — | — | Verification tier affects access |
 
-All paths relative to `E:\Dev2\kai-cmo-harness-work\`.
+All paths relative to the project root.
 
 Also load: `harness/references/advertising-compliance.md` for FTC/GDPR/CAN-SPAM requirements that apply to ALL platforms.
 

--- a/harness/skills/kai-analytics/SKILL.md
+++ b/harness/skills/kai-analytics/SKILL.md
@@ -21,9 +21,9 @@ Check if `MARKETING.md` exists in the **project root** (same directory as CLAUDE
 
 Load these files as context before starting:
 
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\analytics-attribution.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\technical-marketing-tracking.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\saas-metrics-guide.md`
+- `knowledge/playbooks/analytics-attribution.md`
+- `knowledge/playbooks/technical-marketing-tracking.md`
+- `knowledge/playbooks/saas-metrics-guide.md`
 
 ## Phase 1 — Discovery
 

--- a/harness/skills/kai-audit/SKILL.md
+++ b/harness/skills/kai-audit/SKILL.md
@@ -7,7 +7,7 @@ One-click full marketing audit. Runs all relevant harness checklists and produce
 
 ## Non-Negotiable: Kai Data Provenance
 
-Before writing any finding, load `E:\Dev2\kai-cmo-harness-work\harness\references\audit-data-provenance.md`.
+Before writing any finding, load `harness/references/audit-data-provenance.md`.
 
 Every audit must declare one of these modes:
 
@@ -97,7 +97,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 ## Phase 2: Checklist Execution
 
-Run applicable checklists from `E:\Dev2\kai-cmo-harness-work\knowledge\checklists\`. Skip checklists for channels the user isn't using.
+Run applicable checklists from `knowledge/checklists/`. Skip checklists for channels the user isn't using.
 
 ### Audit Modules
 

--- a/harness/skills/kai-brand/SKILL.md
+++ b/harness/skills/kai-brand/SKILL.md
@@ -21,9 +21,9 @@ Check if `MARKETING.md` exists in the **project root** (same directory as CLAUDE
 
 Load these files as context before starting:
 
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\brand-positioning.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\content-copywriting\perception-engineering.md`
+- `knowledge/playbooks/brand-positioning.md`
+- `knowledge/personas/_persona-index.md`
+- `knowledge/frameworks/content-copywriting/perception-engineering.md`
 
 ## Phase 1 — Discovery
 
@@ -74,9 +74,9 @@ Build these deliverables:
 
 1. Deliver the full messaging framework as a structured document.
 2. Run all copy through the banned word check:
-   - `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
+   - `python scripts/quality_gates/banned_word_check.py <file>`
 3. Run the Four U's score on the positioning statement and taglines:
-   - `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+   - `python scripts/quality_gates/four_us_score.py <file>`
 4. Present the final package with a summary of scores and any flags.
 
 ## Constraints

--- a/harness/skills/kai-brief/SKILL.md
+++ b/harness/skills/kai-brief/SKILL.md
@@ -30,7 +30,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 ### 2. Select Persona
 
-Read `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md` for the full list. Quick reference:
+Read `knowledge/personas/_persona-index.md` for the full list. Quick reference:
 
 | Persona | Core Hook | Best For |
 |---------|-----------|----------|
@@ -47,7 +47,7 @@ Load the full persona file before writing the brief. It contains language patter
 
 ### 3. Output Brief
 
-Follow the schema from `E:\Dev2\kai-cmo-harness-work\harness\brief-schema.md`:
+Follow the schema from `harness/brief-schema.md`:
 
 ```json
 {

--- a/harness/skills/kai-budget/SKILL.md
+++ b/harness/skills/kai-budget/SKILL.md
@@ -21,9 +21,9 @@ Check if `MARKETING.md` exists in the **project root** (same directory as CLAUDE
 
 Load these files as context before starting:
 
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\marketing-budget-forecasting.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\saas-metrics-guide.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
+- `knowledge/playbooks/marketing-budget-forecasting.md`
+- `knowledge/playbooks/saas-metrics-guide.md`
+- `knowledge/personas/_persona-index.md`
 
 ## Phase 1 — Discovery
 

--- a/harness/skills/kai-case-study/SKILL.md
+++ b/harness/skills/kai-case-study/SKILL.md
@@ -28,7 +28,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 3. **The problem** — What was broken before? Quantify the pain.
 4. **The solution** — What did we do? Be specific about the product/service.
 5. **The results** — Hard numbers. Revenue, time saved, conversion lift, cost reduction.
-6. **Persona alignment** — Which harness persona does this customer map to? Load from `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
+6. **Persona alignment** — Which harness persona does this customer map to? Load from `knowledge/personas/_persona-index.md`
 7. **Permission** — Does the customer approve named use? Or anonymized?
 
 ---
@@ -37,8 +37,8 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 Structure the case study:
 
-1. **Load content checklist**: `E:\Dev2\kai-cmo-harness-work\knowledge\checklists\content-checklist.md`
-2. **Load perception engineering**: `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\content-copywriting\perception-engineering.md`
+1. **Load content checklist**: `knowledge/checklists/content-checklist.md`
+2. **Load perception engineering**: `knowledge/frameworks/content-copywriting/perception-engineering.md`
 3. **Define the narrative arc**:
    - **Before state** — The specific pain, in the customer's words
    - **Turning point** — Why they chose us (decision trigger)
@@ -72,9 +72,9 @@ Apply perception engineering layers:
 
 Run all gates before delivery:
 
-1. **Four U's Score**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+1. **Four U's Score**: `python scripts/quality_gates/four_us_score.py <file>`
    - Minimum: **12/16** (content threshold)
-2. **Banned Word Check**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
+2. **Banned Word Check**: `python scripts/quality_gates/banned_word_check.py <file>`
    - Zero Tier 1 violations
 3. **AI Slop Check** — No filler phrases ("In conclusion", "It's worth noting that", etc.)
 4. **Specificity check** — Every claim has a number or named example. No vague praise.
@@ -94,4 +94,4 @@ Deliver the final case study package:
 - **Four U's scorecard**
 - **Gate pass/fail summary**
 
-Write output to `E:\Dev2\kai-cmo-harness-work\workspace\` with filename pattern: `case-study-[company]-YYYY-MM-DD.md`
+Write output to `workspace/` with filename pattern: `case-study-[company]-YYYY-MM-DD.md`

--- a/harness/skills/kai-cold-outreach/SKILL.md
+++ b/harness/skills/kai-cold-outreach/SKILL.md
@@ -54,9 +54,9 @@ Present sequence map + variant strategy before writing.
 ## Phase 3: Production
 
 Load these before writing:
-- `E:\Dev2\kai-cmo-harness-work\harness\skill-contracts\cold-email.yaml`
-- `E:\Dev2\kai-cmo-harness-work\harness\references\cold-email-rules.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\channels\email-lifecycle.md` (subject line formulas)
+- `harness/skill-contracts/cold-email.yaml`
+- `harness/references/cold-email-rules.md`
+- `knowledge/channels/email-lifecycle.md` (subject line formulas)
 
 ### Per-Touch Output
 

--- a/harness/skills/kai-competitors/SKILL.md
+++ b/harness/skills/kai-competitors/SKILL.md
@@ -24,7 +24,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 3. **Depth** — quick (30 min, top 3) or deep (2-3 hours, full landscape)?
 4. **Output need** — strategy doc, sales battlecard, or both?
 
-Load: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\competitive-intelligence.md`
+Load: `knowledge/playbooks/competitive-intelligence.md`
 
 ## Phase 2: 5-Layer Analysis
 

--- a/harness/skills/kai-cro/SKILL.md
+++ b/harness/skills/kai-cro/SKILL.md
@@ -28,10 +28,10 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 ## Phase 2: Audit Execution
 
 Load these before starting:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\conversion-rate-optimization.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\funnel-hack-offer-architecture.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\checklists\cro-audit-checklist.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\checklists\landing-page-messaging-checklist.md`
+- `knowledge/playbooks/conversion-rate-optimization.md`
+- `knowledge/playbooks/funnel-hack-offer-architecture.md`
+- `knowledge/checklists/cro-audit-checklist.md`
+- `knowledge/checklists/landing-page-messaging-checklist.md`
 
 ### Competitor Funnel-Hack Step (required for ecommerce/CRO)
 

--- a/harness/skills/kai-daily-ad-review/SKILL.md
+++ b/harness/skills/kai-daily-ad-review/SKILL.md
@@ -12,7 +12,7 @@ This is NOT the same as `/kai-ad-campaign` (which creates/evaluates campaigns en
 Run the unified pull script. It auto-detects which platforms have credentials and pulls everything.
 
 ```bash
-cd E:/Dev2/kai-cmo-harness-work && python scripts/ads/pull_all.py
+python scripts/ads/pull_all.py
 ```
 
 This writes structured JSON to `workspace/ads/pulls/YYYY-MM-DD/`:

--- a/harness/skills/kai-email-system/SKILL.md
+++ b/harness/skills/kai-email-system/SKILL.md
@@ -52,7 +52,7 @@ Then create `MARKETING.md` in the **project root** (next to CLAUDE.md) with this
 
 ## Personas
 
-Map to the closest harness personas from `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`, then customize for this product:
+Map to the closest harness personas from `knowledge/personas/_persona-index.md`, then customize for this product:
 
 ### Persona 1: [Name] — based on [harness persona name]
 - **Who they are:** [1-2 sentences]
@@ -148,13 +148,13 @@ Produce emails in priority order (P0 first). For each email:
 ### 3a. Load Context
 
 Read these harness files before writing:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\channels\email-lifecycle.md` — lifecycle patterns, subject line formulas, anti-patterns
-- `E:\Dev2\kai-cmo-harness-work\harness\skill-contracts\email-lifecycle.yaml` — quality gates and output format
-- `E:\Dev2\kai-cmo-harness-work\harness\skill-contracts\email.yaml` — general email contract
+- `knowledge/channels/email-lifecycle.md` — lifecycle patterns, subject line formulas, anti-patterns
+- `harness/skill-contracts/email-lifecycle.yaml` — quality gates and output format
+- `harness/skill-contracts/email.yaml` — general email contract
 
 For cold outreach emails, also load:
-- `E:\Dev2\kai-cmo-harness-work\harness\skill-contracts\cold-email.yaml`
-- `E:\Dev2\kai-cmo-harness-work\harness\references\cold-email-rules.md`
+- `harness/skill-contracts/cold-email.yaml`
+- `harness/references/cold-email-rules.md`
 
 ### 3b. Write Each Email
 
@@ -270,4 +270,4 @@ When producing emails, use parallel agents for independent emails. Emails within
 
 ## Persona Application
 
-If `MARKETING.md` specifies a persona, load the full persona file from `E:\Dev2\kai-cmo-harness-work\knowledge\personas/` and match email tone to the persona's language patterns and pain points. If no persona applies, use the brand voice from `MARKETING.md`.
+If `MARKETING.md` specifies a persona, load the full persona file from `knowledge/personas/` and match email tone to the persona's language patterns and pain points. If no persona applies, use the brand voice from `MARKETING.md`.

--- a/harness/skills/kai-growth-plan/SKILL.md
+++ b/harness/skills/kai-growth-plan/SKILL.md
@@ -29,10 +29,10 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 ## Phase 2: Stage Diagnosis
 
-Load: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\marketing-by-stage.md`
-Also load: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\growth-loops-applied.md`
-Also load: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\demand-generation.md`
-Also load: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\saas-metrics-guide.md`
+Load: `knowledge/playbooks/marketing-by-stage.md`
+Also load: `knowledge/playbooks/growth-loops-applied.md`
+Also load: `knowledge/playbooks/demand-generation.md`
+Also load: `knowledge/playbooks/saas-metrics-guide.md`
 Also load: `knowledge/playbooks/growth-hacker-first-hire-os.md` when the request asks for distribution, a first growth hire, growth hacking, channel coverage, or a channel operating system.
 
 ### Stage Map
@@ -94,7 +94,7 @@ What to measure at this stage (from SaaS metrics guide):
 |---------|------------|-----------|-----|
 | [channel] | [%] | [$] | [reason] |
 
-Load: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\marketing-budget-forecasting.md` for budget frameworks.
+Load: `knowledge/playbooks/marketing-budget-forecasting.md` for budget frameworks.
 
 ## Phase 4: Skill Routing
 

--- a/harness/skills/kai-influencer/SKILL.md
+++ b/harness/skills/kai-influencer/SKILL.md
@@ -25,7 +25,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 1. **Campaign goal** — Awareness, conversions, content generation, social proof?
 2. **Product/service** — What are we promoting? Price point, differentiator.
-3. **Target audience** — Which persona(s)? Load from `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
+3. **Target audience** — Which persona(s)? Load from `knowledge/personas/_persona-index.md`
 4. **Platforms** — Instagram, TikTok, YouTube, LinkedIn, podcast, other?
 5. **Budget** — Total campaign budget and per-creator range
 6. **Timeline** — Launch date, campaign duration, key milestones
@@ -38,7 +38,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 Build the influencer campaign strategy:
 
-1. **Load influencer playbook**: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\influencer-MARKETING.md`
+1. **Load influencer playbook**: `knowledge/playbooks/influencer-marketing.md`
 2. **Define creator tiers**:
    - **Nano** (1K-10K followers): High engagement, low cost, authentic feel
    - **Micro** (10K-100K): Niche authority, good reach/engagement balance
@@ -86,9 +86,9 @@ Create campaign deliverables:
 
 Validate before launch:
 
-1. **Four U's Score** (on briefs and outreach): `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+1. **Four U's Score** (on briefs and outreach): `python scripts/quality_gates/four_us_score.py <file>`
    - Minimum: **10/16**
-2. **Banned Word Check**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
+2. **Banned Word Check**: `python scripts/quality_gates/banned_word_check.py <file>`
 3. **FTC compliance check** — All content requires clear disclosure
 4. **Platform policy check** — Branded content tags, paid partnership labels
 5. **Brief clarity check** — Could a creator execute this without a follow-up call?
@@ -108,4 +108,4 @@ Deliver the influencer campaign package:
 - **Contract checklist** (key terms to include)
 - **Gate pass/fail summary**
 
-Write output to `E:\Dev2\kai-cmo-harness-work\workspace\` with filename pattern: `influencer-campaign-YYYY-MM-DD.md`
+Write output to `workspace/` with filename pattern: `influencer-campaign-YYYY-MM-DD.md`

--- a/harness/skills/kai-landing-page/SKILL.md
+++ b/harness/skills/kai-landing-page/SKILL.md
@@ -28,10 +28,10 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 ## Phase 2: Page Architecture
 
 Load these before planning:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\content-copywriting\perception-engineering.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\checklists\landing-page-messaging-checklist.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\landing-page-messaging-workflow.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\conversion-rate-optimization.md`
+- `knowledge/frameworks/content-copywriting/perception-engineering.md`
+- `knowledge/checklists/landing-page-messaging-checklist.md`
+- `knowledge/playbooks/landing-page-messaging-workflow.md`
+- `knowledge/playbooks/conversion-rate-optimization.md`
 
 Generate a page wireframe (sections in order) before writing copy:
 

--- a/harness/skills/kai-launch/SKILL.md
+++ b/harness/skills/kai-launch/SKILL.md
@@ -81,7 +81,7 @@ Produce assets in dependency order:
 
 Each asset follows the standard harness pipeline:
 
-1. Load the right framework from `E:\Dev2\kai-cmo-harness-work\knowledge/`
+1. Load the right framework from `knowledge/`
 2. Load the skill contract from `harness/skill-contracts/`
 3. Load platform policy (for ads) from `harness/references/`
 4. Write against the framework + persona

--- a/harness/skills/kai-monthly-audit/SKILL.md
+++ b/harness/skills/kai-monthly-audit/SKILL.md
@@ -9,7 +9,7 @@ Run a monthly strategic audit. This skill turns weekly signals into an executive
 
 ## Non-Negotiable: Data Provenance
 
-Before writing findings, load `E:\Dev2\kai-cmo-harness-work\harness\references\audit-data-provenance.md`.
+Before writing findings, load `harness/references/audit-data-provenance.md`.
 
 Declare the data mode:
 

--- a/harness/skills/kai-newsletter/SKILL.md
+++ b/harness/skills/kai-newsletter/SKILL.md
@@ -24,7 +24,7 @@ Check if `MARKETING.md` exists in the **project root** (same directory as CLAUDE
 Read from `MARKETING.md`. Only ask about things not covered there:
 
 1. **Newsletter purpose** — What is the goal? (nurture, educate, drive traffic, retain)
-2. **Audience** — Which persona(s) from the harness? Load from `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
+2. **Audience** — Which persona(s) from the harness? Load from `knowledge/personas/_persona-index.md`
 3. **Cadence** — Weekly, biweekly, monthly?
 4. **Existing content** — Any blog posts, articles, or assets to feature?
 5. **Brand voice** — Formal, conversational, irreverent?
@@ -36,9 +36,9 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 Build the newsletter edition plan:
 
-1. **Load strategy framework**: `E:\Dev2\kai-cmo-harness-work\knowledge\channels\newsletter-strategy.md`
-2. **Load email lifecycle patterns**: `E:\Dev2\kai-cmo-harness-work\knowledge\channels\email-lifecycle.md`
-3. **Load skill contract**: `E:\Dev2\kai-cmo-harness-work\harness\skill-contracts\email-lifecycle.yaml`
+1. **Load strategy framework**: `knowledge/channels/newsletter-strategy.md`
+2. **Load email lifecycle patterns**: `knowledge/channels/email-lifecycle.md`
+3. **Load skill contract**: `harness/skill-contracts/email-lifecycle.yaml`
 4. **Define edition structure**:
    - Hero story / lead piece
    - Supporting content (2-3 items)
@@ -72,9 +72,9 @@ Apply these rules from the harness:
 
 Run all gates before delivery:
 
-1. **Four U's Score**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+1. **Four U's Score**: `python scripts/quality_gates/four_us_score.py <file>`
    - Minimum: **10/16** (email threshold)
-2. **Banned Word Check**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
+2. **Banned Word Check**: `python scripts/quality_gates/banned_word_check.py <file>`
    - Zero Tier 1 violations
 3. **AI Slop Check** — No phrases like "In conclusion", "It's important to note", "In today's rapidly evolving"
 4. **Subject line validation** — Under 50 characters, no spam trigger words, no ALL CAPS
@@ -94,4 +94,4 @@ Deliver the final newsletter package:
 - **Four U's scorecard**
 - **Gate pass/fail summary**
 
-Write output to `E:\Dev2\kai-cmo-harness-work\workspace\` with filename pattern: `newsletter-YYYY-MM-DD.md`
+Write output to `workspace/` with filename pattern: `newsletter-YYYY-MM-DD.md`

--- a/harness/skills/kai-partnership/SKILL.md
+++ b/harness/skills/kai-partnership/SKILL.md
@@ -21,9 +21,9 @@ Check if `MARKETING.md` exists in the **project root** (same directory as CLAUDE
 
 Load these files as context before starting:
 
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\partnership-coMARKETING.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\channels\email-lifecycle.md`
+- `knowledge/playbooks/partnership-comarketing.md`
+- `knowledge/personas/_persona-index.md`
+- `knowledge/channels/email-lifecycle.md`
 
 ## Phase 1 — Discovery
 
@@ -95,8 +95,8 @@ Build these deliverables:
 
 1. Deliver the partnership brief and campaign plan as structured documents.
 2. Run all outreach copy through quality gates:
-   - `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
-   - `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+   - `python scripts/quality_gates/banned_word_check.py <file>`
+   - `python scripts/quality_gates/four_us_score.py <file>`
 3. Flag any co-branded content that needs legal review (claims, testimonials, data sharing).
 4. Present the complete package with a timeline summary.
 
@@ -104,6 +104,6 @@ Build these deliverables:
 
 - No banned Tier 1 words in any outreach or co-branded copy.
 - All partner claims must be verifiable — no inflated audience numbers.
-- Email outreach must comply with CAN-SPAM (reference: `E:\Dev2\kai-cmo-harness-work\harness\references\cold-email-rules.md`).
+- Email outreach must comply with CAN-SPAM (reference: `harness/references/cold-email-rules.md`).
 - Cross-promotion emails require clear sender identification.
 - Max 2 auto-retry cycles on quality gate failures.

--- a/harness/skills/kai-podcast/SKILL.md
+++ b/harness/skills/kai-podcast/SKILL.md
@@ -25,7 +25,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 1. **Mode** — Are we launching a show (Host) or getting booked on shows (Guest)?
 2. **Goal** — Brand awareness, thought leadership, lead gen, networking, SEO backlinks?
-3. **Target audience** — Which persona(s)? Load from `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
+3. **Target audience** — Which persona(s)? Load from `knowledge/personas/_persona-index.md`
 4. **Topic territory** — What subjects can we own? What's our unique angle?
 5. **Existing assets** — Blog posts, talks, interviews that prove expertise?
 6. **Commitment level** — Weekly, biweekly, monthly? (Host) / How many appearances per month? (Guest)
@@ -54,8 +54,8 @@ Guardrails:
 
 ### Host Mode — Launch a Podcast
 
-1. **Load podcast channel guide**: `E:\Dev2\kai-cmo-harness-work\knowledge\channels\podcast.md`
-2. **Load podcast marketing playbook**: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\podcast-MARKETING.md`
+1. **Load podcast channel guide**: `knowledge/channels/podcast.md`
+2. **Load podcast marketing playbook**: `knowledge/playbooks/podcast-marketing.md`
 3. **Show concept**:
    - Name (3-5 candidates, check availability)
    - Format (solo, interview, co-host, panel, hybrid)
@@ -68,7 +68,7 @@ Guardrails:
 
 ### Guest Mode — Get Booked on Shows
 
-1. **Load podcast marketing playbook**: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\podcast-MARKETING.md`
+1. **Load podcast marketing playbook**: `knowledge/playbooks/podcast-marketing.md`
 2. **Speaker positioning**:
    - 3 signature topics you can speak on
    - Unique stories/frameworks/data you bring
@@ -104,10 +104,10 @@ Guardrails:
 
 Validate written assets:
 
-1. **Four U's Score**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+1. **Four U's Score**: `python scripts/quality_gates/four_us_score.py <file>`
    - Minimum: **12/16** for show descriptions and episode outlines
    - Minimum: **10/16** for emails and pitches
-2. **Banned Word Check**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
+2. **Banned Word Check**: `python scripts/quality_gates/banned_word_check.py <file>`
 3. **AI Slop Check** — No filler. Every sentence earns its place.
 4. **Pitch specificity check** — Does the pitch reference the host's show specifically?
 
@@ -135,4 +135,4 @@ Deliver the podcast package:
 - **Tracking spreadsheet structure**
 - **Gate pass/fail summary**
 
-Write output to `E:\Dev2\kai-cmo-harness-work\workspace\` with filename pattern: `podcast-[host|guest]-YYYY-MM-DD.md`
+Write output to `workspace/` with filename pattern: `podcast-[host|guest]-YYYY-MM-DD.md`

--- a/harness/skills/kai-repurpose/SKILL.md
+++ b/harness/skills/kai-repurpose/SKILL.md
@@ -23,7 +23,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 2. **Platforms** — which channels should get derivative content?
 3. **Priority** — what matters most? (social reach, email engagement, SEO, video views)
 
-Load: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\content-repurposing.md`
+Load: `knowledge/playbooks/content-repurposing.md`
 
 ## Phase 2: Extraction Map
 
@@ -48,7 +48,7 @@ Generate `workspace/repurposed/_extraction-map.md`:
 
 When the source is a transcript, podcast, webinar, interview, or long article, run a quote mining pass before derivative production.
 
-Load `E:\Dev2\kai-cmo-harness\harness\references\transcript-video-research-rules.md` before quote mining third-party video, audio, podcast, webinar, or transcript material.
+Load `harness/references/transcript-video-research-rules.md` before quote mining third-party video, audio, podcast, webinar, or transcript material.
 
 Create `workspace/repurposed/_quote-bank.md` with:
 - **Source location**: file path, URL, episode name, transcript timestamp, or paragraph locator

--- a/harness/skills/kai-retarget/SKILL.md
+++ b/harness/skills/kai-retarget/SKILL.md
@@ -37,18 +37,18 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 Build the retargeting architecture:
 
-1. **Load retargeting playbook**: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\retargeting-reMARKETING.md`
+1. **Load retargeting playbook**: `knowledge/playbooks/retargeting-remarketing.md`
 2. **Load platform policy references** (for each active platform):
-   - Meta: `E:\Dev2\kai-cmo-harness-work\harness\references\meta-ads-rules.md`
-   - Google: `E:\Dev2\kai-cmo-harness-work\harness\references\google-ads-policy-reference.md`
-   - LinkedIn: `E:\Dev2\kai-cmo-harness-work\harness\references\linkedin-ads-rules.md`
-   - TikTok: `E:\Dev2\kai-cmo-harness-work\harness\references\tiktok-ads-policy-reference.md`
-   - Microsoft: `E:\Dev2\kai-cmo-harness-work\harness\references\microsoft-ads-rules.md`
-   - Pinterest: `E:\Dev2\kai-cmo-harness-work\harness\references\pinterest-ads-rules.md`
-   - Snapchat: `E:\Dev2\kai-cmo-harness-work\harness\references\snapchat-ads-policy-reference.md`
-   - Amazon: `E:\Dev2\kai-cmo-harness-work\harness\references\amazon-ads-policy-reference.md`
-   - X/Twitter: `E:\Dev2\kai-cmo-harness-work\harness\references\x-ads-policy-reference.md`
-3. **Load compliance framework**: `E:\Dev2\kai-cmo-harness-work\harness\references\advertising-compliance.md`
+   - Meta: `harness/references/meta-ads-rules.md`
+   - Google: `harness/references/google-ads-policy-reference.md`
+   - LinkedIn: `harness/references/linkedin-ads-rules.md`
+   - TikTok: `harness/references/tiktok-ads-policy-reference.md`
+   - Microsoft: `harness/references/microsoft-ads-rules.md`
+   - Pinterest: `harness/references/pinterest-ads-rules.md`
+   - Snapchat: `harness/references/snapchat-ads-policy-reference.md`
+   - Amazon: `harness/references/amazon-ads-policy-reference.md`
+   - X/Twitter: `harness/references/x-ads-policy-reference.md`
+3. **Load compliance framework**: `harness/references/advertising-compliance.md`
 4. **Define audience segments**:
    - Segment by intent level (visited homepage vs. visited pricing vs. started checkout)
    - Set recency windows (1-3 days, 3-7 days, 7-30 days, 30-90 days)
@@ -78,9 +78,9 @@ Build the campaign assets:
 
 Validate before launch:
 
-1. **Four U's Score** (on ad copy): `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+1. **Four U's Score** (on ad copy): `python scripts/quality_gates/four_us_score.py <file>`
    - Minimum: **10/16** (ad threshold)
-2. **Banned Word Check**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
+2. **Banned Word Check**: `python scripts/quality_gates/banned_word_check.py <file>`
 3. **Platform policy compliance** — Check each ad against its platform's TOS
 4. **Frequency cap validation** — Confirm caps are set per segment
 5. **Exclusion list verification** — Confirm converters are excluded
@@ -102,4 +102,4 @@ Deliver the retargeting package:
 - **Policy compliance checklist** (per platform)
 - **Gate pass/fail summary**
 
-Write output to `E:\Dev2\kai-cmo-harness-work\workspace\` with filename pattern: `retarget-campaign-YYYY-MM-DD.md`
+Write output to `workspace/` with filename pattern: `retarget-campaign-YYYY-MM-DD.md`

--- a/harness/skills/kai-retention/SKILL.md
+++ b/harness/skills/kai-retention/SKILL.md
@@ -21,10 +21,10 @@ Check if `MARKETING.md` exists in the **project root** (same directory as CLAUDE
 
 Load these files as context before starting:
 
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\customer-retention.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\growth-loops-applied.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\channels\email-lifecycle.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
+- `knowledge/playbooks/customer-retention.md`
+- `knowledge/playbooks/growth-loops-applied.md`
+- `knowledge/channels/email-lifecycle.md`
+- `knowledge/personas/_persona-index.md`
 
 ## Phase 1 — Discovery
 
@@ -122,14 +122,14 @@ For customers who have already churned:
 
 1. Deliver the retention playbook and engagement scoring spec.
 2. Run all email sequences through quality gates:
-   - `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
-   - `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+   - `python scripts/quality_gates/banned_word_check.py <file>`
+   - `python scripts/quality_gates/four_us_score.py <file>`
 3. Include a 90-day implementation roadmap and monthly metrics to track (churn rate, cohort retention, health score distribution, NPS trend, expansion vs. contraction revenue).
 
 ## Constraints
 
 - No banned Tier 1 words in any customer-facing copy.
-- Win-back emails must comply with CAN-SPAM (reference: `E:\Dev2\kai-cmo-harness-work\harness\references\cold-email-rules.md`).
+- Win-back emails must comply with CAN-SPAM (reference: `harness/references/cold-email-rules.md`).
 - Loyalty program rewards must not erode margins below profitability.
 - Discount offers in rescue plays capped at 20% unless user approves higher.
 - All email sequences target 10+/16 on Four U's scoring.

--- a/harness/skills/kai-seo-audit/SKILL.md
+++ b/harness/skills/kai-seo-audit/SKILL.md
@@ -7,7 +7,7 @@ Run a technical SEO audit using the harness SOPs and checklists. Produces a prio
 
 ## Non-Negotiable: Kai Data Provenance
 
-Before writing any finding, load `E:\Dev2\kai-cmo-harness-work\harness\references\audit-data-provenance.md`.
+Before writing any finding, load `harness/references/audit-data-provenance.md`.
 
 Declare the audit mode:
 
@@ -66,9 +66,9 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 ## Phase 2: Audit Execution
 
 Load these before starting:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\checklists\technical-seo-audit-sop.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\checklists\technical-seo-checklist.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\checklists\seo-checklist.md`
+- `knowledge/checklists/technical-seo-audit-sop.md`
+- `knowledge/checklists/technical-seo-checklist.md`
+- `knowledge/checklists/seo-checklist.md`
 
 ### Audit Layers (run in order)
 

--- a/harness/skills/kai-social/SKILL.md
+++ b/harness/skills/kai-social/SKILL.md
@@ -30,13 +30,13 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 ## Phase 2: Social Calendar
 
 Load these before planning:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\social-media-strategy.md`
+- `knowledge/playbooks/social-media-strategy.md`
 - Platform-specific channels as needed:
-  - `E:\Dev2\kai-cmo-harness-work\knowledge\channels\instagram.md`
-  - `E:\Dev2\kai-cmo-harness-work\knowledge\channels\x-twitter.md`
-  - `E:\Dev2\kai-cmo-harness-work\knowledge\channels\tiktok-algorithm.md`
-  - `E:\Dev2\kai-cmo-harness-work\knowledge\channels\youtube.md`
-  - `E:\Dev2\kai-cmo-harness-work\knowledge\channels\linkedin-articles.md`
+  - `knowledge/channels/instagram.md`
+  - `knowledge/channels/x-twitter.md`
+  - `knowledge/channels/tiktok-algorithm.md`
+  - `knowledge/channels/youtube.md`
+  - `knowledge/channels/linkedin-articles.md`
 
 Generate `workspace/social/_calendar.md`:
 

--- a/harness/skills/kai-surround-sound/SKILL.md
+++ b/harness/skills/kai-surround-sound/SKILL.md
@@ -28,11 +28,11 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 ## Phase 2: Consensus Audit
 
 Load these before starting:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\surround-sound-llm-manipulation.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\llm-citation-tracking.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\entity-seo-knowledge-graph-deep-dive.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\perplexity-ranking-reverse-engineered.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\geo-academic-research-synthesis.md`
+- `knowledge/playbooks/surround-sound-llm-manipulation.md`
+- `knowledge/frameworks/aeo-ai-search/llm-citation-tracking.md`
+- `knowledge/frameworks/aeo-ai-search/entity-seo-knowledge-graph-deep-dive.md`
+- `knowledge/frameworks/aeo-ai-search/perplexity-ranking-reverse-engineered.md`
+- `knowledge/frameworks/aeo-ai-search/geo-academic-research-synthesis.md`
 
 ### Audit the Current Consensus Web
 
@@ -53,7 +53,7 @@ Map where your brand appears (and doesn't) across LLM training/retrieval sources
 
 Before you can surround-sound from third parties, your own site has to be legible to the agents routing back. If ChatGPT can't parse your homepage, every pulse you build elsewhere dead-ends.
 
-Load: `E:\Dev2\kai-cmo-harness-work\knowledge\checklists\agent-readiness-checklist.md`
+Load: `knowledge/checklists/agent-readiness-checklist.md`
 
 Run the checklist against the user's primary domain. Report:
 
@@ -133,7 +133,7 @@ Skip to Month 1 only if the linter reports Pass on P0.
 
 ### AEO-Optimized Content Rules
 
-Load: `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\aeo-ai-search-playbook-2026.md`
+Load: `knowledge/frameworks/aeo-ai-search/aeo-ai-search-playbook-2026.md`
 
 For every content piece in the plan:
 - **Atomic facts** — one verifiable claim per sentence

--- a/harness/skills/kai-topical-map/SKILL.md
+++ b/harness/skills/kai-topical-map/SKILL.md
@@ -26,7 +26,7 @@ Check if `MARKETING.md` exists in the **project root** (same directory as CLAUDE
 ## Phase 1: Topic Space Discovery
 
 Load before starting:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\aeo-ai-search-playbook-2026.md`
+- `knowledge/frameworks/aeo-ai-search/aeo-ai-search-playbook-2026.md`
 
 Read from `MARKETING.md`. Only ask about things not covered there:
 
@@ -54,7 +54,7 @@ This scorecard becomes the "before" measurement. Run it again at 30/60/90 days t
 ## Phase 2: Entity Map
 
 Load before starting:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\entity-seo-knowledge-graph-deep-dive.md`
+- `knowledge/frameworks/aeo-ai-search/entity-seo-knowledge-graph-deep-dive.md`
 
 ### Map the Entity Landscape
 
@@ -98,8 +98,8 @@ Output: `workspace/topical-map/_entity-map.md`
 ## Phase 3: Query Fan-Out Coverage Matrix
 
 Load before starting:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\query-fan-out-guide.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\content-copywriting\qdp-qdh-qds-content-architecture.md`
+- `knowledge/frameworks/aeo-ai-search/query-fan-out-guide.md`
+- `knowledge/frameworks/content-copywriting/qdp-qdh-qds-content-architecture.md`
 
 ### How AI Search Decomposes Queries
 
@@ -148,8 +148,8 @@ Output: `workspace/topical-map/_fan-out-matrix.md`
 ## Phase 4: Information Gain Audit
 
 Load before starting:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\patent-information-gain-US12013887B2.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\hidden-aeo-edges.md`
+- `knowledge/frameworks/aeo-ai-search/patent-information-gain-US12013887B2.md`
+- `knowledge/frameworks/aeo-ai-search/hidden-aeo-edges.md`
 
 ### Why Information Gain Matters
 
@@ -193,8 +193,8 @@ Output: `workspace/topical-map/_information-gain-audit.md`
 ## Phase 5: Content Node Architecture
 
 Load before starting:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\geo-academic-research-synthesis.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\frameworks\aeo-ai-search\perplexity-ranking-reverse-engineered.md`
+- `knowledge/frameworks/aeo-ai-search/geo-academic-research-synthesis.md`
+- `knowledge/frameworks/aeo-ai-search/perplexity-ranking-reverse-engineered.md`
 
 ### Synthesize Into Hub-and-Spoke Architecture
 
@@ -293,8 +293,8 @@ Output: `workspace/topical-map/_content-nodes.md`, `workspace/topical-map/_schem
 ## Phase 6: 90-Day Publishing Calendar + Distribution Plan
 
 Load before starting:
-- `E:\Dev2\kai-cmo-harness-work\harness\brief-schema.md`
-- `E:\Dev2\kai-cmo-harness-work\harness\skills\kai-content-calendar\SKILL.md` (for format compatibility)
+- `harness/brief-schema.md`
+- `harness/skills/kai-content-calendar/SKILL.md` (for format compatibility)
 
 ### AEO Sequencing Rules
 
@@ -341,7 +341,7 @@ Each content node gets a distribution plan. Publishing on your site alone leaves
 
 ### Brief Generation
 
-Generate briefs for the first 4 weeks using the schema from `E:\Dev2\kai-cmo-harness-work\harness\brief-schema.md`, extended with AEO-specific fields:
+Generate briefs for the first 4 weeks using the schema from `harness/brief-schema.md`, extended with AEO-specific fields:
 
 ```json
 {

--- a/harness/skills/kai-video/SKILL.md
+++ b/harness/skills/kai-video/SKILL.md
@@ -29,10 +29,10 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 ## Phase 2: Script Production
 
 Load these before writing:
-- `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\video-content-creation.md`
-- `E:\Dev2\kai-cmo-harness-work\knowledge\channels\tiktok-algorithm.md` (if TikTok)
-- `E:\Dev2\kai-cmo-harness-work\knowledge\channels\youtube.md` (if YouTube)
-- `E:\Dev2\kai-cmo-harness-work\knowledge\channels\instagram.md` (if Reels)
+- `knowledge/playbooks/video-content-creation.md`
+- `knowledge/channels/tiktok-algorithm.md` (if TikTok)
+- `knowledge/channels/youtube.md` (if YouTube)
+- `knowledge/channels/instagram.md` (if Reels)
 
 ### Short-Form Script Structure (15-60 seconds)
 
@@ -130,8 +130,8 @@ Load these before writing:
 
 If the user has long-form content, generate a clipping plan:
 
-Load: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\video-clipping-automation-workflow.md`
-Load for any transcript, caption, podcast, webinar, or third-party source: `E:\Dev2\kai-cmo-harness\harness\references\transcript-video-research-rules.md`
+Load: `knowledge/playbooks/video-clipping-automation-workflow.md`
+Load for any transcript, caption, podcast, webinar, or third-party source: `harness/references/transcript-video-research-rules.md`
 
 | Clip # | Timestamp | Hook | Platform | Length | Script Adaptation |
 |--------|-----------|------|----------|--------|-------------------|

--- a/harness/skills/kai-webinar/SKILL.md
+++ b/harness/skills/kai-webinar/SKILL.md
@@ -25,7 +25,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 1. **Event type** — Webinar, workshop, panel, AMA, product demo, conference talk?
 2. **Goal** — Lead generation, nurture, product launch, thought leadership, retention?
-3. **Target audience** — Which persona(s)? Load from `E:\Dev2\kai-cmo-harness-work\knowledge\personas\_persona-index.md`
+3. **Target audience** — Which persona(s)? Load from `knowledge/personas/_persona-index.md`
 4. **Topic candidates** — What expertise can we share that the audience needs?
 5. **Speakers** — Internal, external guests, customer panels?
 6. **Platform** — Zoom, Teams, StreamYard, Crowdcast, in-person, hybrid?
@@ -39,7 +39,7 @@ Read from `MARKETING.md`. Only ask about things not covered there:
 
 Build the event marketing plan:
 
-1. **Load event playbook**: `E:\Dev2\kai-cmo-harness-work\knowledge\playbooks\event-webinar-MARKETING.md`
+1. **Load event playbook**: `knowledge/playbooks/event-webinar-marketing.md`
 2. **Topic validation** — Score topic against:
    - Audience pain relevance (does it solve a real problem?)
    - Competitive differentiation (can only WE teach this?)
@@ -85,10 +85,10 @@ Apply harness writing rules:
 
 Validate before launch:
 
-1. **Four U's Score** (on emails and registration page): `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\four_us_score.py <file>`
+1. **Four U's Score** (on emails and registration page): `python scripts/quality_gates/four_us_score.py <file>`
    - Minimum: **10/16** (email threshold) for emails
    - Minimum: **12/16** (content threshold) for registration page
-2. **Banned Word Check**: `python E:\Dev2\kai-cmo-harness-work\scripts\quality_gates\banned_word_check.py <file>`
+2. **Banned Word Check**: `python scripts/quality_gates/banned_word_check.py <file>`
 3. **AI Slop Check** — No filler phrases
 4. **Subject line check** — Under 50 characters, no spam triggers
 5. **CTA clarity check** — Every asset has exactly one clear next step
@@ -110,4 +110,4 @@ Deliver the complete event marketing package:
 - **Promotion timeline with dates**
 - **Gate pass/fail summary**
 
-Write output to `E:\Dev2\kai-cmo-harness-work\workspace\` with filename pattern: `webinar-[topic-slug]-YYYY-MM-DD.md`
+Write output to `workspace/` with filename pattern: `webinar-[topic-slug]-YYYY-MM-DD.md`

--- a/harness/skills/kai-weekly-audit/SKILL.md
+++ b/harness/skills/kai-weekly-audit/SKILL.md
@@ -9,7 +9,7 @@ Run a fast weekly operating audit. This skill is the cadence layer above `/kai-a
 
 ## Non-Negotiable: Data Provenance
 
-Before writing findings, load `E:\Dev2\kai-cmo-harness-work\harness\references\audit-data-provenance.md`.
+Before writing findings, load `harness/references/audit-data-provenance.md`.
 
 Declare the data mode:
 

--- a/harness/skills/kai-write/SKILL.md
+++ b/harness/skills/kai-write/SKILL.md
@@ -17,7 +17,7 @@ Check if `MARKETING.md` exists in the **project root** (same directory as CLAUDE
 
 ## Step 1: Identify Format and Load Context
 
-Determine the content format from the user's request, then load the corresponding files from the harness at `E:\Dev2\kai-cmo-harness-work`:
+Determine the content format from the user's request, then load the corresponding files from the harness (paths relative to the project root):
 
 | Format | Framework | Contract | Checklist |
 |--------|-----------|----------|-----------|


### PR DESCRIPTION
## Summary

- 31 `harness/skills/*/SKILL.md` files loaded knowledge/harness references via one author's absolute Windows dev path (`E:\Dev2\kai-cmo-harness-work\...`), unresolvable for anyone else who clones the repo. `kai-repurpose` also had the un-suffixed `E:\Dev2\kai-cmo-harness\...` variant that a prior partial fix missed — that's what this branch was originally scoped to, but the same bug turned out to be repo-wide.
- Stripped the `E:\Dev2\kai-cmo-harness(-work)?\` prefix everywhere, converting to project-root-relative forward-slash paths (145 references across 31 files, 2 intro-sentence mentions with no trailing path, and one shell command example in `kai-daily-ad-review`).
- Fixed six playbook filenames referenced as `-MARKETING.md` (uppercase) that actually exist on disk as `-marketing.md` — invisible on Windows' case-insensitive filesystem, broken on Linux/Mac.

`kai-product-maker`'s separate `E:\Dev2\DigitalProduct\...` example paths are untouched — those point to external example products outside this repo (a different problem needing a product decision, not a path fix).

## Test plan

- [x] `grep -rn 'Dev2' harness/skills/*/SKILL.md` — only the unrelated `kai-product-maker` DigitalProduct examples remain
- [x] Every path touched by the diff verified to resolve to a real file on disk
- [x] `python scripts/doctor.py` — instruction chain intact (190 doc-referenced paths checked), golden corpus passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01NxT7h45rkXATdPFY8oBi1R)_