### PR TITLE
Raise LinkedIn article word-count floor to 2,200w

### DIFF
--- a/harness/skill-contracts/linkedin-article.yaml
+++ b/harness/skill-contracts/linkedin-article.yaml
@@ -3,7 +3,7 @@ version: 3.0
 harness: kai-harness
 format: linkedin-article
 risk_tier: medium
-word_count: 700-1000
+word_count: 2200-3000
 min_four_us: 12
 seo_lint: false
 
@@ -62,7 +62,7 @@ quality_gates:
 deterministic_checks:
   - id: word_count_range
     evaluator: script
-    pass_when: "700 <= word_count <= 1000"
+    pass_when: "2200 <= word_count <= 3000"
   - id: linkedin_format
     evaluator: quality_gate
     pass_when: "short paragraphs, no markdown H1/H2 headers, and readable spacing"

--- a/harness/skill-contracts/social-post.yaml
+++ b/harness/skill-contracts/social-post.yaml
@@ -52,7 +52,7 @@ quality_gates:
   - x_account_capability_checked == true  # required for X long posts, Articles, Spaces, creator monetization, or promoted candidates
 
 word_count: 50-900  # varies by platform and post_type
-# linkedin update: 150-700 words | linkedin article: 700-1000
+# linkedin update: 150-700 words | linkedin article: 2200-3000
 # X update: 20-50 words by default | X thread: 150-500 words total | X long-form/Article only when account capability is declared
 # instagram/facebook/threads: 20-400 words depending on format
 # tiktok/youtube/snapchat: script-first; short-form hooks must land in first 1-3 seconds

--- a/harness/skills/kai-repurpose/SKILL.md
+++ b/harness/skills/kai-repurpose/SKILL.md
@@ -84,7 +84,7 @@ From one pillar, produce:
 | 11 | TikTok video script (contrarian take) | TikTok | 15-30 seconds |
 | 12 | Email newsletter section | Email | 100-200 words |
 | 13 | Email standalone (value-add) | Email | 300-500 words |
-| 14 | LinkedIn article (expanded angle) | LinkedIn | 700-1000 words |
+| 14 | LinkedIn article (expanded angle) | LinkedIn | 2,200-3,000 words |
 | 15 | YouTube Shorts script | YouTube | 30-60 seconds |
 | 16-25 | Additional platform-specific variants | Various | Various |
 

--- a/knowledge/channels/linkedin-articles.md
+++ b/knowledge/channels/linkedin-articles.md
@@ -6,7 +6,7 @@
 
 | Metric | Target |
 |--------|--------|
-| **Length** | 1,200-2,000 words |
+| **Length** | 2,200-3,000 words |
 | **Headline** | Under 50 characters |
 | **Subheadings** | Every 200-300 words |
 | **Hashtags** | 3-5 relevant tags |
@@ -127,9 +127,9 @@ Right: "Respond to comments quickly."
 
 **Rule 3: Use short, declarative sentences**
 ```
-Wrong: "When it comes to LinkedIn articles, which have been shown to perform better than posts for long-term visibility, the optimal length appears to be somewhere between 1,200 and 2,000 words."
+Wrong: "When it comes to LinkedIn articles, which have been shown to perform better than posts for long-term visibility, the optimal length appears to be somewhere between 2,200 and 3,000 words."
 
-Right: "LinkedIn articles outperform posts for long-term visibility. The optimal length is 1,200-2,000 words."
+Right: "LinkedIn articles outperform posts for long-term visibility. The optimal length is 2,200-3,000 words."
 ```
 
 ### List & Formatting Rules
@@ -221,8 +221,8 @@ Right: "Use strong hooks in your opening. For example: 'We analyzed 10,000 cold 
 
 **Rule 12: Bold the ANSWER, not the query terms**
 ```
-Wrong: "The **optimal length** for LinkedIn articles is 1,200-2,000 words."
-Right: "The optimal length for LinkedIn articles is **1,200-2,000 words**."
+Wrong: "The **optimal length** for LinkedIn articles is 2,200-3,000 words."
+Right: "The optimal length for LinkedIn articles is **2,200-3,000 words**."
 ```
 
 ### Internal Linking Rules (For Articles That Link Out)
@@ -292,7 +292,7 @@ LinkedIn articles are indexed by Google, providing:
 - [ ] Related keywords throughout body
 - [ ] Descriptive subheadings with keyword variants
 - [ ] Alt text on images (if applicable)
-- [ ] 1,200-2,000 words for depth
+- [ ] 2,200-3,000 words for depth
 
 ---
 
@@ -357,7 +357,7 @@ LinkedIn articles are indexed by Google, providing:
 Structure & Format
 [ ] Headline under 50 characters
 [ ] Hook in first 200 characters
-[ ] 1,200-2,000 words
+[ ] 2,200-3,000 words
 [ ] Subheadings every 200-300 words
 [ ] Short paragraphs (2-4 sentences)
 [ ] Cover image (1280x720)

--- a/scripts/content/_writer.py
+++ b/scripts/content/_writer.py
@@ -110,7 +110,7 @@ STRUCTURE:
 [CTA — one sentence, low friction]
 
 REQUIREMENTS:
-- 600-900 words
+- 2,200-3,000 words (floor is 2,200 — do not stop before it)
 - One idea per paragraph
 - No hashtags, no "Thoughts?" endings
 - Every paragraph separated by a blank line""",

--- a/scripts/content/linkedin_article_writer.py
+++ b/scripts/content/linkedin_article_writer.py
@@ -272,7 +272,7 @@ def write_article(headline: str, cluster_name: str, cluster_context: str = "") -
 Cluster topic: {cluster_name}{context_block}
 
 Requirements:
-- 900–1,200 words
+- 2,200–3,000 words (this is a floor — do not stop before 2,200)
 - Start with a specific scenario, data point, or concrete problem — NOT "I'm excited to share" or any opener about yourself
 - Short paragraphs (2–4 sentences max)
 - Use bold headers (##) to break the article into 4–6 sections
@@ -289,7 +289,7 @@ Output the full article in markdown. Include the title as an H1 at the top."""
             {"role": "user", "content": prompt}
         ],
         temperature=0.7,
-        max_tokens=2000,
+        max_tokens=4500,
     )
     return response.choices[0].message.content.strip()
 


### PR DESCRIPTION
## What & why

The default `linkedin-article` skill contract targeted **700–1,000 words**, which is wrong for this channel. Per Connor's LinkedIn writing feedback, the LinkedIn article floor is **2,200 words**. The deployed writer on the agent box was still generating to the stale 700–1,000w (its own prompt said 900–1,200w), so drafts came out far shorter than the channel warrants.

This PR raises the floor to 2,200 words and aligns every stale downstream target that fed generation off the old number, so the contract, the channel guide, and the writers all agree.

## Changes

- **`harness/skill-contracts/linkedin-article.yaml`** — `word_count` `700-1000` → `2200-3000`; `word_count_range` deterministic check raised to `2200 <= word_count <= 3000`. This is the source of truth the writer derives its floor target from.
- **`scripts/content/linkedin_article_writer.py`** (deployed agent-box writer) — prompt length `900–1,200` → `2,200–3,000` (floor); `max_tokens` `2000` → `4500` so a 2,200w+ article is not truncated mid-generation.
- **`scripts/content/_writer.py`** — engine `linkedin` format instruction `600-900` → `2,200-3,000` (this format maps to the `linkedin-article` policy, so the old number contradicted the contract in-prompt).
- **`knowledge/channels/linkedin-articles.md`** — length spec `1,200-2,000` → `2,200-3,000` across the quick-reference table, checklists, and worked examples.
- **`harness/skills/kai-repurpose/SKILL.md`** — LinkedIn article variant `700-1000` → `2,200-3,000`.
- **`harness/skill-contracts/social-post.yaml`** — article cross-reference comment updated to `2200-3000` (the LinkedIn organic-post range is unchanged).

## Verification

- `python scripts/quality_gates/golden_check.py` → 4/4 golden cases intact.
- `python scripts/doctor.py` → harness intact (45/45 referenced files, instruction chain, gate scripts compile). Remaining warnings are pre-existing unconfigured-env warnings, unrelated to this change.
- Confirmed the contract still parses and the writer's floor target resolves to `2200`.

## Note

The ceiling (3,000w) is not specified by the feedback — the feedback fixes only the 2,200 floor. I paired it with a 3,000 ceiling to keep a bounded range for the deterministic check and writer target (the prior contract and channel guide both used bounded ranges). Easy to widen if you'd prefer a higher or open-ended ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dF1TwvB2u4jxSKhbyERr6

---
_Generated by [Claude Code](https://claude.ai/code/session_016dF1TwvB2u4jxSKhbyERr6)_