### PR TITLE
Fix ads CLI runtime credential routing

### DIFF
--- a/scripts/ads/_pull_common.py
+++ b/scripts/ads/_pull_common.py
@@ -62,9 +62,13 @@ def _load_env_file() -> Dict[str, str]:
 
 
 def env(key: str, default: str = "") -> str:
-    """Get an env var: .env.local first, then os.environ, then default."""
+    """Get an env var: explicit process environment, then env file, then default.
+
+    Operators may source a current secret before invoking the CLI. That explicit
+    runtime choice must not be silently replaced by a stale repo-local value.
+    """
     loaded = _load_env_file()
-    return loaded.get(key, os.environ.get(key, default))
+    return os.environ.get(key, loaded.get(key, default))
 
 
 def has_creds(*keys: str) -> bool:

--- a/tests/test_ads_env_precedence.py
+++ b/tests/test_ads_env_precedence.py
@@ -1,0 +1,19 @@
+from scripts.ads import _pull_common
+
+
+def test_process_environment_overrides_repo_env_file(tmp_path, monkeypatch):
+    (tmp_path / ".env.local").write_text("META_ACCESS_TOKEN=stale-file-token\n", encoding="utf-8")
+    monkeypatch.setattr(_pull_common, "REPO_ROOT", tmp_path)
+    monkeypatch.setenv("META_ACCESS_TOKEN", "current-runtime-token")
+    _pull_common._env_cache.clear()
+
+    assert _pull_common.env("META_ACCESS_TOKEN") == "current-runtime-token"
+
+
+def test_repo_env_file_remains_fallback(tmp_path, monkeypatch):
+    (tmp_path / ".env.local").write_text("META_ACCESS_TOKEN=file-token\n", encoding="utf-8")
+    monkeypatch.setattr(_pull_common, "REPO_ROOT", tmp_path)
+    monkeypatch.delenv("META_ACCESS_TOKEN", raising=False)
+    _pull_common._env_cache.clear()
+
+    assert _pull_common.env("META_ACCESS_TOKEN") == "file-token"


### PR DESCRIPTION
## Summary
- let explicitly sourced runtime credentials override stale repo-local env values
- keep repo env files as fallback
- add regression coverage

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_ads_env_precedence.py tests/test_ads_upload_guardrails.py -q
- 9 passed