### PR TITLE
Fix self-improvement measurement intake

### DIFF
--- a/scripts/harness_config.py
+++ b/scripts/harness_config.py
@@ -219,9 +219,13 @@ def load_config() -> HarnessConfig:
     gsc_urls = sites_raw.get("gsc_urls", {})
     ga4_props = {}
     for site_key, prop_id in sites_raw.get("ga4_properties", {}).items():
-        # Allow env var override per site
-        env_key = f"GA4_PROPERTY_{site_key.upper()}"
-        ga4_props[site_key] = os.environ.get(env_key, str(prop_id))
+        # setup.sh and deployed .env files use GA_<SITE>_PROPERTY_ID.
+        # Retain GA4_PROPERTY_<SITE> as a compatibility fallback.
+        env_key = f"GA_{site_key.upper()}_PROPERTY_ID"
+        legacy_env_key = f"GA4_PROPERTY_{site_key.upper()}"
+        ga4_props[site_key] = os.environ.get(
+            env_key, os.environ.get(legacy_env_key, str(prop_id))
+        )
     sites = SiteConfig(gsc_urls=gsc_urls, ga4_properties=ga4_props)
 
     # Build threshold config

--- a/scripts/quality/tests/test_harness_config.py
+++ b/scripts/quality/tests/test_harness_config.py
@@ -6,6 +6,8 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
 
 
@@ -201,6 +203,22 @@ quality:
         fw = get_filler_words()
         assert fw == ["um", "uh", "like"], f"Expected custom list: {fw}"
         print("PASS: Custom filler words list")
+
+
+def test_ga4_property_uses_deployed_env_contract(tmp_path, monkeypatch):
+    """The harness reads the GA_<SITE>_PROPERTY_ID name emitted by setup.sh."""
+    config = tmp_path / "config.yaml"
+    config.write_text("sites:\n  ga4_properties:\n    meetkai: ''\n")
+    monkeypatch.setenv("CMO_CONFIG_PATH", str(config))
+    monkeypatch.setenv("GA_MEETKAI_PROPERTY_ID", "123456789")
+    monkeypatch.delenv("GA4_PROPERTY_MEETKAI", raising=False)
+
+    import scripts.harness_config as hc
+    hc._config = None
+    try:
+        assert hc.get_config().sites.ga4_properties["meetkai"] == "123456789"
+    finally:
+        hc._config = None
 
 
 if __name__ == "__main__":

--- a/scripts/self_improvement/performance_check.py
+++ b/scripts/self_improvement/performance_check.py
@@ -66,6 +66,37 @@ def save_log(entries: list):
         json.dump(entries, f, indent=2)
 
 
+def _normalize_pending_check(check_file: Path, check: dict, entries: list) -> dict | None:
+    """Upgrade legacy pending-check records at the read boundary."""
+    entries_by_id = {entry.get("id"): entry for entry in entries if entry.get("id")}
+    entries_by_url = {entry.get("url"): entry for entry in entries if entry.get("url")}
+    entry = entries_by_id.get(check.get("id")) or entries_by_url.get(check.get("url"))
+    normalized = dict(check)
+    if entry:
+        normalized.setdefault("id", entry.get("id"))
+        normalized.setdefault("keyword", entry.get("keyword"))
+        normalized.setdefault("site", entry.get("site"))
+        normalized.setdefault(
+            "published_at", entry.get("published_at") or entry.get("publish_date")
+        )
+    if not normalized.get("check_due") and normalized.get("check_after"):
+        normalized["check_due"] = normalized["check_after"]
+
+    required = ("id", "url", "keyword", "site", "check_due")
+    missing = [key for key in required if not normalized.get(key)]
+    if missing:
+        log.warning("Skipping invalid pending check %s (missing: %s)", check_file, ", ".join(missing))
+        return None
+
+    if normalized != check:
+        temp_file = check_file.with_suffix(f"{check_file.suffix}.tmp")
+        with open(temp_file, "w") as f:
+            json.dump(normalized, f, indent=2)
+        os.replace(temp_file, check_file)
+        log.info("Normalized legacy pending check %s", check_file)
+    return normalized
+
+
 def reconcile_pending_checks(dry_run: bool = False) -> int:
     """Regenerate missing pending-check files from the content log.
 
@@ -129,15 +160,21 @@ def get_pending_checks() -> list:
         return []
     checks = []
     now = datetime.now(timezone.utc)
+    entries = load_log()
     for f in Path(PENDING_CHECKS_DIR).glob("*.json"):
         with open(f) as fh:
             check = json.load(fh)
+        check = _normalize_pending_check(f, check, entries)
+        if check is None:
+            continue
         if not check.get("url"):
             # Approved-but-unpublished entries carry url=None — there is no
             # live page to measure, so never schedule a GSC/GA4 pull for them.
             continue
         due = datetime.fromisoformat(check["check_due"])
-        if check["status"] == "pending" and due <= now:
+        if due.tzinfo is None:
+            due = due.replace(tzinfo=timezone.utc)
+        if check.get("status") == "pending" and due <= now:
             checks.append((f, check))
     return checks
 
@@ -294,11 +331,10 @@ def pull_ga4_data(url: str, site: str) -> dict:
         from google.analytics.data_v1beta.types import (
             DateRange,
             Dimension,
-            DimensionFilter,
+            Filter,
             FilterExpression,
             Metric,
             RunReportRequest,
-            StringFilter,
         )
 
         property_id = GA4_PROPERTY_IDS.get(site)
@@ -323,9 +359,9 @@ def pull_ga4_data(url: str, site: str) -> dict:
             ],
             date_ranges=[DateRange(start_date="30daysAgo", end_date="today")],
             dimension_filter=FilterExpression(
-                filter=DimensionFilter(
+                filter=Filter(
                     field_name="pagePath",
-                    string_filter=StringFilter(
+                    string_filter=Filter.StringFilter(
                         match_type="CONTAINS",
                         value=path,
                     ),

--- a/tests/test_learning_loop_repair.py
+++ b/tests/test_learning_loop_repair.py
@@ -221,6 +221,44 @@ class TestPendingChecksSkipNullUrl:
         due = pc.get_pending_checks()
         assert [c["id"] for _, c in due] == ["due"]
 
+    def test_get_pending_checks_normalizes_legacy_check_after(self, perf):
+        pc, content_log, checks_dir = perf
+        content_log.write_text(json.dumps([{
+            "id": "legacy-1",
+            "url": "https://example.com/legacy",
+            "keyword": "legacy keyword",
+            "site": "meetkai",
+            "publish_date": "2026-01-01",
+            "performance_30d": None,
+        }]))
+        check_file = checks_dir / "legacy-1.json"
+        check_file.write_text(json.dumps({
+            "url": "https://example.com/legacy",
+            "check_after": "2020-01-01",
+            "status": "pending",
+        }))
+
+        due = pc.get_pending_checks()
+
+        assert len(due) == 1
+        assert due[0][1]["id"] == "legacy-1"
+        assert due[0][1]["keyword"] == "legacy keyword"
+        assert due[0][1]["site"] == "meetkai"
+        assert due[0][1]["published_at"] == "2026-01-01"
+        normalized = json.loads(check_file.read_text())
+        assert normalized["check_due"] == "2020-01-01"
+
+    def test_get_pending_checks_skips_malformed_record_without_stopping_batch(self, perf, caplog):
+        pc, content_log, checks_dir = perf
+        content_log.write_text("[]")
+        (checks_dir / "bad.json").write_text(json.dumps({"status": "pending"}))
+        self._check(checks_dir, "due")
+
+        due = pc.get_pending_checks()
+
+        assert [c["id"] for _, c in due] == ["due"]
+        assert "Skipping invalid pending check" in caplog.text
+
     def test_reconcile_skips_approved_unpublished_null_url(self, perf):
         pc, content_log, checks_dir = perf
         entries = [


### PR DESCRIPTION
## Summary
- normalize legacy pending-check records from the canonical content log
- skip malformed records without stopping the daily batch
- use the deployed GA_<SITE>_PROPERTY_ID contract for GA4
- update the GA4 filter construction for the installed client library

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_learning_loop_repair.py scripts/quality/tests/test_harness_config.py -q
- 45 passed
- Hermes live dry-run returned valid GSC + GA4 data for both pending MeetKai pages
- real loop persisted both performance_30d records and marked both checks done
- follow-up --all: No pending performance checks due