### PR TITLE
Fix Meta Leads campaign and video-ad creation

### DIFF
--- a/scripts/ads/_pull_common.py
+++ b/scripts/ads/_pull_common.py
@@ -162,9 +162,16 @@ def _request(
                     time.sleep(wait)
                     continue
                 # Permanent error: raise
+                details = [
+                    f"subcode={err['error_subcode']}" if err.get("error_subcode") else "",
+                    err.get("error_user_title", ""),
+                    err.get("error_user_msg", ""),
+                ]
+                detail_text = " | ".join(part for part in details if part)
                 raise APIError(
                     f"API error{' (' + label + ')' if label else ''}: "
                     f"[{err.get('code', '?')}] {err.get('message', 'Unknown error')}"
+                    f"{' | ' + detail_text if detail_text else ''}"
                 )
 
             return body

--- a/scripts/ads/meta.py
+++ b/scripts/ads/meta.py
@@ -631,6 +631,7 @@ def cmd_create_campaign(args: argparse.Namespace) -> None:
         "objective": args.objective,
         "status": args.status or "PAUSED",
         "special_ad_categories": f"[{args.special_ad_category}]" if args.special_ad_category else "[]",
+        "is_adset_budget_sharing_enabled": "false",
         "access_token": _token(),
     }
 

--- a/scripts/ads/meta.py
+++ b/scripts/ads/meta.py
@@ -670,6 +670,7 @@ def cmd_create_adset(args: argparse.Namespace) -> None:
         "daily_budget": str(budget_cents),
         "billing_event": "IMPRESSIONS",
         "optimization_goal": args.optimization_goal,
+        "bid_strategy": "LOWEST_COST_WITHOUT_CAP",
         "targeting": args.targeting,  # JSON string
         "status": "PAUSED",
         "access_token": _token(),

--- a/scripts/ads/upload.py
+++ b/scripts/ads/upload.py
@@ -49,6 +49,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--asset", required=True, type=Path, help="Path to image/video file")
     p.add_argument("--asset-ref", default=None,
                    help="Reuse an already uploaded platform asset ref after a failed ad-create attempt.")
+    p.add_argument("--thumbnail", type=Path, default=None,
+                   help="Video thumbnail image. Uploaded through the same approved canonical path.")
     p.add_argument("--kind", required=True, choices=["image", "video"])
     p.add_argument("--adset-id", required=True,
                    help="Meta ad-set id / TikTok ad-group id / Google ad-group resource / LinkedIn campaign URN")
@@ -118,6 +120,12 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"[1/2] Uploading {args.kind} to {args.platform}: {args.asset}", file=sys.stderr)
                 upload = uploader.upload_asset(asset)
             print(f"      → ref={upload.ref}", file=sys.stderr)
+            if args.kind == "video" and args.thumbnail:
+                print(f"      → uploading thumbnail: {args.thumbnail}", file=sys.stderr)
+                thumbnail_upload = uploader.upload_asset(
+                    CreativeAsset(path=args.thumbnail, kind="image", title=f"{asset.title or asset.path.stem}-thumbnail")
+                )
+                upload.raw["thumbnail_hash"] = thumbnail_upload.ref
         else:
             print(f"[1/2] Dry-run asset preview for {args.platform}: {args.asset}", file=sys.stderr)
             upload = UploadResult(
@@ -127,6 +135,7 @@ def main(argv: list[str] | None = None) -> int:
                 raw={
                     "dry_run": True,
                     "asset": str(args.asset),
+                    "thumbnail_hash": "DRY_RUN_THUMBNAIL_HASH" if args.thumbnail else None,
                     "guardrail": "No upload performed without --execute and --approval-id",
                 },
             )

--- a/scripts/ads/upload.py
+++ b/scripts/ads/upload.py
@@ -47,6 +47,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--platform", required=True, choices=list_platforms(),
                    help="Destination ad platform")
     p.add_argument("--asset", required=True, type=Path, help="Path to image/video file")
+    p.add_argument("--asset-ref", default=None,
+                   help="Reuse an already uploaded platform asset ref after a failed ad-create attempt.")
     p.add_argument("--kind", required=True, choices=["image", "video"])
     p.add_argument("--adset-id", required=True,
                    help="Meta ad-set id / TikTok ad-group id / Google ad-group resource / LinkedIn campaign URN")
@@ -104,8 +106,17 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         if args.execute:
-            print(f"[1/2] Uploading {args.kind} to {args.platform}: {args.asset}", file=sys.stderr)
-            upload = uploader.upload_asset(asset)
+            if args.asset_ref:
+                print(f"[1/2] Reusing uploaded {args.kind} ref on {args.platform}: {args.asset_ref}", file=sys.stderr)
+                upload = UploadResult(
+                    platform=args.platform,
+                    kind=args.kind,
+                    ref=args.asset_ref,
+                    raw={"reused": True, "asset": str(args.asset)},
+                )
+            else:
+                print(f"[1/2] Uploading {args.kind} to {args.platform}: {args.asset}", file=sys.stderr)
+                upload = uploader.upload_asset(asset)
             print(f"      → ref={upload.ref}", file=sys.stderr)
         else:
             print(f"[1/2] Dry-run asset preview for {args.platform}: {args.asset}", file=sys.stderr)

--- a/scripts/ads/uploaders/meta.py
+++ b/scripts/ads/uploaders/meta.py
@@ -140,24 +140,32 @@ class MetaUploader(AdUploader):
                 "creative.page_id (or META_PAGE_ID env) required for Meta ads"
             )
 
-        link_data: dict[str, Any] = {
+        common_data: dict[str, Any] = {
             "message": creative.description,
-            "link": creative.link,
-            "name": creative.headline,
             "call_to_action": {
                 "type": creative.cta,
                 "value": {"link": creative.link},
             },
         }
         if asset.kind == "video":
-            link_data["video_id"] = asset.ref
+            object_story_spec: dict[str, Any] = {
+                "page_id": page_id,
+                "video_data": {
+                    **common_data,
+                    "video_id": asset.ref,
+                    "title": creative.headline,
+                },
+            }
         else:
-            link_data["image_hash"] = asset.ref
-
-        object_story_spec: dict[str, Any] = {
-            "page_id": page_id,
-            "link_data": link_data,
-        }
+            object_story_spec = {
+                "page_id": page_id,
+                "link_data": {
+                    **common_data,
+                    "link": creative.link,
+                    "name": creative.headline,
+                    "image_hash": asset.ref,
+                },
+            }
         ig_user_id = creative.instagram_user_id or os.getenv("META_INSTAGRAM_USER_ID")
         if ig_user_id:
             # NOTE per harness/references/meta-ads-api-reference.md: use

--- a/scripts/ads/uploaders/meta.py
+++ b/scripts/ads/uploaders/meta.py
@@ -148,11 +148,15 @@ class MetaUploader(AdUploader):
             },
         }
         if asset.kind == "video":
+            thumbnail_hash = asset.raw.get("thumbnail_hash")
+            if not thumbnail_hash:
+                raise UploadError("Meta video creative requires a thumbnail image/hash")
             object_story_spec: dict[str, Any] = {
                 "page_id": page_id,
                 "video_data": {
                     **common_data,
                     "video_id": asset.ref,
+                    "image_hash": thumbnail_hash,
                     "title": creative.headline,
                 },
             }

--- a/tests/test_ads_upload_guardrails.py
+++ b/tests/test_ads_upload_guardrails.py
@@ -124,7 +124,12 @@ def test_meta_video_creative_uses_video_data(monkeypatch):
         cta="LEARN_MORE",
         page_id="page_1",
     )
-    asset = UploadResult(platform="meta", kind="video", ref="video_1", raw={})
+    asset = UploadResult(
+        platform="meta",
+        kind="video",
+        ref="video_1",
+        raw={"thumbnail_hash": "thumb_1"},
+    )
 
     uploader.create_ad("adset_1", creative, asset, execute=False)
 
@@ -132,6 +137,7 @@ def test_meta_video_creative_uses_video_data(monkeypatch):
     payload = __import__("json").loads(creative_json)
     story = payload["object_story_spec"]
     assert story["video_data"]["video_id"] == "video_1"
+    assert story["video_data"]["image_hash"] == "thumb_1"
     assert "link_data" not in story
 
 

--- a/tests/test_ads_upload_guardrails.py
+++ b/tests/test_ads_upload_guardrails.py
@@ -87,6 +87,26 @@ def test_upload_cli_execute_with_approval_uploads_and_creates_paused(monkeypatch
     assert dummy.create_called is True
 
 
+def test_upload_cli_reuses_existing_asset_ref_without_upload(monkeypatch, tmp_path):
+    asset = tmp_path / "ad.mp4"
+    asset.write_bytes(b"fake")
+    dummy = _DummyUploader()
+    monkeypatch.setattr(upload, "get_uploader", lambda platform: dummy)
+
+    exit_code = upload.main(
+        _args(
+            asset,
+            "--execute",
+            "--approval-id", "act_123",
+            "--asset-ref", "video_123",
+        )
+    )
+
+    assert exit_code == 0
+    assert dummy.upload_called is False
+    assert dummy.create_called is True
+
+
 def test_meta_video_creative_uses_video_data(monkeypatch):
     captured = {}
 

--- a/tests/test_ads_upload_guardrails.py
+++ b/tests/test_ads_upload_guardrails.py
@@ -124,6 +124,29 @@ def test_meta_campaign_create_rejects_active_status():
     assert exc.value.code == 1
 
 
+def test_meta_campaign_create_disables_adset_budget_sharing(monkeypatch):
+    captured = {}
+    monkeypatch.setenv("META_AD_ACCOUNT_ID", "act_123")
+    monkeypatch.setenv("META_ACCESS_TOKEN", "token")
+    monkeypatch.setattr(
+        meta_cli,
+        "_dry_run_banner",
+        lambda method, url, payload: captured.update(payload),
+    )
+    args = meta_cli.argparse.Namespace(
+        name="Leads",
+        objective="OUTCOME_LEADS",
+        special_ad_category=None,
+        status="PAUSED",
+        execute=False,
+        approval_id=None,
+    )
+
+    meta_cli.cmd_create_campaign(args)
+
+    assert captured["is_adset_budget_sharing_enabled"] == "false"
+
+
 def test_tiktok_uploader_upload_asset_requires_approval_context(monkeypatch, tmp_path):
     asset = tmp_path / "ad.png"
     asset.write_bytes(b"fake")

--- a/tests/test_ads_upload_guardrails.py
+++ b/tests/test_ads_upload_guardrails.py
@@ -147,6 +147,31 @@ def test_meta_campaign_create_disables_adset_budget_sharing(monkeypatch):
     assert captured["is_adset_budget_sharing_enabled"] == "false"
 
 
+def test_meta_adset_create_uses_lowest_cost_without_cap(monkeypatch):
+    captured = {}
+    monkeypatch.setenv("META_AD_ACCOUNT_ID", "act_123")
+    monkeypatch.setenv("META_ACCESS_TOKEN", "token")
+    monkeypatch.setattr(
+        meta_cli,
+        "_dry_run_banner",
+        lambda method, url, payload: captured.update(payload),
+    )
+    args = meta_cli.argparse.Namespace(
+        campaign_id="campaign_1",
+        name="Lead test",
+        daily_budget="2",
+        optimization_goal="OFFSITE_CONVERSIONS",
+        targeting='{"geo_locations":{"countries":["US"]}}',
+        promoted_object='{"pixel_id":"pixel_1","custom_event_type":"LEAD"}',
+        execute=False,
+        approval_id=None,
+    )
+
+    meta_cli.cmd_create_adset(args)
+
+    assert captured["bid_strategy"] == "LOWEST_COST_WITHOUT_CAP"
+
+
 def test_tiktok_uploader_upload_asset_requires_approval_context(monkeypatch, tmp_path):
     asset = tmp_path / "ad.png"
     asset.write_bytes(b"fake")

--- a/tests/test_ads_upload_guardrails.py
+++ b/tests/test_ads_upload_guardrails.py
@@ -8,6 +8,9 @@ from scripts.ads import upload
 from scripts.ads import google as google_cli
 from scripts.ads import meta as meta_cli
 from scripts.ads.uploaders import AdRef, UploadError, UploadResult
+from scripts.ads.uploaders.base import CreativeSpec
+from scripts.ads.uploaders.meta import MetaUploader
+from scripts.ads.uploaders import meta as meta_uploader_module
 from scripts.ads.uploaders.tiktok import TikTokUploader
 
 
@@ -82,6 +85,34 @@ def test_upload_cli_execute_with_approval_uploads_and_creates_paused(monkeypatch
     assert exit_code == 0
     assert dummy.upload_called is True
     assert dummy.create_called is True
+
+
+def test_meta_video_creative_uses_video_data(monkeypatch):
+    captured = {}
+
+    def fake_run_meta(*args, capture=True):
+        captured["args"] = args
+        return type("Result", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+
+    monkeypatch.setattr(meta_uploader_module, "_run_meta", fake_run_meta)
+    uploader = MetaUploader()
+    creative = CreativeSpec(
+        name="Creature",
+        headline="Just Call Kai Today",
+        description="Kai answers after-hours calls.",
+        link="https://kaicalls.com",
+        cta="LEARN_MORE",
+        page_id="page_1",
+    )
+    asset = UploadResult(platform="meta", kind="video", ref="video_1", raw={})
+
+    uploader.create_ad("adset_1", creative, asset, execute=False)
+
+    creative_json = captured["args"][captured["args"].index("--creative-json") + 1]
+    payload = __import__("json").loads(creative_json)
+    story = payload["object_story_spec"]
+    assert story["video_data"]["video_id"] == "video_1"
+    assert "link_data" not in story
 
 
 def test_google_cli_execute_requires_approval_id_before_credentials():


### PR DESCRIPTION
## Summary
- send Meta's required ad-set budget-sharing flag on campaign creation
- set explicit lowest-cost bid strategy for new ad sets
- surface Meta parameter subcodes and user-facing errors
- build video creatives with video_data and approved thumbnails
- reuse uploaded asset IDs after failed container creation

## Verification
- python -m pytest tests/test_ads_upload_guardrails.py tests/test_ads_env_precedence.py -q (13 passed)
- live approved PAUSED campaign, Leads ad set, and eight PAUSED video ads created and read back

## Safety
- approval ID: connor-2026-07-12-creature-leads-8
- no activation
- no spend initiated