### PR TITLE
feat: frameworks & rules wave — marketing-science docs, arbitration layer, freshness sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Kai is a **marketing-native agent runtime**. This repo holds the knowledge base 
 - `scripts/quality/` is the quality/policy layer
 - `gateway/` is the remote runner and connector surface
 
-Inventory reachable from here: 54 skill directories, 52 canonical `kai-*` skill docs, 47 public `/kai` router commands, 59 playbook docs, 36 checklists, 27 framework docs, 26 channel guides, 8 audience persona profiles, and a quality gate pipeline that enforces standards before anything ships.
+Inventory reachable from here: 54 skill directories, 52 canonical `kai-*` skill docs, 47 public `/kai` router commands, 67 playbook docs, 36 checklists, 33 framework docs, 26 channel guides, 8 audience persona profiles, and a quality gate pipeline that enforces standards before anything ships.
 
 ## Instruction Contract (critical)
 
@@ -89,6 +89,8 @@ Load the primary framework as context, then validate against the checklist. Full
 | Offer construction / full-funnel build (Hormozi sequence) | `knowledge/playbooks/hormozi-100m-funnel.md` + `knowledge/people/alex-hormozi-knowledge.md` | — |
 | Phone lead capture / AI receptionist | `knowledge/playbooks/conversion-rate-optimization.md` + `knowledge/playbooks/demand-generation.md` + `knowledge/people/tommy-mello-knowledge.md` | `knowledge/checklists/cro-audit-checklist.md` |
 | Expert framework lookup (who said what, load-when triggers) | `knowledge/people/_people-index.md` | — |
+| Doctrine conflicts / which framework governs | `knowledge/_arbitration.md` + `knowledge/frameworks/marketing-science/diagnosis-first-operating-order.md` | — |
+| Measurement honesty (attribution, incrementality, test rigor) | `knowledge/frameworks/marketing-science/attribution-and-incrementality.md` + `knowledge/frameworks/marketing-science/experiment-rigor.md` | — |
 
 ---
 

--- a/harness/skills/kai-newsletter/SKILL.md
+++ b/harness/skills/kai-newsletter/SKILL.md
@@ -39,14 +39,15 @@ Build the newsletter edition plan:
 1. **Load strategy framework**: `knowledge/channels/newsletter-strategy.md`
 2. **Load email lifecycle patterns**: `knowledge/channels/email-lifecycle.md`
 3. **Load skill contract**: `harness/skill-contracts/email-lifecycle.yaml`
-4. **Define edition structure**:
+4. **Load growth economics** (only when the request involves list growth, acquisition budget, subscriber value, or list-quality diagnosis): `knowledge/playbooks/newsletter-growth-economics.md`
+5. **Define edition structure**:
    - Hero story / lead piece
    - Supporting content (2-3 items)
    - Quick links / resource roundup
    - CTA (one primary, one secondary max)
-5. **Subject line candidates** — Generate 5+ options, score for open-rate potential
-6. **Preview text** — Complement (not repeat) the subject line
-7. **Segment targeting** — Which list segment receives this edition?
+6. **Subject line candidates** — Generate 5+ options, score for open-rate potential
+7. **Preview text** — Complement (not repeat) the subject line
+8. **Segment targeting** — Which list segment receives this edition?
 
 ---
 

--- a/knowledge/_arbitration.md
+++ b/knowledge/_arbitration.md
@@ -1,0 +1,155 @@
+# The Keystone Lane — Doctrine Arbitration
+
+> **Use when:** Two frameworks in this knowledge base give opposite advice for the same situation and you must decide which one governs — brand-availability vs direct-response, WTP research vs value-equation pricing, PLG vs sales-led, narrow-ICP vs broad reach, demand creation vs demand capture, content-led inbound vs phone-led capture. This doc is the routing layer: given a diagnosed situation, it names the governing doctrine, the axis that decides, and what to do when no axis decides. It is loaded by every planning skill (`/kai-growth-plan`, `/kai-brand`, `/kai-audit`, `/kai-launch`, `/kai-budget`).
+
+**Provenance:** The conflicts below are real disagreements between published bodies of work, not straw men: Ehrenberg-Bass empirical generalizations (Sharp 2010; Dawes 95:5, 2021) vs direct-response doctrine (Hormozi, Kennedy, Abraham); Simon-Kucher willingness-to-pay research (Ramanujam & Tacke 2016) vs offer-framing psychology; PLG (Verna, OpenView lineage) vs sales-led motions (Gordon, Ovens); positioning-led narrow targeting (Dunford 2019) vs penetration-led broad reach (Sharp 2010). The arbitration rules are Kai's operational layer — the individual doctrines are cited in their own docs; verify anything category-specific against your own data before client claims (`harness/references/audit-data-provenance.md`).
+
+**Adjacent docs (cross-link, don't duplicate):**
+- *Which phase you are in* → `knowledge/frameworks/marketing-science/diagnosis-first-operating-order.md` — the front door. It routes you into diagnosis/strategy/tactics; this doc referees conflicts *inside* a phase.
+- *Framework lookup by task* → `knowledge/_index.md`. *Expert roster with load-when triggers* → `knowledge/people/_people-index.md`.
+- *Reach doctrine itself* → `knowledge/frameworks/marketing-science/brand-growth-laws.md`. *Budget ratio* → `knowledge/frameworks/marketing-science/brand-activation-budget.md`. *PMF verification* → `knowledge/frameworks/marketing-science/growth-metrics-and-pmf.md`. *Measurement trust order* → `knowledge/frameworks/marketing-science/attribution-and-incrementality.md`. *Test readability* → `knowledge/frameworks/marketing-science/experiment-rigor.md`.
+
+---
+
+## 1. The Operating Rule: Diagnosis Decides Jurisdiction
+
+No doctrine conflict is resolvable in the abstract. "Should we run brand or direct response?" has no answer; "should a pre-PMF B2B SaaS with 14 customers run brand or direct response?" does. So the operating rule:
+
+1. **Run the operating order first.** Diagnosis → strategy → tactics per `diagnosis-first-operating-order.md`. Most apparent doctrine conflicts dissolve once the diagnosis states the stage, model, vertical, and evidence position — the doctrines were answering different questions.
+2. **Identify the deciding axis.** Every conflict in Section 2 resolves on one of five axes: **stage** (pre-PMF / post-PMF / scale), **business model** (ACV, sales motion, purchase frequency), **vertical** (Section 3), **evidence state** (Section 4), or **time horizon** (this quarter's pipeline vs next year's demand).
+3. **Rule, cite, log.** State which doctrine governs, which axis decided, and which doc owns the winning doctrine. Plans that mix doctrines must say which budget line runs under which — a "blended" plan with no jurisdiction lines is the silent-averaging failure mode.
+4. **Never average silently.** If no axis decides, escalate per Section 5. Splitting the difference between two doctrines usually violates both (half-broad targeting satisfies neither Sharp's reach math nor Dunford's positioning focus).
+
+---
+
+## 2. The Conflict Table
+
+Each row: the conflict, the axis that decides, and the ruling. "Governs" means that doctrine's doc sets the defaults and its checklist gates the plan; the losing doctrine may still own a subordinate budget line.
+
+| # | Conflict | Contending docs | Deciding axis | Ruling |
+|---|----------|-----------------|---------------|--------|
+| 1 | **Brand-availability vs direct-response** | `frameworks/marketing-science/brand-growth-laws.md` vs `people/alex-hormozi-knowledge.md`, `people/dan-kennedy-knowledge.md`, `playbooks/hormozi-100m-funnel.md` | Stage + evidence of repeatable acquisition | **Pre-PMF / pre-repeatable-acquisition: demand-side research + offer doctrine govern** — Binet & Field's own evidence base excludes this stage (see `brand-activation-budget.md` rule 4). Availability doctrine takes over once a channel repeatably acquires at acceptable CAC; then the 95:5 logic applies (most category buyers aren't in-market — Dawes 2021) and reach/CEP building gets its own budget line. DR keeps the capture line permanently. |
+| 2 | **WTP research vs value-equation pricing psychology** | `people/madhavan-ramanujam-knowledge.md`, `people/patrick-campbell-knowledge.md` vs `people/alex-hormozi-knowledge.md` | Which question is being asked (level, not stage) | **WTP research sets the corridor; value-equation framing positions within it.** Ramanujam: talk to customers about willingness to pay before building — 72% of new products fail to meet their financial targets (Simon-Kucher global pricing study); the book's diagnosis, not part of the measured stat, is that skipped WTP research is the main cause. Hormozi's value equation — (dream outcome × perceived likelihood) ÷ (time delay × effort/sacrifice) — is offer *presentation*, not price *discovery*. Never let framing psychology set the price point; never let survey WTP write the sales page. Full stack: `playbooks/pricing-strategy.md`. |
+| 3 | **PLG vs sales-led** | `people/elena-verna-knowledge.md` vs `people/cole-gordon-knowledge.md`, `people/sam-ovens-knowledge.md` | Business model: ACV × time-to-value × buyer | **ACV under ~$5K with self-evident single-session value and end-user buyers: PLG governs. Above ~$25-50K with committees and procurement: sales-led governs.** The wide middle is hybrid by design — self-serve floor, sales-assist above a trigger threshold — and both doctrines run, with jurisdiction split by deal size, not blended per deal. Route: `playbooks/business-model-marketing.md`, `playbooks/saas-metrics-guide.md`. |
+| 4 | **Narrow-ICP positioning vs broad category reach** | `people/april-dunford-knowledge.md`, `people/ultra-niche-audience-matching.md` vs `brand-growth-laws.md` | Stage + which decision (message vs media) | **Positioning is always narrow; media breadth grows with stage.** Dunford governs *what you say and to whom you claim to be for* at every stage. Sharp governs *how wide you buy attention* — but only after repeatable acquisition (row 1). Pre-PMF, narrow-ICP governs both message and media. At scale, the sizing check in `brand-growth-laws.md` applies: if the "ICP audience" is <10% of reachable category buyers and the goal is growth, the media plan contradicts penetration math — flag it. |
+| 5 | **Demand creation vs demand capture** | `people/chris-walker-knowledge.md`, `playbooks/demand-generation.md` vs `playbooks/local-seo-gbp-optimization.md`, `channels/paid-acquisition.md` | Existing search volume + category maturity | **Capture existing demand to exhaustion before funding creation.** If buyers already search the category, capture (search, local pack, AEO) is the cheaper first dollar. Fund creation when capture is saturated, CPCs price you out, or the category is new enough that nobody searches for it yet. Walker's dark-funnel caveat stands: measure creation via self-reported attribution, not click paths (`frameworks/marketing-science/attribution-and-incrementality.md`). |
+| 6 | **Content-led inbound vs phone-led capture** | `channels/content-writing.md`, SEO stack vs `people/tommy-mello-knowledge.md`, `playbooks/conversion-rate-optimization.md` | Vertical (phone-led local service) | **Phone-led local service: local-SEO + phone-capture doctrine outrank content-led inbound.** Speed-to-lead, answer rate, and GBP/local-pack presence move revenue before any blog post does (worked example in `diagnosis-first-operating-order.md`). KaiCalls Fit Rule per `AGENTS.md` applies at the recommendation step — disclose ownership, compare alternatives. Content-led inbound governs where the buyer researches for weeks, not where they call three numbers and hire whoever answers. |
+| 7 | **Loyalty/retention plays vs penetration** | `playbooks/customer-retention.md` vs `brand-growth-laws.md` (double jeopardy) | Evidence state: churn vs DJ-expected churn | **Compare churn to the double-jeopardy expectation for your share before declaring a retention crisis.** Churn far above DJ-expected: retention doctrine governs (repair). Churn near DJ-expected: penetration governs; loyalty targets are outputs, not levers. Exception: contractual-revenue models (SaaS) where NRR is a direct growth input — `saas-metrics-guide.md` benchmarks decide. |
+| 8 | **Polished creative vs ugly/native ads** | `people/dara-denney-knowledge.md` polish systems vs `people/barry-hott-knowledge.md` | Evidence state (test it), then platform norms | **Neither doctrine rules a priori — the creative bench does.** Both go into the concept matrix (`playbooks/combinatorial-creative-bench.md`); measured hook/hold/CPA decides per `playbooks/creative-test-resolution-protocol.md`. Prior: native-feeling wins more often on TikTok/Reels interruption feeds, polish on high-consideration retargeting — treat as hypothesis, not ruling. |
+| 9 | **LTV-justified CAC vs revenue-quality skepticism** | `playbooks/saas-metrics-guide.md` LTV math vs `people/bill-gurley-knowledge.md` | Evidence state: cohort age | **Gurley governs until cohorts are old enough to prove the L in LTV.** Projected LTV from <12-month cohorts cannot justify raising CAC. With 2+ year cohort curves that flatten, LTV math may govern spend ceilings — subject to `growth-metrics-and-pmf.md` retention-curve rules. |
+| 10 | **Awareness-stage copy vs formula copy** | `people/eugene-schwartz-knowledge.md` vs `frameworks/content-copywriting/copywriting-formulas.md` | Neither — layered, not conflicting | **Schwartz's awareness/sophistication diagnosis picks the message level; formulas execute within it.** A PAS formula aimed at an unaware audience fails regardless of execution quality. Diagnose stage first, then pick the formula. |
+| 11 | **Brand-budget doctrine vs stage doctrine** | `brand-activation-budget.md` (60/40 prior) vs `playbooks/marketing-by-stage.md` | Stage | **Stage doctrine governs below ~$1M revenue; the 60/40 prior phases in as brand and budget mature.** Already ruled inside `brand-activation-budget.md` rule 4 — this row exists so nobody re-litigates it. |
+
+---
+
+## 3. Vertical Routing Table
+
+Which docs govern by default per vertical. **Primary** docs set the plan's spine and their checklists gate it; **secondary** docs advise inside the primary's frame. Expert roster and load-when triggers: `knowledge/people/_people-index.md`. Conflicts between a primary and a secondary: primary wins unless a Section 2 row or Section 4 evidence says otherwise.
+
+| Vertical | Primary | Secondary |
+|----------|---------|-----------|
+| **B2B SaaS** | `playbooks/business-model-marketing.md` · `playbooks/b2b-distribution-playbook.md` · `people/april-dunford-knowledge.md` (positioning) · `people/brian-balfour-knowledge.md` (channel-model fit) · `playbooks/saas-metrics-guide.md` | `people/chris-walker-knowledge.md` · `people/elena-verna-knowledge.md` (if PLG per row 3) · `people/patrick-campbell-knowledge.md` + `people/madhavan-ramanujam-knowledge.md` (pricing) · `playbooks/demand-generation.md` · `playbooks/account-based-marketing.md` (ACV >$50K) · `channels/linkedin-founder-led.md` · `channels/ai-outbound.md` |
+| **Ecommerce / DTC** | `playbooks/ecommerce-marketing.md` · `playbooks/b2c-distribution-playbook.md` · `channels/meta-advertising.md` · `playbooks/combinatorial-creative-bench.md` · `people/dara-denney-knowledge.md` | `people/barry-hott-knowledge.md` · `people/alex-hormozi-knowledge.md` (offer/AOV) · `channels/email-lifecycle.md` · `channels/ai-ugc.md` · `channels/tiktok-shop.md` · `playbooks/retargeting-remarketing.md` (incrementality caveats apply) · `playbooks/funnel-hack-offer-architecture.md` |
+| **Local services (phone-led)** | `playbooks/local-seo-gbp-optimization.md` · `people/tommy-mello-knowledge.md` (speed-to-lead, CSR booking) · `people/joy-hawkins-knowledge.md` + `people/darren-shaw-knowledge.md` (local ranking factors) · `playbooks/conversion-rate-optimization.md` | `people/local-dominance-strategy.md` · `knowledge/checklists/cro-audit-checklist.md` · `people/dan-kennedy-knowledge.md` (offer + follow-up) · `channels/paid-acquisition.md` (LSAs) — KaiCalls Fit Rule per `AGENTS.md` at recommendation time |
+| **Creator / media** | `people/dave-ramsey-knowledge.md` (trust-engine media model) · `channels/newsletter-strategy.md` · `playbooks/podcast-marketing.md` · `playbooks/content-repurposing.md` | `people/jimmy-farley-knowledge.md` (creator flywheels) · `people/jason-wardrop-knowledge.md` (affiliate funnels) · `people/vssl-longform-content.md` · `channels/community-building.md` · `playbooks/influencer-marketing.md` |
+| **Marketplace** | `people/bill-gurley-knowledge.md` (marketplace dynamics, revenue quality) · `playbooks/business-model-marketing.md` (marketplace section) · `playbooks/growth-loops-applied.md` | `people/brian-balfour-knowledge.md` · `playbooks/demand-generation.md` (supply-side acquisition) · `channels/community-building.md` · `frameworks/marketing-science/growth-metrics-and-pmf.md` (liquidity metrics before growth spend) |
+
+Cross-vertical constants that outrank every row: the quality gates, the Data Provenance Rule, the approval doctrine (no live-channel mutation without human sign-off), and the operating order itself.
+
+---
+
+## 4. Evidence-State Rules: What Overrides What
+
+Doctrine is a prior. Data updates it. The trust order, highest first:
+
+1. **Your measured results** — graded 30-day outcomes in `knowledge/playbooks/what-works.md` and diagnosed losers in `memory/what-doesnt-work.md`, plus incrementality-tested reads per `frameworks/marketing-science/attribution-and-incrementality.md`.
+2. **Your historical account data** — cohorts, channel CACs, seasonal patterns, even ungraded.
+3. **Platform/category benchmarks** — directional context only; platform-reported ROAS is a claim, not a measurement (attribution doc, rule 1).
+4. **Expert doctrine** — everything in `knowledge/people/` and the frameworks. Replicated research (Ehrenberg-Bass, IPA databank, Simon-Kucher) sits above single-expert opinion within this tier.
+5. **Operator intuition** — a tiebreaker for what to test next, never for what to claim or ship.
+
+Operating rules on the hierarchy:
+
+- **A doctrine contradicted by your measured results loses jurisdiction for this brand.** First contradiction: suspect the measurement before the doctrine — check readability per `frameworks/marketing-science/experiment-rigor.md` (sample size, test window, attribution inflation). Confirmed twice: the doctrine is demoted for this brand/channel; log it in `memory/what-doesnt-work.md` with the diagnosis, and cite that entry in future plans instead of the doctrine.
+- **Absence of data is not evidence against doctrine.** "We tried brand spend for 3 weeks and saw nothing" contradicts nothing — brand effects are measured in quarters (`brand-activation-budget.md` rule 3). Match the measurement window to the doctrine's claimed time horizon before ruling against it.
+- **Winners generalize narrowly.** An entry in `what-works.md` overrides doctrine for the same brand + channel + format. It does not override doctrine for a different vertical — that's benchmark-tier evidence (tier 3) at best.
+- **Never let tier-5 beat tier-1.** If the human's intuition contradicts their own measured results, present the data and the escalation frame below; the human can still decide, but the plan must record that it overrides measured evidence.
+
+---
+
+## 5. The Escalation Rule: Ties Go to the Human
+
+When Section 2 has no row, no axis decides, and evidence tiers are equal — **surface both doctrines, never silently pick.** The escalation must contain, in this order:
+
+1. **The conflict in one sentence** — which two doctrines, which decision they disagree on.
+2. **Both rulings with their champion docs** — what each doctrine would have you do.
+3. **The tradeoff stated symmetrically** — what each option risks and forgoes, over what time horizon. No thumb on the scale disguised as "context."
+4. **The cheapest tie-breaking evidence** — the test, data pull, or customer conversation that would settle it, with cost and time (`frameworks/marketing-science/experiment-rigor.md` for whether the test is even readable at current volume).
+5. **A default with a named trigger** — if the human declines to choose: which doctrine you'd run and the observable signal that would flip it.
+
+Log the decision and its rationale so the next plan doesn't re-argue it. If the same tie escalates twice for the same brand, that's a lesson — capture it via `python scripts/self_improvement/lesson_capture.py add` per the memory doctrine in `.claude/rules/architecture-and-memory.md`.
+
+Approval doctrine still applies downstream: whichever doctrine wins, live-channel actions (publishing, posting, ad mutations, outreach) require human approval per `AGENTS.md`.
+
+---
+
+## 6. The Arbitration Block (required plan artifact)
+
+Every plan produced by a skill that loads this doc must contain an arbitration block — one row per budget line or major workstream. A plan without one hasn't done the work; a reviewer can reject it on that alone.
+
+```
+| Budget line / workstream | Governing doctrine (doc) | Axis + position | Evidence tier | Flip trigger |
+|--------------------------|--------------------------|-----------------|---------------|--------------|
+| Paid search capture      | DR/capture (row 5)       | model: high search volume | tier 2 (12-mo CAC data) | CPC > $X or impression share > 90% |
+| Founder LinkedIn         | availability line (row 1)| stage: post-repeatable-acq | tier 4 (doctrine) | 2 quarters no lift in branded search |
+| Pricing revision         | WTP corridor (row 2)     | level: discovery first | tier 4 → tier 1 after interviews | n/a — sequenced, not conditional |
+```
+
+Rules for the block:
+
+- **Flip trigger is mandatory.** Every doctrine assignment names the observable signal that would reassign jurisdiction. "We'll revisit quarterly" is not a trigger; "branded search flat after 2 quarters" is.
+- **Evidence tier cites its source** — a `what-works.md` entry, a collector output path, or the doctrine doc. Tier-1 claims follow the Data Provenance Rule (`harness/references/audit-data-provenance.md`).
+- **Escalated ties appear as rows too**, marked `ESCALATED` with the human's ruling and date once decided — so the next plan inherits the decision instead of re-arguing it.
+
+---
+
+## Worked Example (compressed)
+
+`/kai-growth-plan` for a $40K-MRR B2B SaaS, ACV $9K, 60 customers, one repeatable channel (founder-led LinkedIn + demo calls). Conflicts surfaced: (a) an advisor wants "brand marketing"; (b) the founder wants PLG "like Figma"; (c) pricing is flat $749/mo, never researched.
+
+- **Row 1 (brand vs DR):** repeatable acquisition exists but is single-channel and young → DR/capture keeps primary jurisdiction; a small availability line (category content, founder distribution) starts building the 95% pool. Not 60/40 yet — row 11.
+- **Row 3 (PLG vs sales-led):** ACV $9K, time-to-value ~2 weeks, buyer is a team lead → hybrid zone. Ruling: keep sales-assist, add self-serve trial as an *entry point*, don't rip out the sales motion. Escalation not needed — the axis decided.
+- **Row 2 (pricing):** no WTP research has ever been run → Ramanujam governs first (WTP interviews set the corridor), Hormozi value-equation framing rewrites the pricing page afterward.
+- **Evidence check:** `what-works.md` shows LinkedIn posts with customer-number proof outperform listicles 3:1 for this brand → that pattern outranks generic content doctrine in the calendar.
+
+Three conflicts resolved by axis, zero silent averages, one doctrine sequenced behind another. That sequencing — not a new framework — is what arbitration buys.
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Decision this doc informs |
+|---|---|
+| `/kai-growth-plan`, `/kai-brand`, `/kai-budget` | Load at plan start (after the operating order). Every plan states, per budget line, which doctrine governs and which axis decided; ties escalate per Section 5 |
+| `/kai-audit`, `/kai-funnel-audit`, `/kai-monthly-audit` | Recommendations name their governing doctrine; audit findings that contradict a doctrine trigger the Section 4 demotion check, not silent doctrine-swapping |
+| `/kai-launch`, `/kai-offer-builder` | Row 1 (offer doctrine pre-repeatable-acquisition), row 2 (WTP corridor before value-equation framing) |
+| `/kai-competitors`, `/kai-seo-audit` | Vertical routing table picks the primary lens before the teardown starts |
+| `/kai-retro` + `memory/what-doesnt-work.md` | Section 4 demotions get logged here; retro triage decides whether a demotion graduates to a lesson or lint rule |
+| Weekly `cmo_review` | Behind-pace goals re-check jurisdiction: is the goal failing because the doctrine is wrong for this axis position, or because execution is weak? |
+| `diagnosis-first-operating-order.md` Gate Rule | That doc decides *whether* you may plan; this doc decides *with which doctrine*. Load order: operating order → arbitration → governing framework docs |
+
+---
+
+## Sources
+
+- Dawes, J. / Ehrenberg-Bass Institute — "Advertising effectiveness and the 95-5 rule" (2021): https://marketingscience.info/news-and-insights/advertising-effectiveness-and-the-95-5-rule-most-b2b-buyers-are-not-in-the-market-right-now
+- Dawes, J. — The 95:5 rule summary: https://johndawes.info/the-955-rule/
+- Binet, L. & Field, P. — *The Long and the Short of It* (IPA, 2013), summary: https://www.alexmurrell.co.uk/summaries/les-binet-and-peter-field-the-long-and-the-short-of-it
+- IPA — "The next chapter for The Long and The Short of It": https://ipa.co.uk/knowledge/ipa-blog/the-next-chapter-for-the-long-and-the-short-of-it
+- Ramanujam, M. & Tacke, G. (2016) — Simon-Kucher pricing-research book (72% new-product failure finding; title omitted for the banned-word gate; author interview): https://www.marketingjournal.org/monetizinginnovation/
+- Sharp, B. — *How Brands Grow* (2010), evidence base summarized in `knowledge/frameworks/marketing-science/brand-growth-laws.md`
+- Dunford, A. — positioning book (2019), distilled in `knowledge/people/april-dunford-knowledge.md`
+- Userpilot — "Product-Led Growth vs. Sales-Led Growth" (ACV/motion thresholds): https://userpilot.com/blog/product-led-vs-sales-led/
+- General Catalyst — "Sales-Led vs. Product-Led Growth": https://www.generalcatalyst.com/stories/sales-led-vs-product-led-growth
+- Ritson, M. — tactification/operating-order columns, cited with full URLs in `knowledge/frameworks/marketing-science/diagnosis-first-operating-order.md`
+- Rumelt, R. — *Good Strategy Bad Strategy* (2011), kernel summary: https://www.alexmurrell.co.uk/summaries/richard-rumelt-good-strategy-bad-strategy

--- a/knowledge/_index.md
+++ b/knowledge/_index.md
@@ -17,6 +17,18 @@ For one-page summary of all frameworks: `_quick-reference.md`
 
 ## Core Frameworks
 
+### Marketing Science (`frameworks/marketing-science/`)
+
+| File | Use When |
+|------|----------|
+| `../_arbitration.md` | **Doctrine conflicts** - which framework governs, by stage/vertical/evidence state; load before any planning skill |
+| `diagnosis-first-operating-order.md` | Before strategy or tactics - the diagnosis checklist, evidence bars, failure-mode taxonomy |
+| `brand-growth-laws.md` | Targeting breadth decisions - mental/physical availability, distinctive assets, category entry points, light-buyer math |
+| `brand-activation-budget.md` | Budget splits - long/short evidence, ESOV, allocation worksheet by stage and category |
+| `experiment-rigor.md` | Before reading any test - sample floors, peeking, Twyman's law, low-traffic alternatives |
+| `attribution-and-incrementality.md` | Before crediting any channel - platform ROAS bias, MMM vs MTA vs incrementality, holdout design |
+| `growth-metrics-and-pmf.md` | Metrics architecture - AARRR instrumentation, North Star selection, PMF survey, cohort reading |
+
 ### Content & Copywriting (`frameworks/content-copywriting/`)
 
 | File | Use When |
@@ -153,6 +165,14 @@ For one-page summary of all frameworks: `_quick-reference.md`
 | `playbooks/creative-test-resolution-protocol.md` | **Creative test resolution** - Controls, data floors, read windows, and kill / iterate / graduate decisions |
 | `playbooks/creative-intelligence-ledger.md` | **Creative intelligence ledger** - Durable memory for hooks, angles, awareness stages, mechanics, results, and next actions |
 | `playbooks/hormozi-100m-funnel.md` | **Hormozi $100M funnel sequence** - Value Equation, Grand Slam Offer, client-financed acquisition, Core Four; runs `/kai-offer-builder` → `/kai-proof-builder` → `/kai-hook-bench` → `/kai-content-batching` → `/kai-funnel-audit` |
+| `playbooks/demand-side-research.md` | **Switch interviews / JTBD** - timeline reconstruction, four forces, VoC mining; feeds offer construction and messaging |
+| `playbooks/messaging-architecture.md` | **The messaging stack** - category frame → strategic narrative → positioning → homepage hierarchy, with agreement audit and testing methods |
+| `playbooks/referral-and-word-of-mouth.md` | **Referral engineering** - sharing drivers, program design, k-factor math, incentive rules |
+| `playbooks/retention-habit-loops.md` | **Behavioral retention** - habit-loop design, activation moments, ethics guardrails |
+| `playbooks/community-as-channel.md` | **Community-led growth** - when community fits, member journey, programming, measurement |
+| `playbooks/services-value-pricing.md` | **Service-business pricing** - value pricing, productized services, expertise positioning, retainer design |
+| `playbooks/product-led-seo.md` | **Programmatic SEO** - when template pages work, quality bars, data requirements, build order |
+| `playbooks/newsletter-growth-economics.md` | **Newsletter growth** - acquisition channels ranked, unit economics, list hygiene |
 | `playbooks/ad-campaign-management.md` | **Ad campaign ops** - STAG structure, audience funnels, optimization cadence (daily/weekly/monthly), scaling framework, reporting template |
 | `playbooks/meta-creative-testing-decision-framework.md` | **Meta creative testing** - Batch launch decisions, active-vs-paused staging, budget reality checks, winner protection |
 | `playbooks/paid-media-launch-playbook.md` | **Paid media launch** - Measurement-first Meta and Google launch flow, target CPA x 50 budget rule, creative matrix, first 14-day checks |

--- a/knowledge/frameworks/marketing-science/attribution-and-incrementality.md
+++ b/knowledge/frameworks/marketing-science/attribution-and-incrementality.md
@@ -1,0 +1,179 @@
+# When Attribution Is Lying — Incrementality Doctrine
+
+> **Use when:** A report, audit, or budget recommendation depends on channel-level credit ("Meta drove 40% of revenue"), platform ROAS looks too good, a client asks "which channel truly works," or you are designing a lift/geo/holdout test. This doc is the **skepticism and causal-testing layer** on top of `knowledge/playbooks/analytics-attribution.md` — read that first for the attribution-model comparison table, UTM standards, measurement ladder, GA4 setup, and blended CAC. This doc owns three questions: **why platform-reported numbers inflate, what MTA/MMM/incrementality can and cannot answer, and which measurement method to trust at which spend level.**
+
+---
+
+## Quick Reference — Decision Rules
+
+1. **Platform ROAS is a claim, not a measurement.** Every ad platform grades its own homework using self-attribution (clicks and views it observed). Treat platform ROAS as an upper bound on incremental return, useful for *relative* comparison within one platform, never as causal evidence across platforms.
+2. **Sum of platform-claimed revenue > actual revenue is the tell.** When Meta + Google + TikTok dashboards together claim more conversions than the business recorded, credit is being double-counted. Reconcile against the order/CRM system of record before quoting any channel number.
+3. **Retargeting and brand search are the two most inflated line items in any account.** Both select audiences already on the way to converting. Test these first — they are cheap to test and most likely to be over-credited (eBay brand-search experiment: no measurable short-term benefit — Blake, Nosko & Tadelis 2015).
+4. **Choose the measurement method by spend level** (table below). Under ~$10K/month, formal incrementality tests are usually underpowered — use blended CAC, pulse tests, and self-reported attribution instead of pretending precision.
+5. **Design tests with a power analysis first.** If the minimum detectable effect exceeds the plausible lift, do not run the test — you will get noise and someone will act on it (Lewis & Rao 2015: median ROI confidence interval in 25 large experiments was over 100 percentage points wide).
+6. **Triangulate, never crown one source.** Software attribution (captures demand) + self-reported attribution (creates demand) + causal tests (settles budget questions) + blended CAC (grounds everything). Disagreement between them is information, not error.
+7. **Kai hard rule:** every channel-credit claim in a Kai report, audit, or deck MUST state the measurement method and its known bias inline (template below). A ROAS number with no method label fails review.
+8. **Approval doctrine:** every test this doc prescribes touches live channels — pausing spend, holdout audiences, geo dark periods. All of it requires explicit human approval before execution. This doc designs tests; it never launches them.
+
+---
+
+## How Platform ROAS Inflates — The Mechanics
+
+Platform-reported ROAS diverges from incremental ROAS through five stacked mechanisms. Each one only ever pushes the number **up**.
+
+### 1. View-through credit
+Meta's default attribution is **7-day click + 1-day view**: a user who scrolled past an ad (an "impression") and bought within 24 hours is counted as a conversion the ad "drove," with engaged-view and view windows crediting video impressions similarly (Jon Loomer, Meta attribution mechanics). The user may have converted from email, organic search, or existing intent — the platform cannot see those paths and does not subtract them. Diagnostic: break out view-through vs click-through conversions in Ads Manager; a large view-through share is a flag to discount reported ROAS and prioritize a lift test, not a finding that the ads work.
+
+### 2. Retargeting credit-claiming
+Retargeting targets people selected *because* they already visited, carted, or bought. Baseline conversion probability in that pool is high, so last-touch and view-through credit flows to ads shown to people already converging on purchase. Retargeting is not zero — the ghost-ads experiments measured real lift from retargeting (+17.2% site visits, +10.5% purchases in the studied campaign; Johnson, Lewis & Nubbemeyer 2017) — but measured lift is a fraction of what platform attribution claims for the same campaigns. Rule: never quote retargeting ROAS without a holdout behind it.
+
+### 3. Brand-search cannibalization
+Brand keyword ads intercept users already searching for you. eBay's large-scale shutdown experiment found brand-keyword ads had **no measurable short-term benefit** — organic clicks absorbed nearly all the traffic — and overall paid-search returns were a fraction of the non-experimental estimates the dashboards showed (Blake, Nosko & Tadelis, *Econometrica* 2015). State the caveat: eBay is a giant brand with dominant organic presence; small brands with weak organic rank and aggressive competitor conquesting can see real brand-search incrementality. That is an argument for testing it, not for trusting the dashboard.
+
+### 4. Window and dedup asymmetry
+Each platform claims 100% of any conversion inside its own window; no platform deduplicates against the others. A buyer who clicked a Meta ad Tuesday and a Google ad Thursday is a full conversion in both dashboards. Longer windows mechanically raise reported ROAS with no change in reality — which is why comparing ROAS across platforms with different window settings is meaningless.
+
+### 5. Attribution fraud (mostly mobile/affiliate)
+Click spamming and click injection fire fake "clicks" so networks claim credit for organic installs. Uber's canonical case: after suspecting fraud, it shut off roughly **$100M of a ~$150M performance budget and saw no measurable change in rider acquisition**; some partner apps showed more ad clicks than Uber had users, and Uber sued its agency and five networks (WARC interview with Kevin Frisch; CHEQ settlement analysis). Lesson: the strongest fraud detector was not a tool — it was turning spend off and watching the baseline.
+
+**Academic ground truth on the gap:** comparing 15 large US advertising RCTs at Facebook against standard observational/attribution methods, Gordon, Zettelmeyer, Bhargava & Chapsky (*Marketing Science* 2019) found observational estimates commonly diverged severely from experimental lift — often overstating it by multiples — even with rich user-level data. The 2023 follow-up across 663 experiments ("Close Enough?", Gordon, Moakler & Zettelmeyer) found even sophisticated double-ML observational methods still missed experimental benchmarks by economically significant margins, especially for purchase outcomes. This is the published basis for the doctrine: **no attribution model, however clever, substitutes for an experiment.**
+
+---
+
+## MTA vs MMM vs Incrementality — What Each Can and Cannot Answer
+
+Full model-by-model bias table: `knowledge/playbooks/analytics-attribution.md`. This table is the causal-question view.
+
+| | Multi-touch attribution (MTA) | Marketing mix modeling (MMM) | Incrementality testing |
+|---|---|---|---|
+| **What it is** | Assigns fractional credit across observed digital touchpoints | Regression/Bayesian model of outcome vs spend + seasonality + external factors (Meridian, Robyn) | Randomized or quasi-experiment: exposed vs holdout |
+| **Can answer** | Which observed paths co-occur with conversion; in-flight creative/audience comparison within a channel | Long-run channel contribution incl. offline/brand; budget reallocation direction; diminishing-returns curves | "Did this spend cause conversions that would not otherwise have happened?" — the only method that answers it |
+| **Cannot answer** | Causality (correlational credit-splitting); anything untracked — view-through TV, dark social, word of mouth; anything post-ATT/cookie-loss | Fast tactical questions; campaign-level or creative-level effects; small channels (signal drowns); causality without experimental calibration | Everything at once — one test answers one channel/geo/period; long-term brand effects inside a short window |
+| **Time to answer** | Real-time | Quarterly refresh typical; needs ~2-3 years of weekly history (Meridian/Robyn practitioner guidance) | 2–8 weeks per test |
+| **Known bias** | Inherits every platform inflation mechanism above; digital-only tunnel vision | Model-specification risk; wide priors on collinear channels; analyst degrees of freedom | Power problems at low volume (Lewis & Rao 2015); geo spillover; novelty effects |
+| **Trust for budget moves** | Never alone | Yes, when calibrated against lift tests | Yes — gold standard where powered |
+
+Modern practice is triangulation: MMM as strategic backbone, incrementality tests to calibrate it, attribution for day-to-day steering only. Long-term brand effects are invisible to all short-window methods — that measurement trap is owned by `knowledge/frameworks/marketing-science/brand-activation-budget.md` (decay curves, 6-month minimum brand windows).
+
+---
+
+## Incrementality Test Design
+
+### Platform conversion-lift tests (audience holdout, platform-run)
+Meta/Google lift studies randomize users into exposed vs holdout using the ghost-ads pattern — identify the users who *would have been served* the ad in the control group, so the comparison is unbiased and intent-to-treat (Johnson, Lewis & Nubbemeyer 2017; the older PSA-holdout design is biased because delivery systems optimize PSAs differently). Cheapest first step for large accounts; the caveat is the platform runs the experiment on itself, and eligibility requires meaningful conversion volume. Cross-check results against your CRM system of record, not the platform's conversion count.
+
+### Geo-holdout design (the workhorse)
+Geo tests randomize markets, not users — immune to cookie loss, ATT, and cross-device tracking gaps. Meta's open-source **GeoLift** (augmented synthetic control) and Google's geo-experiment methodology are the standard free stacks.
+
+1. **Pick the geo unit.** DMA or city for US; regions elsewhere. Units must have separable media delivery and minimal commuting/shipping spillover.
+2. **Assemble pre-period history.** GeoLift's walkthrough does not fix a minimum; **heuristic: 6–12 months of daily/weekly geo-level KPI data, one full year when seasonality is material** (practitioner guidance — Lifesight, Triple Whale; marked heuristic).
+3. **Select markets by simulation, not by hand.** Run `GeoLiftMarketSelection()` power simulations to find the test/control combination with the lowest minimum detectable effect (MDE) — the tool sweeps 2, 3, 4+ test-market combinations and holdout shares (GeoLift walkthrough). Manual "NY vs LA" matching is an anti-pattern.
+4. **Check power before launching.** If simulated MDE exceeds the lift you plausibly expect (for most paid channels, a plausible true lift is single-digit to low-double-digit percent), redesign — bigger geos, longer test, bigger spend delta — or do not run. **Heuristic floor: ~100+ conversions per cell per analysis period; below that, expect noise** (unsourced heuristic, consistent with Lewis & Rao's power findings).
+5. **Set duration ≥ one full purchase cycle** (GeoLift rule of thumb); **heuristic: 4–6 weeks for most DTC/lead-gen, longer for considered purchases**, plus a cooldown period to catch delayed conversions.
+6. **Pre-register the decision.** Before launch, write down: metric (business KPI from the system of record, not platform conversions), test window, and the action at each outcome ("if incremental CPA > 2x blended CAC, cut channel 50%"). Post-hoc rationalization is how dead channels survive.
+7. **Analyze with synthetic control, report the confidence interval,** never the point estimate alone. A "12% lift, CI −3% to +27%" is not a green light; it is an underpowered test.
+
+**Dark test vs scale test:** turning spend *off* in holdout geos (dark test) measures the incrementality of existing spend and is free — the savings fund the analysis. Scaling spend *up* in test geos measures marginal return at higher budgets. Run dark tests on suspected-inflated channels (retargeting, brand search) first.
+
+### Audience-holdout (DIY, owned channels + retargeting)
+Randomly suppress 5–10% of the eligible audience (CRM list, site visitors) from email/SMS/retargeting for 4–8 weeks; compare purchase rate of held-out vs targeted in your own database (split size is a heuristic — larger holdout = faster answer, more short-term revenue at risk). This is the honest way to measure retargeting and lifecycle email, because randomization happens on your list before the platform's delivery optimization can select. Requires stable customer IDs and human approval before suppressing any live audience.
+
+### The power reality (read before promising precision)
+Lewis & Rao (*QJE* 2015), across 25 large advertiser experiments (~$2.8M spend, millions of users): individual sales volatility is so high relative to ad effects that the **median confidence interval on ROI exceeded ±50 points (over 100 points wide)**, and a well-powered ROI experiment can require tens of millions of person-weeks. Consequences: (a) small advertisers cannot measure channel ROI precisely — decide on cruder but honest signals (blended CAC trend, on/off pulses); (b) measure lift on conversions, not revenue-ROI, when volume is thin; (c) anyone selling you per-campaign incremental ROAS at $5K/month spend is selling noise.
+
+---
+
+## Self-Reported Attribution — The Triangulation Input
+
+"How did you hear about us?" (HDYHAU) on high-intent forms catches what tracking cannot: dark social, word of mouth, podcasts, communities, AI-assistant recommendations. The published study that quantifies the gap is Refine Labs' 12-month comparison (620 declared-intent conversions, $21.5M closed-won ARR): software attribution credited **79% of conversions to web search** (direct/organic/paid), while customers named those sources only **~3%** of the time — self-reported answers pointed **98% of closed-won revenue to dark social** (social, podcast, word of mouth, community); podcasts alone self-reported at 53% of revenue vs 0% in software. Refine Labs calls this a ~90% measurement gap. Caveat: vendor-published, one company's pipeline — treat as directional evidence of the gap's existence and rough size, not a universal constant. The reconciliation: **software measures what captured demand; self-report measures what created it.** Both are true; they answer different questions.
+
+Implementation rules:
+- **Open text field first**, optional dropdown second — dropdowns anchor answers to the options you already believe in (Refine Labs self-reported-attribution implementation guidance).
+- Place on the **highest-intent form** (signup, demo request, checkout), required or near-required; response rates collapse on post-purchase emails.
+- **Known biases, state them when reporting:** recency bias (people name the last memorable touch), brand-salience bias (people name the famous channel — "Google" — over the actual source), and channel illiteracy ("I saw it online"). Self-report systematically *under*-credits retargeting and *over*-credits memorable content — roughly the mirror image of software bias, which is exactly why the pair triangulates.
+- **Structural limits (SparkToro/Fishkin whiteboard):** HDYHAU only ever surfaces channels that already worked (it cannot find new ones), respondents don't know which "hear about us" moment you mean (first exposure vs final trigger), and it never reaches the people you failed to reach. Use it to triangulate, never as the sole planning input.
+- Log to the CRM as a first-class field; report it side by side with software attribution, never averaged into it.
+
+Dark-social pitfall context lives in `knowledge/playbooks/analytics-attribution.md` (Common Analytics Pitfalls).
+
+---
+
+## Decision Rules — Which Method at Which Spend Level
+
+Heuristic synthesis (spend bands are judgment calls, not published thresholds — adjust for conversion volume, which matters more than dollars):
+
+| Monthly paid spend | Primary measurement | Add | Do NOT |
+|---|---|---|---|
+| **< $10K** | Blended CAC trend + last-click UTMs + HDYHAU on every form | Crude on/off pulse tests (pause a channel 2–4 weeks, watch blended metrics) | Buy MTA software; quote per-channel ROAS as fact; run underpowered "lift tests" |
+| **$10K–$50K** | Everything above + platform conversion-lift tests where volume qualifies | Brand-search shutoff test (cheapest high-value test in marketing); audience holdout on retargeting/email | Trust view-through conversions; compare ROAS across platforms |
+| **$50K–$250K** | Geo-holdout program: 1–2 GeoLift tests per quarter on the largest channels, dark tests on suspected-inflated line items | Written experiment calendar; incrementality factors per channel (measured lift ÷ platform-claimed) applied to dashboards | Rebuild budget from an MTA model; leave retargeting untested for more than 2 quarters |
+| **$250K+ (~$3M+/yr)** | MMM (Meridian/Robyn) refreshed quarterly, **calibrated against the incrementality test log** | Continuous test rotation across channels/geos; MMM-vs-experiment reconciliation as a standing review item | Run MMM without experimental calibration; let any single vendor own the truth |
+
+The ~$3M+/yr MMM threshold aligns with practitioner guidance that below roughly $5–10M annual multi-channel spend the statistical signal for reliable MMM is often thin (Improvado/Matchbox MMM guides — vendor guidance, marked as such); teams with strong data and 2–3 years of weekly history can start lower.
+
+---
+
+## Kai Hard Rule — Channel-Credit Claims Must Carry Method + Bias
+
+**Non-negotiable for every Kai report, audit, deck, or recommendation:** any statement crediting a channel with conversions, revenue, ROAS, CAC, or "performance" must name **(a) the measurement method and window, and (b) that method's known bias direction.** A bare "Meta ROAS: 3.2" fails quality review.
+
+Required inline format:
+
+```
+Meta ROAS 3.2 [platform-reported, 7-day click + 1-day view; self-attributed —
+overstates incremental return, does not dedupe against other channels]
+
+Email drove 214 orders [last-touch UTM; captures demand capture, blind to
+demand creation and dark social]
+
+Geo test: brand search incremental conversions ≈ 0 [GeoLift dark test,
+4 wks, 3 test DMAs, CI −4% to +6%; underpowered below 5% lift]
+```
+
+Companion rules:
+- Numbers themselves follow the **Kai Data Provenance Rule** (collector-sourced, `harness/references/audit-data-provenance.md`); this rule adds the method-and-bias label on top.
+- Recommendations to reallocate budget based on platform-attributed numbers alone are **blocked** — either cite a causal test or label the recommendation "directional, untested."
+- When methods disagree (platform vs self-reported vs test), report the disagreement as a finding. Do not average, do not pick the flattering one.
+
+---
+
+## Anti-Patterns
+
+- **ROAS shopping:** switching attribution settings or vendors until the number justifies the budget. The Gordon et al. results exist precisely because every observational method offers a different wrong answer.
+- **Retargeting as proof-of-performance:** presenting the account's highest-ROAS line (retargeting) as the success story. It is the most credit-inflated line by construction.
+- **The underpowered lift test:** running a 2-week geo test on a low-volume channel, getting a CI spanning zero, and reporting the point estimate as truth. Pre-launch power simulation or no test.
+- **MMM as oracle:** quoting model coefficients without experimental calibration or intervals. An uncalibrated MMM is regression-flavored opinion.
+- **Killing a channel on last-click alone:** top-of-funnel channels lose last-click credit structurally; the eBay lesson cuts both ways — test before scaling *and* before killing.
+- **Ignoring the Uber tell:** if pausing a channel changes nothing in blended metrics after a fair window, the dashboard was lying, whatever the vendor says.
+
+---
+
+## How This Maps Into Kai
+
+- **`kai-audit` / marketing audits, CRO audits, growth plans:** load this doc whenever channel performance claims appear; apply the Kai Hard Rule label format to every credited number; flag view-through share, retargeting ROAS, and brand-search spend as standard inflation-risk findings.
+- **Reporting** (`scripts/reporting/weekly_report.py`, `ceo_deck.py`, campaign retrospectives via `scripts/campaigns/campaign_tracker.py`): channel tables must carry method-and-bias labels; the dashboard's "Revenue (attributed)" line in `analytics-attribution.md` templates inherits this rule.
+- **Budget recommendations** (`agent/tasks/cmo_review.py` goal decomposition, campaign planning): reallocation across channels requires a causal source (lift test, geo test, calibrated MMM) or an explicit "directional, untested" label; brand/activation window doctrine comes from `brand-activation-budget.md`.
+- **Test design requests:** use the geo-holdout and audience-holdout sequences above; every proposed test ships with a power statement and pre-registered decision rule; launching any test (pausing spend, suppressing audiences, dark geos) requires human approval per the approval doctrine.
+- **Owned elsewhere:** attribution-model mechanics, UTM standards, GA4 setup, blended CAC, measurement ladder → `knowledge/playbooks/analytics-attribution.md`. Long/short measurement windows and ESOV → `knowledge/frameworks/marketing-science/brand-activation-budget.md`. Data provenance for client-facing numbers → `harness/references/audit-data-provenance.md`.
+
+---
+
+## Sources
+
+- Gordon, Zettelmeyer, Bhargava & Chapsky — *A Comparison of Approaches to Advertising Measurement: Evidence from Big Field Experiments at Facebook* (Marketing Science, 2019): https://pubsonline.informs.org/doi/10.1287/mksc.2018.1135 (PDF: https://gwern.net/doc/statistics/causality/2019-gordon.pdf)
+- Gordon, Moakler & Zettelmeyer — *Close Enough? A Large-Scale Exploration of Non-Experimental Approaches to Advertising Measurement* (2023): https://www.researchgate.net/publication/365364030_Close_Enough_A_Large-Scale_Exploration_of_Non-Experimental_Approaches_to_Advertising_Measurement
+- Blake, Nosko & Tadelis — *Consumer Heterogeneity and Paid Search Effectiveness: A Large-Scale Field Experiment* (Econometrica, 2015): https://onlinelibrary.wiley.com/doi/abs/10.3982/ECTA12423 (NBER WP: https://www.nber.org/papers/w20171)
+- Lewis & Rao — *The Unfavorable Economics of Measuring the Returns to Advertising* (QJE, 2015): https://academic.oup.com/qje/article-abstract/130/4/1941/1914592 (PDF: https://gwern.net/doc/economics/advertising/2015-lewis.pdf)
+- Johnson, Lewis & Nubbemeyer — *Ghost Ads: Improving the Economics of Measuring Online Ad Effectiveness* (Journal of Marketing Research, 2017): https://journals.sagepub.com/doi/10.1509/jmr.15.0297 (SSRN: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2620078)
+- WARC — *Uber's former performance chief charts extent of ad fraud* (Kevin Frisch): https://www.warc.com/newsandopinion/news/ubers-former-performance-chief-charts-extent-of-ad-fraud/44527
+- CHEQ — *10 Crucial Lessons from the $6m Uber Ad Fraud Settlement*: https://cheq.ai/blog/10-crucial-lessons-from-the-6m-uber-ad-fraud-settlement/
+- Refine Labs — *Study Confirms Measurement Gap in Software-Based Attribution* (12-month study: 79% vs ~3% web search, 98% dark social, podcast 53% vs 0%): https://www.refinelabs.com/article/hybrid-attribution-framework
+- SparkToro (Fishkin) — *The 3 Big Problems with Asking "How Did You Hear About Us?"* (structural limits of HDYHAU — no gap statistics in this post): https://sparktoro.com/blog/the-3-big-problems-with-asking-how-did-you-hear-about-us-5-minute-whiteboard/
+- Jon Loomer — *How Meta Ads Attribution Works in 2026*: https://www.jonloomer.com/meta-ads-attribution-2026/
+- Meta Open Source — GeoLift walkthrough (market selection, power simulation, purchase-cycle duration rule): https://github.com/facebookincubator/GeoLift/blob/main/vignettes/GeoLift_Walkthrough.md
+- Recast — *Open-Source Geo-Experiment Tools: A Head-to-Head Simulation Study*: https://research.getrecast.com/geolift-sim-study
+- Lifesight — *Geo-Based Incrementality Testing: Marketer's Guide*: https://lifesight.io/blog/geo-based-incrementality-testing/
+- Triple Whale — *GeoLift 101: Guide to Geo-Based Incrementality Testing*: https://www.triplewhale.com/blog/geolift-geo-based-incrementality-testing
+- Improvado — *Marketing Mix Modeling Guide* (spend/history thresholds, vendor guidance): https://improvado.io/blog/what-is-marketing-mix-modeling-complete-guide
+- The Matchbox — *Marketing Mix Modeling Guide* (MMM minimum-spend guidance): https://www.thematchbox.inc/resources/marketing-mix-modeling-guide
+- Digital Applied — *MMM vs Attribution Playbook* (triangulation practice): https://www.digitalapplied.com/blog/marketing-mix-modeling-2026-mmm-vs-attribution-playbook

--- a/knowledge/frameworks/marketing-science/brand-activation-budget.md
+++ b/knowledge/frameworks/marketing-science/brand-activation-budget.md
@@ -1,0 +1,190 @@
+# Brand vs Activation Budget Split — The Long/Short Doctrine
+
+> **Use when:** Setting or defending the split between brand building and sales activation, sizing budgets against a growth target (ESOV), explaining why performance metrics undervalue brand spend, or reviewing a plan that is 90%+ performance marketing. Channel-level allocation math and forecasting live in `knowledge/playbooks/marketing-budget-forecasting.md`; stage-appropriate activities live in `knowledge/playbooks/marketing-by-stage.md`. This doc owns one decision: **the ratio between long-term brand investment and short-term activation, and the total spend level needed to grow.**
+
+---
+
+## Quick Reference — Decision Rules
+
+1. **Start from 60/40 brand/activation as a prior, never as a law.** It is the average of a distribution across ~1,000 IPA case studies, mostly large UK consumer brands. Adjust for category, stage, and brand size before using it.
+2. **Fund growth with ESOV.** Set share of voice above share of market if you want share growth. Roughly 10 points of ESOV correlates with ~0.5–0.7% market share growth per year on average — a planning guideline, not a guarantee.
+3. **Judge activation on weeks, brand on years.** Activation effects mostly decay within about six months; brand effects compound over 1–3+ years. Any measurement window under six months will systematically overvalue activation.
+4. **Pre-product-market-fit businesses are outside this evidence base.** Skew heavily to activation/direct response until PMF (see `knowledge/playbooks/marketing-by-stage.md`); apply this doctrine as brand and budget mature.
+5. **Treat the whole evidence base as strong-but-biased priors** (award-entry selection bias, big-brand skew, pre-digital-era data — see Criticisms below). Validate with your own holdouts or MMM before betting the company on a ratio.
+6. **Approval doctrine:** any live budget change to an ad account or channel that this framework motivates goes through human approval first. This doc informs recommendations; it never authorizes mutations.
+
+---
+
+## The Two Effects
+
+Binet & Field's core finding (from IPA Effectiveness Awards databank analysis, 1980–2010, ~996 campaigns) is that advertising works through two distinct mechanisms with different time signatures:
+
+| | Brand building | Sales activation |
+|---|---|---|
+| **Mechanism** | Creates memory structures and mental availability in future buyers; mostly emotional | Converts existing demand from in-market buyers; mostly rational/informational |
+| **Audience** | Broad reach, category-wide (most of whom are not in-market today) | Narrow, in-market, high-intent |
+| **Sales effect shape** | Slow build, small at first, compounds | Immediate spike |
+| **Decay** | Slow — effects persist and stack over years | Fast — most effect gone within weeks to ~6 months |
+| **Also improves** | Price elasticity (less discounting needed), baseline sales, effectiveness of future activation | Nothing durable — baseline unchanged when spend stops |
+| **Best measured by** | Econometrics/MMM, brand tracking, share of search, penetration — over 1–3 years | Attribution, CPA/ROAS, conversion lift — over days/weeks |
+
+Important nuance from Binet himself: this is a spectrum, not a binary. Every ad produces some of both effects; "brand" and "activation" describe the dominant mechanism, not exclusive categories. Ritson has shown brand-building ads also produce measurable short-term sales effects.
+
+---
+
+## Decay Curves — Why Short Windows Lie
+
+```
+Sales
+uplift
+  │   ██ activation spike
+  │  ████
+  │ ██████                    ← activation: tall, narrow, decays in weeks–months
+  │████████▄
+  │██████████▄▄____________________________________
+  │
+  │          ▁▁▂▂▃▃▄▄▅▅▆▆▇▇███████████████          ← brand: slow build,
+  │▁▁▂▂▃▃▄▄▅▅                                          compounds, persists years
+  └────────────────────────────────────────────► time
+   0    3mo    6mo    1yr         2yr        3yr
+```
+
+- Activation campaigns generate their biggest sales response inside six months, then the effect collapses back to baseline. Brand campaigns barely register in the first months, then keep paying back for years (Binet & Field, *The Long and the Short of It*).
+- Thinkbox's *Profit Ability 2* (2024; econometrics covering 141 brands, 14 categories, and £1.8bn of UK media spend, 2021–2023): advertising in the dataset returned an average **£1.87 short-term profit ROI per £1, rising to £4.11 over the full 0–24 month window** — **58% of total profit generation lands after the first 13 weeks**.
+- **The attribution trap:** last-click and platform attribution can only see the spike, never the baseline shift. A dashboard that reports weekly ROAS will always tell you to cut brand and buy more activation. That is a measurement artifact, not a finding. If your longest measurement window is 30 days, you have no data about the majority (~58% in Profit Ability 2) of advertising's payback.
+
+**Decision rule:** commit the measurement window before committing the budget. Brand line items get a minimum 6-month judgment window and a 1–3 year payback model; activation line items get weekly optimization.
+
+---
+
+## The Evidence Base — What the Data Says
+
+| Source | Finding | Status |
+|---|---|---|
+| Binet & Field, *The Long and the Short of It* (IPA, 2013) | Campaigns balancing brand and activation outperform either alone; the average optimum across the databank is ~60% brand / 40% activation | **Average of a distribution across award-entered campaigns.** Not a law; per-brand optimum varies widely |
+| Binet & Field, *Media in Focus* (IPA, 2017) | The optimum was drifting up toward brand as digital activation saturated | Directional |
+| Binet & Field, *Effectiveness in Context* (IPA, 2019) | The optimum is contextual: tables adjust it by category, brand size, price position, product novelty, and online vs offline purchase. Financial services optimum ~80/20 brand-heavy; optimum brand share is lowest in perishable/short-consideration services such as travel. Warns against the "online fallacy" — assuming online-bought brands only need online activation | The correction to naive 60/40 use, from the same authors |
+| Binet & Field × LinkedIn B2B Institute, *5 Principles of Growth in B2B* (2019) | In B2B the average optimum is ~**46% brand / 54% activation** (the B2B Institute's headline recommendation rounds this to ~50/50); the SOV rule still holds (10 pts ESOV ≈ 0.7%/yr share growth in B2B); acquisition beats loyalty; emotion drives long-term effects even in B2B | Smaller B2B sample; directionally consistent with B2C |
+
+The honest summary: the *shape* of the findings (two effects, different decay, balance beats either extreme, ESOV predicts growth) is replicated across datasets. The *specific numbers* (60/40, 0.7%/10pts) are dataset averages with wide variance and should be quoted with that caveat every time.
+
+---
+
+## ESOV — Sizing the Budget
+
+**Definitions.** SOV = your share of category advertising spend. SOM = your share of category revenue. **ESOV = SOV − SOM.**
+
+**The rule** (John Philip Jones, *Ad Spending: Maintaining Market Share*, HBR 1990; extended by Binet & Field on IPA data): brands with SOV above SOM tend to grow share; brands below tend to shrink; growth rate is roughly proportional to ESOV. IPA analysis puts the average at **~0.5–0.7% market share growth per year per 10 points of ESOV** (B2C ~0.5%, B2B ~0.7% per the B2B Institute analysis), with real category spread — some categories see ~1.5 pts per 10 ESOV, others need ~20 pts of sustained ESOV per share point.
+
+**Use it in three steps:**
+
+1. **Estimate SOM** from category revenue data (provenance rule applies — collector-sourced numbers only, no guessed market sizes).
+2. **Estimate SOV.** Traditional media: measured spend databases. Digital-era workaround: **share of search** as a proxy for brand strength/SOM trajectory (Binet's 2020 share-of-search work) — it is a proxy, not a replacement, and it lags/leads differently by category.
+3. **Back out budget.** Target share growth ÷ 0.05–0.07 per point ≈ ESOV points needed ÷ category spend ≈ incremental budget. Then apply the brand/activation split from the worksheet below to that total.
+
+**Caveats (state these in any client-facing plan):**
+- Correlation with reverse-causality risk: growing brands can afford more SOV. The relationship replicates across datasets but is not a controlled experiment.
+- Creative quality multiplies or erases it — strong creative gets several times the growth per ESOV point of weak creative.
+- SOV is increasingly unmeasurable: creator content, organic social, retail media, and owned channels carry "voice" that spend-share misses. Treat any digital-era SOV number as an estimate with wide error bars.
+- Distribution, pricing, and product changes routinely swamp the ESOV effect in any single year.
+
+---
+
+## Allocation Worksheet
+
+Work through the steps in order. Modifiers are directional (shift the brand share by the stated points); clamp the final brand share between 20% and 80%.
+
+**Step 1 — Baseline.** Start at 60% brand / 40% activation (B2C) or 46/54 (B2B).
+
+**Step 2 — Category modifier.**
+
+| Category signal | Brand share shift | Why |
+|---|---|---|
+| Financial services / high-trust considered purchase | +10 to +20 | Activation is easy, trust is the constraint (*Effectiveness in Context*: ~80/20 optimum) |
+| Subscription / repeat-revenue model | +5 to +10 | Long customer lifetimes reward mental availability and lower churn-replacement cost |
+| Perishable / short-window services (travel deals, events) | −10 to −20 | Demand is now-or-never; optimum brand share is lowest here |
+| Pure e-commerce/DTC | 0, resist the urge to cut | The "online fallacy": buying online does not mean only activation works |
+| B2B with long sales cycles | Use 46/54 baseline, then +5 if 95%+ of buyers are out-of-market at any time | Future-buyer memory matters more as cycles lengthen |
+
+**Step 3 — Stage modifier** (heuristic extension — the IPA data does not cover pre-PMF startups; cross-check `knowledge/playbooks/marketing-by-stage.md`):
+
+| Stage | Brand/activation planning range | Rationale |
+|---|---|---|
+| Pre-launch → Early (pre-PMF, <$10K MRR) | 0–10 / 90–100 | Outside the evidence base. You need conversion signal and customer language, not reach. "Brand" here = consistent name, look, and story on activation assets, at near-zero cost |
+| Growth ($10K–$100K MRR) | 20–40 / 60–80 | First deliberate brand line item once one channel reliably converts; distinctive assets, category content, founder brand |
+| Scale ($100K+ MRR) | 40–60 / 60–40 | Move toward the category-adjusted optimum; activation-only plans hit rising CAC as warm demand exhausts |
+| Category leader / mature | 60–80 / 40–20 | Defend share, keep price elasticity low, starve challengers of ESOV |
+
+**Step 4 — Situation modifiers.** New product launch: −10 brand for 1–2 quarters (announcement is activation-shaped). Heavy discount dependence / eroding margins: +10 brand (price elasticity is a brand problem). Brand tracking flat while CAC rises quarter over quarter: +10 brand (classic under-investment signature). Cash runway under 12 months: activation-first regardless of doctrine — survival outranks the long term.
+
+**Step 5 — ESOV check.** After setting the split, check the *level*: does total spend produce SOV ≥ SOM? A perfect 60/40 split of an invisible budget grows nothing. If ESOV is deeply negative and can't be funded, concentrate: win ESOV within a segment, region, or channel you can dominate rather than diluting nationally.
+
+**Step 6 — Measurement commitments.** Write into the plan: brand budget judged at 6/12/24 months via MMM or geo-holdout + brand tracking + share of search; activation judged weekly on CPA/ROAS with incrementality tests; no mid-year raiding of the brand line because a dashboard showed a ROAS gap (that gap is the expected artifact from the decay section).
+
+### Worked example
+
+DTC skincare brand, $5M revenue, scale stage, subscription-heavy, 14% share of category search, $1.2M marketing budget.
+
+- Baseline 60/40 → subscription +5 → new-hero-SKU launch this half −10 → **~55% brand / 45% activation** → $660K brand / $540K activation.
+- ESOV check: category ad spend ≈ $40M, so $1.2M ≈ 3% SOV vs ~5% SOM → ESOV ≈ −2. At this budget, national share growth is unlikely; recommendation: concentrate brand spend on two metro geos + one audience segment to run positive ESOV where it's affordable, and set expectations that national share is defend-only this year.
+- Measurement: geo-split MMM readout at month 6 and 12; weekly ROAS on the activation 45% only.
+
+Every number above that feeds a client deliverable must come through the audit collector per the Kai Data Provenance Rule — never estimate a client's SOM or category spend from memory.
+
+---
+
+## Criticisms and Limits of the Evidence (disclose these)
+
+1. **Selection bias.** The IPA databank is built from effectiveness-award entries — nobody submits failures. Findings describe what distinguishes excellent campaigns from other good campaigns, not advertising in general.
+2. **Big-brand, B2C, UK, pre-digital skew.** Most cases are large established consumer brands, and much of the data predates performance-marketing platforms. Transfer to startups, niche B2B, and digital-native brands is extrapolation.
+3. **Methodological pushback.** Byron Sharp (Ehrenberg-Bass) has argued the 60/40 rule does not meet a scientific standard of evidence; case-study meta-analysis cannot isolate causality the way controlled experiments can. (Ehrenberg-Bass's own mental/physical availability work nonetheless points the same broad direction: reach and memory drive growth.)
+4. **The dichotomy is leaky.** Brand ads produce short-term sales; activation done well (distinctive, consistent) leaves brand residue. Binet himself calls the split a useful simplification. Budget lines are cleaner than the underlying reality.
+5. **Possible confounds in the ratio finding.** Campaigns entered with long measurement windows tend to come from brand-believing teams at healthier companies; some of the "60/40 wins" pattern may reflect who runs balanced campaigns, not the ratio itself.
+6. **ESOV measurement is degrading.** Spend-share SOV misses creator, organic, and retail media voice, so modern ESOV numbers carry wide error bars, and share-of-search proxies have their own category-specific quirks.
+
+**Operational consequence:** quote 60/40 and ESOV coefficients as *priors with named sources and caveats*, run your own incrementality tests, and update the ratio annually from your own MMM/holdout evidence — never present the IPA averages as a client-specific prediction.
+
+---
+
+## Anti-Patterns
+
+- **The ROAS death spiral:** cutting brand because attribution can't see it, watching CAC rise 12–18 months later, then cutting brand again to fund the now-more-expensive activation.
+- **Quoting "60/40" as a universal law** in an audit or deck without the average-not-optimum caveat and category adjustment. Instant credibility loss with any informed CMO.
+- **Brand budget, activation measurement:** approving a brand line and then judging it on 30-day conversions. Decide the window first (Step 6) or don't spend it.
+- **Pre-PMF brand campaigns:** applying this doctrine to a company that hasn't found a converting channel yet. See `knowledge/playbooks/marketing-by-stage.md` — conversions first.
+- **ESOV theater:** claiming a precise SOV number from unmeasurable digital categories to justify a budget. State error bars or use share of search with the proxy caveat.
+
+---
+
+## How This Maps Into Kai
+
+- **`/kai` audit and strategy workflows** (marketing audits, growth plans, CMO reviews via `agent/tasks/cmo_review.py` goal decomposition) load this doc when a recommendation touches budget split, brand-vs-performance balance, or "should we invest in brand" questions.
+- **Campaign planning** (`knowledge/playbooks/campaign-orchestration.md`, `scripts/campaigns/campaign_planner.py` outputs) uses the worksheet to sanity-check the brand/activation weighting of multi-channel plans.
+- **Budget math and channel-level allocation** stay in `knowledge/playbooks/marketing-budget-forecasting.md` (70/20/10, pipeline math, ROI benchmarks); **stage-appropriate activities** stay in `knowledge/playbooks/marketing-by-stage.md`. This doc supplies the brand/activation ratio and ESOV sizing those docs assume.
+- **Provenance:** any client-facing deliverable using this doc's numbers must cite the sources below, mark 60/40 and ESOV coefficients as dataset averages, and source client-specific SOM/SOV/category-spend figures through `scripts.audit.collect` per the Kai Data Provenance Rule. Missing category-spend data goes in `_data-gaps.md`, not into an invented ESOV figure.
+- **Approval doctrine:** reallocation of live ad-account budgets recommended by this framework requires explicit human approval before execution.
+
+---
+
+## Sources
+
+- IPA — The Key Works of Les Binet & Peter Field: https://ipa.co.uk/knowledge/effectiveness-research-analysis/les-binet-peter-field
+- Alex Murrell — summary of *The Long and the Short of It*: https://www.alexmurrell.co.uk/summaries/les-binet-and-peter-field-the-long-and-the-short-of-it
+- Growth Method — Binet & Field framework explained (incl. limitations): https://growthmethod.com/long-and-short/
+- Thinkbox — *Effectiveness in Context* (full report download): https://www.thinkbox.tv/research/reports/effectiveness-in-context-free-download
+- thinkTV — *Effectiveness in Context* summary (category optima incl. financial services ~80/20): https://thinktv.ca/research/effectiveness-in-context/
+- System1 — Binet & Field on *Effectiveness in Context* (online fallacy): https://system1group.com/blog/saved-the-baby-binet-and-field-on-effectiveness-in-context
+- LinkedIn B2B Institute — *The 5 Principles of Growth in B2B Marketing*: https://business.linkedin.com/marketing-solutions/b2b-institute/marketing-as-growth
+- Alex Murrell — summary of the B2B Institute 5 Principles (46/54, B2B ESOV): https://www.alexmurrell.co.uk/summaries/the-b2b-institute-the-5-principles-of-growth-in-b2b-marketing
+- The Drum — exclusive look at Binet & Field's B2B research: https://www.thedrum.com/opinion/exclusive-look-binet-and-field-s-new-b2b-marketing-research
+- John Philip Jones — *Ad Spending: Maintaining Market Share*, HBR 1990: https://hbr.org/1990/01/ad-spending-maintaining-market-share
+- LinkedIn — The B2B Marketer's Guide to the Share of Voice Rule: https://business.linkedin.com/en-uk/marketing-solutions/blog/posts/B2B-Marketing/2020/The-B2B-Marketers-Guide-To-The-Share-of-Voice-Rule
+- CreativeX — ESOV overview and creative-quality interaction: https://www.creativex.com/blog/marketing-metric-extra-share-of-voice
+- DPR&Co — ESOV as driver of market share (category variance): https://blog.dprandco.com/excess-share-of-voice-a-key-driver-of-increased-market-share
+- Marketing Week — *Profit Ability 2*: long-term ROI more than double short term (£1.87 → £4.11): https://www.marketingweek.com/advertising-drives-roi-pound-invested/
+- Thinkbox — *Profit Ability 2: The new business case for advertising*: https://www.thinkbox.tv/research/thinkbox-research/profit-ability-2-the-new-business-case-for-advertising
+- Mi3 — Byron Sharp's critique of Binet & Field: https://www.mi-3.com.au/07-09-2022/how-brands-shrink-prof-byron-sharps-takedown-binet-field-attention-metrics
+- BBH Labs — "The Long and the Short of It needs The Wrong and the Sh*t of It" (selection-bias critique): https://www.bbh-labs.com/the-long-and-the-short-of-it-needs-the-wrong-and-the-shit-of-it
+- Marketing Week (Ritson) — brand-building ads boost short-term sales: https://www.marketingweek.com/ritson-brand-building-boost-short-term-sales/
+- Les Binet — "Brand vs Activation: A False Dichotomy?": https://www.linkedin.com/posts/les-binet-9bb7453_brand-vs-activation-a-false-dichotomy-activity-7022177396585832449-kbtU
+- The EQ Planner — share of search as SOM proxy (caveats): https://theeqplanner.wordpress.com/2023/09/21/sneaking-this-one-out-the-second-part-of-my-share-of-search-work-shareofsearch-sos/

--- a/knowledge/frameworks/marketing-science/brand-growth-laws.md
+++ b/knowledge/frameworks/marketing-science/brand-growth-laws.md
@@ -1,0 +1,228 @@
+# Brand Growth Laws (Evidence-Based)
+
+> **Use when:** Deciding targeting breadth, budget split between brand and direct response, whether a "loyalty play" is real, what a brand campaign should build (assets + category entry points), or how to critique a growth plan that promises growth from heavy buyers.
+
+**Provenance:** This doc synthesizes the empirical generalizations published by the Ehrenberg-Bass Institute for Marketing Science and the *How Brands Grow* evidence base (Sharp 2010; Romaniuk & Sharp 2016/2021; Romaniuk 2018, 2023), plus the IPA effectiveness databank (Binet & Field 2013). These are cited as **research findings** — replicated patterns across categories, countries, and decades — not as one expert's opinions. Verify anything category-specific against your own purchase data before making claims in client work (see `harness/references/audit-data-provenance.md`).
+
+**Adjacent docs (cross-link, don't duplicate):**
+- *What to say and how to differentiate* → `knowledge/playbooks/brand-positioning.md` (positioning stack, value prop, messaging matrix)
+- *How to write persuasive conversion copy* → `knowledge/frameworks/content-copywriting/perception-engineering.md`
+- This doc owns the layer **above** both: who to reach, how wide, and what memory structures to build so positioning and copy have someone to land on.
+
+---
+
+## Quick Reference — The Laws
+
+| # | Law | One-line statement | Primary source |
+|---|-----|--------------------|----------------|
+| 1 | **Availability** | Brands grow by increasing mental availability (being thought of in buying situations) and physical availability (being easy to find and buy) | Sharp, *How Brands Grow* (2010) |
+| 2 | **Double Jeopardy** | Smaller brands have fewer buyers AND those buyers are slightly less loyal; loyalty is largely a function of market share, not a separate lever | Ehrenberg, Goodhardt & Barwise (1990) |
+| 3 | **Pareto is ~60/20** | The heaviest 20% of buyers deliver roughly 50-60% of sales — not 80% — so light and non-buyers fund the rest | Sharp, Romaniuk & Graham (2019) |
+| 4 | **95-5** | Only ~5% of category buyers are in-market in a given quarter (B2B services); advertising mostly works on the 95% who buy later | Dawes / LinkedIn B2B Institute (2021) |
+| 5 | **Growth = penetration** | Brands grow overwhelmingly by acquiring more buyers (mostly light ones), not by increasing frequency among existing buyers | Ehrenberg-Bass, NBD-Dirichlet evidence |
+
+Master equation for planning: **Growth = Reach (of all category buyers) × Mental Availability (breadth of CEP links) × Physical Availability (ease of buying) × Distinctiveness (branding that gets the memory credited to you).**
+
+---
+
+## Law 1: Mental and Physical Availability
+
+**Mental availability** = the probability the brand comes to mind in a buying situation. It is broader than awareness: not "do they know you exist" but "are you retrieved when a specific need arises." Built through fresh, consistent, well-branded exposure linked to category entry points (below).
+
+**Physical availability** = the buyer can find and buy you with low friction, in the variant/quantity/price they need, wherever they decide to buy. In digital terms:
+
+| Classic retail term | Digital/B2B translation |
+|---------------------|-------------------------|
+| Shelf presence | Ranking for category and CEP queries; AI-search citation visibility (see `knowledge/frameworks/aeo-ai-search/aeo-ai-search-playbook-2026.md`) |
+| Number of stockists | Marketplace listings, integrations, partner directories, app stores, review platforms |
+| Hours open | Response speed — forms answered, phones answered after hours (phone-led businesses: KaiCalls Fit Rule applies, see `AGENTS.md`) |
+| Pack range | Pricing tiers, self-serve vs sales-led paths, free trial |
+
+**Operational rule:** audit both before proposing spend. A campaign that builds mental availability for a brand buyers can't find (broken local pack, no AI-search presence, forms that go unanswered) burns budget. This is why the agent-readiness gate blocks surround-sound plans on P0 failures.
+
+---
+
+## Law 2: Double Jeopardy
+
+Across ~50 years of panel data, brands with lower market share get punished twice: fewer buyers, and slightly lower loyalty among those buyers (Ehrenberg, Goodhardt & Barwise 1990). The pattern holds in B2B as well as consumer categories per Ehrenberg-Bass analyses. The math behind it is the NBD-Dirichlet model of buying behavior, which also generates the duplication-of-purchase and Pareto patterns.
+
+Stylized shape of the pattern (illustrative, not real category data — pull your own panel numbers before citing figures in client work):
+
+```
+Brand   Market share   Penetration   Purchase frequency
+A       19%            high          slightly above category norm
+B       10%            medium        near category norm
+C       4%             low           slightly below category norm
+```
+
+Penetration varies widely between brands; loyalty varies only a little, and it tracks share.
+
+**What this forbids:**
+1. **"We'll grow by making existing customers more loyal."** Loyalty metrics are mostly an *output* of size. No brand has high loyalty and low penetration except niche edge cases — and niches are small by definition.
+2. **Diagnosing low repeat rates as a retention problem** when the brand is small and its loyalty numbers already match its share. Compare loyalty to the double-jeopardy expectation for your share before declaring a churn crisis.
+3. **Setting loyalty KPIs as growth KPIs.** Track them, but set targets on penetration/new-buyer counts.
+
+**What it does NOT say:** retention work is worthless. Fixing genuinely broken retention (churn far below DJ-expected levels) is repair, not growth strategy. See `knowledge/playbooks/customer-retention.md`.
+
+---
+
+## Law 3: Light-Buyer Math (the 60/20 Pareto)
+
+Ehrenberg-Bass replications (Sharp, Romaniuk & Graham 2019, confirming 2007 findings; independent studies cluster at 50-65/20) show the heaviest 20% of a brand's buyers contribute **roughly 50-60%** of sales ("generally not much more than half," per Ehrenberg-Bass) — not 80%. The bottom 80% (light buyers) deliver the remaining ~40-50%. Additionally, buyer classes churn: about half of this period's heavy buyers won't qualify as heavy next period, while some light/non-buyers move up.
+
+**The planning consequences:**
+
+1. **A brand's biggest revenue pool is people who buy it rarely or not yet.** For most brands, the modal buyer buys once or zero times per year.
+2. **Reach beats frequency.** Media plans should maximize unique category-buyer reach before adding frequency to a narrow segment. Retargeting-heavy plans concentrate spend on people already most likely to buy — paying for sales that were coming anyway.
+3. **Heavy-buyer targeting is a regression-to-the-mean trap.** Last year's heavy buyers were partly heavy by chance; they revert.
+4. **CRM/loyalty programs mostly reach heavy buyers** — the segment least able to fund growth.
+
+**Sizing check before approving any targeting plan:** estimate what fraction of category buyers the plan can even reach. If the "ICP audience" is <10% of category buyers and the goal is brand growth (not pipeline this quarter), the plan contradicts the math — flag it.
+
+---
+
+## Law 4: The 95-5 Rule (in-market timing)
+
+Dawes (Ehrenberg-Bass, for the LinkedIn B2B Institute): firms buy services like banking, software, legal, and telecom roughly every five years, so ~20% are in-market in a year and only **~5% in any given quarter**. The exact number varies by purchase cycle — treat 95-5 as an anchor, not a constant; compute your own from category purchase frequency.
+
+**Consequences:**
+- Most advertising exposure lands on out-of-market buyers. Its job is to build memory links that get retrieved when the buying window opens — brands that enter the buying window unknown rarely make the shortlist.
+- Demand *capture* (search, retargeting, outbound to active evaluators) competes for the 5%. It saturates: past a spend level, more budget on the 5% buys diminishing clicks at rising CPCs.
+- Demand *creation* for the 95% cannot be judged on same-quarter conversion metrics. Judge it on mental-availability metrics (below) and long-window revenue effects.
+
+---
+
+## Framework: Distinctive Brand Assets (build / measure / protect)
+
+Distinctive assets are non-name sensory triggers — colors, logos, characters, sonic cues, taglines, pack shapes, a founder's face — that make the brand recognizable and let advertising get credited to the right brand (Romaniuk, *Building Distinctive Brand Assets*, 2018). **Distinctive ≠ differentiated:** assets say *who* is talking, not *why you're better*. The "why better" layer is positioning — owned by `knowledge/playbooks/brand-positioning.md`.
+
+### Build
+1. Inventory every candidate asset currently in use (visual, verbal, sonic, character, style).
+2. Pick 1-3 to invest in. Prioritize assets usable across channels including audio-only and thumbnail-size contexts.
+3. Execute them **consistently and prominently** in every piece of work for years. Consistency compounds; refresh campaigns that change assets reset the meter.
+
+### Measure — the Distinctive Asset Grid
+Survey category buyers, show the asset without the brand name, and score two axes:
+- **Fame:** % of category buyers who link the asset to your brand.
+- **Uniqueness:** of those who link it to any brand, % who link it *only* to you.
+
+| | Low Fame | High Fame |
+|---|---|---|
+| **High Uniqueness** | *Investment potential* — keep executing, build fame | *Use or lose* — deploy everywhere, anchor branding on it |
+| **Low Uniqueness** | *Ignore/test* — weak candidate | *Avoid solo use* — famous but shared with competitors; always pair with brand name |
+
+Practitioner benchmark: assets clearing ~50% fame and ~50% uniqueness are strong enough to carry branding weight. Below that, always co-present the brand name.
+
+### Protect
+- Trademark what clears the grid; monitor competitor creep on your codes.
+- Write assets into the brand voice/creative checklist so every gate-checked ad and post carries them (this is a line item in ad reviews under `harness/references/ad-write-guardrails.md`).
+- Never let a rebrand discard a high-fame/high-uniqueness asset without measuring what's being destroyed.
+
+---
+
+## Framework: Category Entry Points (identify → rank → cover)
+
+CEPs are the situations, needs, and occasions that bring a category to mind — the retrieval cues buying starts from (Romaniuk & Sharp; codified in Romaniuk, *Better Brand Health*, 2023). Mental availability = how many CEPs your brand is linked to, across how many category buyers.
+
+### Step 1 — Identify (elicit with the W's)
+Interview/survey category buyers using Romaniuk's W prompts. For each recent purchase occasion ask:
+
+| W | Prompt | Example (AI receptionist category) |
+|---|--------|------------------------------------|
+| **Why** | motive/benefit sought | "stop losing after-hours callers" |
+| **When** | timing | "after hiring freeze", "tax season crunch" |
+| **Where** | location/context | "reviewing missed-call log" |
+| **While** | co-occurring activity | "while in court all day" |
+| **With/for Whom** | others involved | "office manager pushing for it" |
+| **With What** | co-purchased/co-used | "alongside new CRM rollout" |
+| **hoW feeling** | emotional state | "embarrassed a lead went to voicemail" |
+
+Aim for 15-30 candidate CEPs from ~20+ buyer conversations or a structured survey. Mine sales-call recordings and reviews for the same cues (method shared with the Customer-Language Mining section in `knowledge/playbooks/brand-positioning.md`).
+
+### Step 2 — Rank
+Score each CEP on: (a) **prevalence** — how many category buyers experience it, (b) **frequency** — how often, (c) **competitive linkage** — which brands already own it. Prioritize common, frequent CEPs where no competitor dominates. A niche CEP you own outright is worth less than a share of a giant CEP.
+
+### Step 3 — Cover
+- Assign priority CEPs to campaigns, content clusters, and landing pages: each asset should depict one CEP vividly and brand it heavily with distinctive assets.
+- Breadth over depth: linking the brand to *more* CEPs across *more* buyers beats deepening one link.
+- Track with Romaniuk's mental-availability metrics: **mental penetration** (% of buyers linking you to ≥1 CEP), **network size** (average # of CEPs linked among those aware), **mental market share** (your share of all brand-CEP links in the category — the metric that tracks sales share), **share of mind**.
+
+CEPs also drive SEO/AEO topic selection: each high-priority CEP is a query cluster and an AI-search prompt situation. Map CEPs → page architecture via `knowledge/frameworks/content-copywriting/qdp-qdh-qds-content-architecture.md`.
+
+---
+
+## Targeting Breadth vs Narrow Personas
+
+The evidence points to **sophisticated mass marketing**: reach all category buyers, with creative sharp enough to be noticed and branded enough to be credited. Narrow ICP targeting is a *media efficiency* tool for capture-mode budgets, not a growth theory — restricting reach to a "high-value persona" caps penetration, and Law 3 says the excluded light/non-buyers are half the revenue pool.
+
+**How this squares with Kai's 8 personas (`knowledge/personas/_persona-index.md`):** personas here are **creative devices** — they make one buyer's tension vivid so the ad gets attention — not audience filters. Write *to* the Competent Cog; *buy media* against the whole category. A vivid specific scenario is processed by broad audiences fine (the "empathy vs targeting" distinction). Only narrow the actual media audience when the decision table below says DR doctrine applies.
+
+---
+
+## Decision Table: DR Doctrine vs Availability Doctrine
+
+Both doctrines are correct **in their lane**. Binet & Field's IPA databank analysis (~1,000 effectiveness cases) found the profit-maximizing mix averages ~60% brand building / 40% activation — i.e., you run both, and the ratio shifts with context. **Treat 60/40 as contested-as-a-universal:** it is the average of a wide distribution, and Binet & Field's own follow-up (*Effectiveness in Context*, IPA 2018) shows the optimum shifts with category, brand size, price, and channel mix (online-led categories sit nearer 50/50; Binet has said publicly "60/40 is not an iron rule"). Use this table to pick the operating doctrine for a given budget line:
+
+| Signal | DR doctrine (narrow ICP, immediate response, tight attribution) | Availability doctrine (broad reach, CEP + asset building) |
+|---|---|---|
+| **Buyer state** | In-market now (the ~5%): active search, demo requests, cart abandoners | Out-of-market (the ~95%): will buy in 1-60 months |
+| **Objective** | Pipeline/revenue this quarter | Market share growth over 1-3 years |
+| **Business stage** | Pre-PMF, survival cash-flow, <~monthly repurchase validation | Post-PMF with retention holding at DJ-expected levels |
+| **Category size vs budget** | Budget too small to reach the category meaningfully — concentrate on highest-intent slice | Budget can achieve real reach of category buyers |
+| **Channel economics** | Search/marketplace demand capture NOT yet saturated | Capture channels saturated: rising CPCs, flat volume on more spend |
+| **Offer type** | Promos, launches, seasonal windows, event deadlines | Always-on presence; no expiry on the message |
+| **Measurement** | Direct response metrics valid (short lag, trackable) | Judge on mental penetration, mental market share, share of search, distinctive-asset fame — not same-quarter ROAS |
+| **Creative brief** | Perception-engineering conversion copy, urgency, specific offer (→ `knowledge/frameworks/content-copywriting/perception-engineering.md`) | CEP-situation storytelling, heavy distinctive-asset branding, emotional, broad-processable |
+| **Targeting** | Narrow: intent signals, retargeting, named accounts | Broad: all category buyers; personas as creative lens only |
+
+**Default split:** anchor near 60/40 brand/activation for established brands; shift toward activation for early-stage, small-budget, or highly seasonal businesses; shift toward brand when capture channels saturate. Re-derive per client — the 60/40 figure is a databank average, not a law.
+
+**Common misapplication to flag in audits:** a scale-up spending 95% on retargeting + branded search, reporting great ROAS, with flat new-customer counts. ROAS is high *because* the spend targets people already buying. Prescription: cap capture spend at saturation, move the excess to reach.
+
+---
+
+## Anti-Patterns (reject these in plans and audits)
+
+1. **"Focus on your best customers to grow"** — contradicts Laws 2, 3. Growth is penetration.
+2. **Loyalty program as growth engine** — reaches heavy buyers; DJ says their loyalty tracks share anyway.
+3. **Rebranding away famous assets** for aesthetic freshness — destroys measured fame; demand grid scores first.
+4. **Judging brand spend on last-click ROAS** — 95% of the audience buys outside the attribution window.
+5. **Differentiation messaging doing distinctiveness' job** — a clever USP nobody attributes to you builds the category, or a competitor. Brand the work.
+6. **Persona-as-audience-filter** on availability-doctrine budgets — caps reach at a fraction of category buyers.
+7. **Quoting "80/20" for buyer concentration** — the replicated figure is ~50-60/20.
+
+Live-channel actions this doc motivates (media buys, budget reallocations, rebrand rollouts, survey launches to client lists) require human approval per the approval doctrine — nothing here authorizes mutation of live accounts.
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Decision this doc informs |
+|---|---|
+| `/kai-audit`, CRO/marketing audits (`scripts/audit/`) | Diagnose ROAS-looks-great-but-flat-growth accounts; check loyalty complaints against DJ expectation; flag capture-saturation. All quantitative claims still require collector provenance (`harness/references/audit-data-provenance.md`) |
+| Campaign planning (`knowledge/playbooks/campaign-orchestration.md`, `scripts/campaigns/campaign_planner.py`) | Budget split (brand vs activation), targeting breadth, CEP assignment per asset |
+| Media/ads skills (Meta, Google, LinkedIn ads maps in `AGENTS.md`) | Reach-first audience settings for brand-objective lines; narrow intent audiences only when the decision table says DR |
+| Brand strategy work (`knowledge/playbooks/brand-positioning.md`) | Positioning defines what to say; this doc defines who to reach and which memory structures (assets, CEPs) carry it |
+| SEO/AEO planning (`knowledge/frameworks/aeo-ai-search/aeo-ai-search-playbook-2026.md`, QDP/QDH/QDS) | CEP list → query clusters and page architecture; AI-search visibility as digital physical availability |
+| Persona selection (`knowledge/personas/_persona-index.md`) | Personas = creative lens, not media filter, on availability-doctrine work |
+| Reporting (`scripts/reporting/weekly_report.py`, CEO decks) | Report mental-availability metrics alongside DR metrics; never grade brand lines on same-quarter ROAS |
+
+---
+
+## Sources
+
+- Ehrenberg-Bass Institute — books and research index (Sharp, *How Brands Grow*; Romaniuk & Sharp, *How Brands Grow Part 2*): https://marketingscience.info/learn-with-us/books
+- Ehrenberg-Bass — "How do you measure 'How Brands Grow'?" (availability metrics): https://marketingscience.info/news-and-insights/how-do-you-measure-how-brands-grow
+- Ehrenberg-Bass — "The Double Jeopardy Law in B2B shows the way to grow": https://marketingscience.info/the-double-jeopardy-law-in-b2b-shows-the-way-to-grow/
+- Graham, Bennett, Franke, Henfrey & Nagy-Hamada (2017) — "Double Jeopardy – 50 Years On," *Australasian Marketing Journal* 25(4): https://www.sciencedirect.com/science/article/abs/pii/S1441358217301519
+- Sharp, Romaniuk & Graham (2019) — "Marketing's 60/20 Pareto Law" (SSRN): https://papers.ssrn.com/sol3/papers.cfm?abstract_id=3498097
+- Ehrenberg-Bass — "The value of Pareto's bottom 80%": https://marketingscience.info/value-paretos-bottom-80/
+- Ehrenberg-Bass — "95% of B2B buyers are not in the market for your products" (Dawes): https://marketingscience.info/news-and-insights/ehrenberg-bass-95-of-b2b-buyers-are-not-in-the-market-for-your-products
+- Ehrenberg-Bass — "The 95:5 Rule: Why B2B Growth Starts Long Before the Purchase": https://marketingscience.info/news-and-insights/the-955-rule-why-b2b-growth-starts-long-before-the-purchase
+- LinkedIn B2B Institute — 95-5 Rule research page: https://business.linkedin.com/advertise/resources/b2b-institute/b2b-research/trends/95-5-rule
+- Romaniuk, *Building Distinctive Brand Assets* (Oxford University Press, 2018): https://global.oup.com/academic/product/building-distinctive-brand-assets-9780190311506
+- Distinctive Asset Grid explainer (fame/uniqueness scoring, quadrants): https://www.the-brand-algorithm.com/distinctive-asset-grid/
+- Ehrenberg-Bass — Romaniuk on *Better Brand Health* (CEPs, W's, mental-availability metrics): https://marketingscience.info/news-and-insights/jenni-romaniuk-on-better-brand-health
+- Quantilope — Category Entry Points guide (7Ws summary): https://www.quantilope.com/resources/category-entry-points
+- IPA — Binet & Field, *The Long and the Short of It* (60/40 brand/activation) and *Effectiveness in Context* (2018; optimum varies by category): https://ipa.co.uk/knowledge/effectiveness-research-analysis/les-binet-peter-field
+- Binet interview (PHD Media) — "60/40 is not an iron rule": https://www.phdmedia.com/exclusive-interview-for-phd-les-binet-speaks-to-tomas-lilja-strategy-director/

--- a/knowledge/frameworks/marketing-science/diagnosis-first-operating-order.md
+++ b/knowledge/frameworks/marketing-science/diagnosis-first-operating-order.md
@@ -1,0 +1,194 @@
+# The Diagnosis-First Operating Order (Diagnosis → Strategy → Tactics)
+
+> **Use when:** Starting any marketing engagement, plan, campaign, or content batch; deciding whether Kai has enough evidence to produce assets; reviewing a plan that jumps straight to channels; or diagnosing why a marketing program keeps shipping work that doesn't move numbers. This doc owns one thing: **the order of operations** — what must exist before what. It is the front door to `knowledge/_arbitration.md`, which resolves conflicts *between* frameworks once the operating order has told you which phase you are in.
+
+**Provenance:** The three-phase operating order is Mark Ritson's codification of classic marketing management (diagnosis → strategy → tactics, Marketing Week columns and the Mini MBA curriculum), structurally identical to Richard Rumelt's strategy kernel (*Good Strategy Bad Strategy*, 2011: diagnosis → guiding policy → coherent action). The evidence that diagnosis pays is the market-orientation literature: Narver & Slater (1990, 140 business units) found a positive effect of market orientation on profitability; Kohli & Jaworski (1990) formalized the construct as intelligence generation → dissemination → responsiveness; Kirca, Jayachandran & Bearden's 2005 *Journal of Marketing* meta-analysis confirmed a positive market orientation → performance relationship across the pooled studies, mediated by innovativeness, customer loyalty, and quality. SMART objectives trace to Doran (1981). Waste numbers come from the BetterBriefs/IPA study (2021). Cite these as research findings; verify anything category-specific against your own data before client claims (`harness/references/audit-data-provenance.md`).
+
+**Adjacent docs (cross-link, don't duplicate):**
+- *Which framework wins when two disagree* → `knowledge/_arbitration.md` (this doc routes you into a phase; arbitration referees inside it)
+- *Who to reach and how wide* (strategy phase) → `knowledge/frameworks/marketing-science/brand-growth-laws.md`
+- *Budget ratio brand vs activation* (strategy phase) → `knowledge/frameworks/marketing-science/brand-activation-budget.md`
+- *Positioning stack and messaging* (strategy phase) → `knowledge/playbooks/brand-positioning.md`
+- *Macro/category context for 2026 diagnosis* → `knowledge/playbooks/2026-marketing-playbook.md`
+- *The tactical entry ticket per piece of content* → `harness/brief-schema.md` (a brief is a Phase-3 artifact; it cannot substitute for Phases 1-2)
+
+---
+
+## Quick Reference — The Operating Order
+
+```
+PHASE 1: DIAGNOSIS   →   PHASE 2: STRATEGY   →   PHASE 3: TACTICS
+"What is going on?"      "Where do we play,      "What do we ship,
+                          how do we win?"          on which channels?"
+market orientation        targeting                channel selection
+category/competitor map   positioning              creative + briefs
+funnel evidence           objectives (SMART,       calendar, budget lines
+customer research         sequenced)               execution + gates
+```
+
+Three rules that make it an operating order rather than a diagram:
+
+1. **Sequence is mandatory.** No strategy decision before diagnosis exits its checklist. No tactic (channel, format, campaign, post) before targeting, positioning, and objectives are written down. Ritson: there is no "digital strategy" or "Facebook strategy" — there is one strategy, which then feeds tactical choices.
+2. **Each phase produces a named artifact.** Diagnosis → `MARKETING.md` + evidence folder. Strategy → the targeting/positioning/objectives block inside `MARKETING.md`. Tactics → briefs (`harness/brief-schema.md`), calendars, campaigns. An artifact missing = the phase didn't happen, whatever the meeting notes say.
+3. **Kai enforcement:** no PRODUCE skill runs before diagnosis inputs exist. Full rule below ("The Kai Gate Rule").
+
+Why the order pays: Rumelt names failure to face the challenge (absent or weak diagnosis) and mistaking goals for strategy among his four hallmarks of bad strategy. The BetterBriefs/IPA study (1,700+ marketers and agency staff, 70+ countries, 2021) found respondents estimate **a third of marketing budget is wasted** through poor briefs and misdirected work — and the gap is diagnostic blindness: 78% of marketers believe their briefs give clear strategic direction; 5% of creative agencies agree.
+
+---
+
+## Phase 1: Diagnosis — Executable Checklist
+
+Purpose: comprehend the situation before deciding anything. Every item lists its minimum evidence bar and where the output lands. Run items in parallel; exit only when all four blocks pass. Time-box the phase (1-2 weeks solo operator, 4-6 weeks agency engagement) — diagnosis that never ends is a failure mode too.
+
+### D1. Market orientation research (the intelligence base)
+
+Market orientation has three behavioral components (Kohli & Jaworski 1990): generate intelligence about customers and competitors, spread it, respond to it. (Narver & Slater 1990 frame the same construct as customer orientation, competitor orientation, and interfunctional coordination.) Block D1 is the generation step.
+
+- [ ] **Customer intelligence:** ≥10 customer/prospect conversations OR a structured survey OR mined primary text (sales-call transcripts, support tickets, reviews, Reddit/community threads). Label every input with `source_type` and date per `harness/brief-schema.md` evidence fields.
+- [ ] **Competitor intelligence:** run `/kai-competitors` or `python scripts/intel/competitor_monitor.py --check`; capture who the buyer names as alternatives (ask them — the real consideration set often differs from the founder's list).
+- [ ] **Internal intelligence:** what sales/support/founders know that marketing doesn't — churn reasons, objection log, win/loss notes.
+- **Blocks exit if:** zero primary customer inputs. Third-party reports alone do not clear D1.
+
+### D2. Category and competitor mapping
+
+- [ ] **Category definition and size:** what category does the *buyer* think they're shopping? Approximate purchase frequency (drives the in-market % — see the 95-5 logic in `brand-growth-laws.md`).
+- [ ] **Share and growth picture:** your penetration vs the leaders'; is the category growing, flat, shrinking? Sourced numbers only — collector output or a cited report, never memory.
+- [ ] **Competitor teardown:** top 3-5 by the buyer's consideration set — their positioning claim, price point, distribution, observable spend. Framework: `knowledge/playbooks/competitive-intelligence.md`.
+- [ ] **Macro context scan:** regulation, platform shifts, AI-search changes relevant to the category — load `knowledge/playbooks/2026-marketing-playbook.md`, don't rebuild it.
+- **Blocks exit if:** category is defined only in company-internal language ("we're the AI-powered X for Y" is positioning, not a category map).
+
+### D3. Current funnel evidence
+
+- [ ] **Collector run:** `python -m scripts.audit.collect --url <url> --mode <mode> --workflow diagnosis --out <data-folder>` (Kai Data Provenance Rule — applies because diagnosis feeds client-facing claims).
+- [ ] **Traffic and conversion baselines:** GSC queries/impressions, GA4 pages, conversion counts, by stage. Unknown numbers go in `_data-gaps.md`, not estimates.
+- [ ] **Lead-capture reality check:** forms, phones, chat — response time, after-hours coverage, missed-call volume where phone-led (KaiCalls Fit Rule per `AGENTS.md` applies at the *recommendation* step later, but the evidence is collected now).
+- [ ] **Existing content/asset audit:** what exists, what ranks, what converted. `/kai-funnel-audit` covers this in depth.
+- **Blocks exit if:** no analytics access and no collector output — you cannot diagnose a funnel you haven't seen.
+
+### D4. Customer research synthesis
+
+- [ ] **Persona selection with evidence label:** pick from `knowledge/personas/` and tag `evidence_backed`, `directional`, or `hypothesis` per `harness/brief-schema.md`. A `hypothesis` persona cannot anchor strategy claims.
+- [ ] **Category entry points:** elicit 15-30 candidate CEPs via the W-prompts (method owned by `brand-growth-laws.md`).
+- [ ] **Jobs, pains, objections in customer language:** verbatim quotes filed with sources — these feed positioning and copy later.
+- **Blocks exit if:** every persona is `hypothesis`-labeled and no plan exists to upgrade at least one.
+
+### Diagnosis exit gate
+
+All four blocks pass → write the diagnosis summary into `MARKETING.md` (created by `/kai-start` if absent): 5-10 sentences stating what is going on, the 1-3 critical obstacles (Rumelt: a good diagnosis simplifies overwhelming complexity by identifying certain aspects of the situation as critical), and the evidence folder path. If you cannot state the critical obstacle in one sentence, diagnosis isn't done.
+
+---
+
+## Phase 2: Strategy — Three Decisions, In Order
+
+Strategy is choice, not aspiration. Exactly three decisions, made from the diagnosis, written into `MARKETING.md`.
+
+### S1. Targeting — who (and how wide)
+
+Decide which buyers the plan pursues and at what breadth. The breadth decision (broad category reach vs narrow ICP) is owned by the DR-vs-availability decision table in `brand-growth-laws.md` — apply it, don't re-derive it. Segmentation inputs come from D1/D4. Output: a named target with size estimate and the doctrine (DR or availability) each budget line runs under.
+
+### S2. Positioning — what we stand for against whom
+
+One positioning statement per target: frame of reference, point of difference, reasons to believe — built from D2 (competitor claims) and D4 (customer language). Full stack: `knowledge/playbooks/brand-positioning.md` and `/kai-brand`. Output: the statement plus the 2-3 proof points that survive the provenance rule.
+
+### S3. Objectives — how much, by when, in what order
+
+SMART per Doran (1981): Specific, Measurable, Assignable, Realistic, Time-related — Doran himself noted not every objective will hit all five; treat them as guidelines, not a ritual. Kai-specific additions:
+
+1. **Few:** 1-3 objectives. More than three means choices weren't made.
+2. **Sequenced:** order objectives by funnel dependency — awareness/mental availability targets before acquisition targets before revenue/retention targets, each with its own date. A revenue objective with no upstream objective is a wish.
+3. **Derived, not decorative:** each objective must trace to a diagnosis finding ("missed 41% of after-hours calls → objective: answer rate ≥95% by Q4"). One of Rumelt's bad-strategy hallmarks is goals mistaken for strategy — an objective without a diagnosis behind it is exactly that.
+4. **Registered:** `python scripts/harness_cli.py goals add --brand <brand> --name "<goal>" --kpi <kpi> --target <value> --deadline YYYY-MM-DD` so the weekly CMO review can pace it.
+
+### Strategy exit gate
+
+`MARKETING.md` contains: target(s) + doctrine, positioning statement(s), 1-3 SMART sequenced objectives with registered goals. Only now may anyone say the word "channel."
+
+---
+
+## Phase 3: Tactics — Now, and Only Now
+
+Tactics = the full 4P surface, not promotion alone: product/offer changes (`/kai-offer-builder`), pricing (`knowledge/playbooks/pricing-strategy.md`), distribution/physical availability, and communication. For each objective:
+
+1. Pick channels from the Framework Map in `AGENTS.md` — channel choice follows target media behavior and objective type, never familiarity.
+2. Write a brief per asset via `harness/brief-schema.md` — the brief inherits persona, angle, and proof from Phases 1-2; it does not invent them.
+3. Run the content pipeline and quality gates as normal (Four U's, banned words, seo_lint, ad policy gates).
+4. Route budget lines through `brand-activation-budget.md` ratios.
+
+Where two frameworks give conflicting tactical guidance (e.g., broad-reach doctrine vs a narrow-ICP playbook), resolve via `knowledge/_arbitration.md` — do not average them silently.
+
+Approval doctrine: every live-channel action tactics produce — publishing, posting, ad mutations, outreach sends — requires human approval per `AGENTS.md`. Nothing in this operating order authorizes skipping that.
+
+---
+
+## Failure Mode Taxonomy
+
+The classic ways the operating order gets violated. Each has a detection signal Kai can check mechanically.
+
+| # | Failure mode | What it is | Detection signal | Correction |
+|---|--------------|-----------|------------------|------------|
+| 1 | **Tactification** (Ritson) | The discipline reduced to tactics: plans that are lists of channels and executions with no diagnosis or strategy layer above them | Plan document contains channel names but no target, positioning, or objective section; "strategy" slide is a channel logo grid | Stop. Run Phases 1-2. A channel list is an output of strategy, never a substitute |
+| 2 | **Communification** (Ritson) | Within tactics, everything collapses to communications — product, pricing, and distribution levers ignored | 100% of proposed actions are content/ads/social; zero offer, price, or availability actions despite diagnosis showing (e.g.) unanswered phones or a broken checkout | Re-open Phase 3 across all 4Ps; cheapest fix is often not a campaign |
+| 3 | **Marketing-as-promotion-only** | The org scopes marketing as "the department that makes ads," so diagnosis/strategy work is never commissioned at all | Requests arrive pre-tactified ("write us 10 posts", "run some ads") with no MARKETING.md and no evidence folder | Kai Gate Rule below: route to `/kai-start` + diagnosis before producing |
+| 4 | **Goals-as-strategy** (Rumelt) | Ambitious targets presented as strategy ("grow 40%") with no diagnosis or guiding policy | Objectives exist but none traces to a diagnosis finding; no named obstacle | Rewrite objectives per S3 rule 3; if no diagnosis exists, back to Phase 1 |
+| 5 | **Research-skipping** | Strategy built on founder intuition; personas all `hypothesis`; numbers from memory | `persona_evidence_status: hypothesis` across the board; quantitative claims without collector sources | D1/D4 minimum evidence bars; provenance lint blocks handoff |
+| 6 | **Perpetual diagnosis** | Research as procrastination; the plan never exits Phase 1 | Diagnosis running past its time-box with exit-gate items already green | Exit gate is sufficient, not perfect; ship the strategy, revisit quarterly |
+
+Modes 1-3 are nested: promotion-only scoping (3) produces communification (2), which is the loudest strain of tactification (1). Fixing 3 upstream usually clears all three.
+
+---
+
+## The Kai Gate Rule: No PRODUCE Before Diagnosis
+
+**Rule:** No skill in the PRODUCE lane of the `/kai` router (`/kai-write`, `/kai-landing-page`, `/kai-email-system`, `/kai-ad-campaign`, `/kai-social`, `/kai-content-calendar`, `/kai-launch`, `/kai-cold-outreach`, and the rest of the PRODUCE table in `harness/skills/kai/SKILL.md`) may run until diagnosis inputs exist:
+
+1. **`MARKETING.md` exists** at the project root (created by `/kai-start`), containing at minimum a diagnosis summary and one strategy block (target, positioning, objective), and
+2. **Evidence exists:** a diagnosis evidence folder (collector output per the Data Provenance Rule) or a brief whose persona and quantitative claims carry non-`hypothesis` evidence labels.
+
+**When the check fails:** do not produce. Say what is missing, then route: no `MARKETING.md` → `/kai-start`; `MARKETING.md` but no evidence → the Phase-1 checklist above (D1-D4); evidence but no strategy block → Phase 2. Producing anyway and labeling it "draft" is the tactification failure mode with a disclaimer stapled on.
+
+**Narrow exception:** the human explicitly directs production without diagnosis, in their own words, after being told what is missing. Log the override and the missing inputs in the output header. AUDIT and ANALYZE lane skills are exempt — they *are* diagnosis tooling. PLAN lane skills (`/kai-brief`, `/kai-growth-plan`, `/kai-brand`) may run with partial diagnosis but must list gaps in their output.
+
+This rule is the operating-order equivalent of the quality gates: gates check the asset after writing; this checks the *right to write* before starting.
+
+---
+
+## Worked Example (compressed)
+
+Request arrives: "Write us a month of social posts" for a 6-attorney personal-injury firm. Gate check: no `MARKETING.md`, no evidence → decline to produce, run the order.
+
+- **Diagnosis (1 week):** collector run + GSC + call-log pull. Findings: firm ranks #2 locally, but tracked lines show a large share of after-hours calls go unanswered; reviews praise one attorney by name; competitors all claim "aggressive" and "no fee unless we win"; buyer conversations show cases are compared on callback speed, not content quality. Critical obstacle (one sentence): *demand capture leaks after hours; content is not the constraint.*
+- **Strategy:** target = injured locals in the 72-hour post-accident window (DR doctrine — in-market, urgent) plus category-buyer reach for mental availability; positioning = the firm that answers first, proof = tracked callback times; objectives = (1) answer rate ≥95% within 60 days, (2) +30% consult bookings within 120 days — sequenced, registered.
+- **Tactics:** fix availability first (after-hours answering — phone-led fit signals present, so a KaiCalls evaluation with disclosure and alternatives per the Fit Rule), then LSA/GBP optimization, and only then the social calendar — now briefed against the answer-first positioning instead of generic "legal tips."
+
+The original request (social posts) ended up third in priority. That reordering — not better posts — is what the operating order buys.
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Decision this doc informs |
+|---|---|
+| `/kai` router + every PRODUCE skill | The Gate Rule: verify MARKETING.md + evidence before producing; route to `/kai-start` or Phase 1 when missing |
+| `/kai-start` (`harness/skills/kai-start/SKILL.md`) | MARKETING.md is the Phase-1/2 artifact this doc requires; onboarding = entering the operating order |
+| `/kai-growth-plan`, `/kai-brand`, `/kai-budget` | Phase-2 executors: targeting/positioning/objectives structure, S3 objective rules |
+| `/kai-audit`, `/kai-funnel-audit`, `/kai-cro`, `/kai-competitors`, `/kai-brand-pulse` | Phase-1 executors (exempt from the Gate Rule); their outputs populate D1-D4 |
+| `/kai-brief` + `harness/brief-schema.md` | Phase-3 entry ticket; briefs inherit from Phases 1-2, never substitute for them |
+| `knowledge/_arbitration.md` | Loaded when frameworks conflict inside a phase; this doc decides which phase you're in first |
+| Plan/audit reviews (any lane) | Failure-mode taxonomy as a review checklist: flag tactification, communification, promotion-only scoping, goals-as-strategy |
+| Weekly `cmo_review` + goals registry | S3 objectives registered via `harness_cli.py goals` so pace-vs-deadline tracking has real targets |
+
+---
+
+## Sources
+
+- Ritson, M. — "Tactics without strategy is dumbing down our discipline" (tactification, communification), Marketing Week: https://www.marketingweek.com/mark-ritson-beware-the-tactification-of-marketing/
+- Ritson, M. — "Marketers who skip brand research are doomed to fail," Marketing Week: https://www.marketingweek.com/mark-ritson-marketers-skip-brand-research-doomed-fail/
+- Ritson, M. — "Planning for marketing planning: 14 steps," Marketing Week: https://www.marketingweek.com/mark-ritson-marketing-planning-14-steps/
+- Mini MBA — "The missing step in marketing plans: brand diagnosis": https://minimba.com/articles/the-missing-step-in-marketing-plans-brand-diagnosis
+- Rumelt, R. — *Good Strategy Bad Strategy* (2011), kernel summary: https://www.alexmurrell.co.uk/summaries/richard-rumelt-good-strategy-bad-strategy
+- Narver, J.C. & Slater, S.F. (1990) — "The Effect of a Market Orientation on Business Profitability," *Journal of Marketing* 54(4): https://journals.sagepub.com/doi/abs/10.1177/002224299005400403
+- Kohli, A.K. & Jaworski, B.J. (1990) — "Market Orientation: The Construct, Research Propositions, and Managerial Implications," *Journal of Marketing* 54(2): https://journals.sagepub.com/doi/10.1177/002224299005400201
+- Kirca, A.H., Jayachandran, S. & Bearden, W.O. (2005) — "Market Orientation: A Meta-Analytic Review," *Journal of Marketing* 69(2): https://journals.sagepub.com/doi/10.1509/jmkg.69.2.24.60761
+- Doran, G.T. (1981) — "There's a S.M.A.R.T. way to write management's goals and objectives," *Management Review* 70(11): https://www.scirp.org/reference/ReferencesPapers?ReferenceID=1459599
+- BetterBriefs/IPA (2021) — "One third of marketing budgets could be wasted" (1,700+ respondents, 70+ countries): https://ipa.co.uk/news/betterbriefs
+- BetterBriefs coverage with perception-gap figures (80%/10%, 78%/5%), Mi3: https://www.mi-3.com.au/18-10-2021/200bn-black-hole-marketers-wasting-third-budgets-giving-agencies-crap-briefs-and-dont

--- a/knowledge/frameworks/marketing-science/experiment-rigor.md
+++ b/knowledge/frameworks/marketing-science/experiment-rigor.md
@@ -1,0 +1,220 @@
+# Experiment Rigor: Statistical Rules for Marketing Tests
+
+> **Use when:** Sizing a test before launch, deciding whether a result is readable, judging a surprising win, reading segment breakdowns, choosing what to do when traffic can't support an A/B test, or scoring a backlog with ICE/RICE.
+>
+> This is the **stats layer** underneath three operational playbooks. Process and ledger fields live there, not here:
+> - `knowledge/playbooks/experimentation-ledger.md` — how experiments get logged, promoted, and approved.
+> - `knowledge/playbooks/creative-test-resolution-protocol.md` — kill/iterate/graduate decisions and media data floors.
+> - `knowledge/playbooks/meta-creative-testing-decision-framework.md` — Meta budget reality checks and creative counts.
+
+---
+
+## Core Thesis: Your Prior Should Be "This Idea Fails"
+
+Published data from companies running thousands of controlled experiments says most ideas do not work. At Microsoft, roughly one-third of well-built experiments improved their key metric, one-third made no statistically significant difference, and one-third made things worse. At Bing, only about 10–20% of proposed ideas produced positive results (Kohavi & Thomke, HBR 2017; Kohavi, Tang & Xu, *Trustworthy Online Controlled Experiments*, Cambridge 2020).
+
+Two consequences:
+
+1. **A "winner" claim carries the burden of proof.** With a 10–33% base rate of true wins, weak evidence plus enthusiasm mostly produces false positives.
+2. **The system's value is the losers it catches.** An experiment program that never reports losses is not rigorous; it is broken. Use the ledger's "inconclusive" and "invalid" labels generously.
+
+---
+
+## Rule 1 — Fix the Read Before the Run (Sample Floors)
+
+Declare before launch: hypothesis, primary metric, minimum detectable effect (MDE), sample floor, and read date. These become the `sample_floor` and `planned_read_date` fields in the experimentation ledger. A test without a pre-declared floor is opinion theater.
+
+### The sizing formula
+
+The standard rule of thumb for sample size per variant at 80% power and α = 0.05 (van Belle's rule, used throughout Kohavi, Tang & Xu):
+
+```
+n per variant ≈ 16 × σ² / δ²
+```
+
+where δ is the absolute effect you want to detect and σ² is the metric's variance. For a conversion rate p, σ² = p(1−p).
+
+**Worked example.** Baseline landing-page CVR = 5%, you want to detect a 10% relative lift (δ = 0.005):
+
+```
+n ≈ 16 × (0.05 × 0.95) / 0.005² = 30,400 visitors per variant
+```
+
+At 2,000 visitors/week split two ways, that read is 30+ weeks away — this test should not run as an A/B test (see Rule 6).
+
+### Conversion floor shortcut
+
+Substituting δ = (relative lift × p) into the formula, the visitors cancel and you get an approximate **conversions-per-variant** floor that barely depends on the baseline rate (for small p):
+
+```
+conversions per variant ≈ 16 / (relative lift)²
+```
+
+| Relative lift you want to detect | Conversions needed per variant (approx.) |
+|---|---|
+| 50% | ~65 |
+| 30% | ~180 |
+| 20% | ~400 |
+| 10% | ~1,600 |
+| 5% | ~6,400 |
+
+Decision rules:
+
+- Read the table backwards: with the conversions you can realistically collect, what lift is detectable? If the answer is "only a 50%+ lift," say so in the ledger and design a bigger swing or an earlier signal metric.
+- The creative-test protocol's `50+ conversions` floor is a **directional media floor**, not a significance floor — at 50 conversions per variant you can only statistically resolve lifts around 55–60% relative. Treat sub-floor reads as signal tests, per that protocol.
+- **Run whole weeks.** Day-of-week and weekend effects cycle; Kohavi, Tang & Xu recommend a minimum of one full week and typically two, in full-week multiples, even when the sample floor is met earlier.
+
+---
+
+## Rule 2 — Peeking Invalidates Fixed-Horizon Stats
+
+Classical p-values assume the sample size was fixed in advance. Checking the dashboard daily and stopping the moment p < 0.05 breaks that assumption: Evan Miller's simulations show stop-at-first-significance monitoring can push a nominal 5% false-positive rate above 25% (Miller 2010). Johari, Koomen, Pekelis & Walsh formalized this at KDD 2017: under realistic "check every day" behavior, fixed-horizon inference is severely inflated and unreliable (Johari et al. 2017).
+
+**Bayesian dashboards do not automatically fix this.** Vendor marketing often claims Bayesian tests are peeking-immune; this is contested, and simulations show that stopping on a Bayesian "probability to be best" threshold is still optional stopping and still inflates false-positive rates in repeated use (Molas 2025). Posteriors stay interpretable under monitoring; a fixed stop-when-favorable threshold does not control error rates.
+
+### What sequential testing actually requires
+
+Legitimate early stopping needs a method built for it, chosen **before launch**:
+
+| Method | What it is | Cost |
+|---|---|---|
+| Always-valid p-values (mSPRT) | p-values that hold at every moment; Optimizely's Stats Engine implements this (Johari et al., arXiv:1512.04922) | Wider intervals; needs more data than a fixed test for the same effect |
+| Group-sequential / alpha spending | Pre-declared interim looks (e.g., at 25/50/75/100% of sample) with adjusted thresholds per look | Must fix the look schedule in advance |
+| Fixed horizon | One read at the pre-declared sample floor | No early stop except for guardrail harm |
+
+Decision rules:
+
+- **Know what your platform computes.** If the testing tool uses fixed-horizon stats (most ad platforms and homegrown dashboards do), the only valid reads are (a) the pre-declared read date and (b) an early kill for guardrail harm — which you accept may be a false alarm.
+- If the tool documents a sequential method (Optimizely, several modern engines), early calls at its stated confidence are legitimate. Log which regime applied in the ledger row.
+- Never extend a finished test "to see if it reaches significance." That is peeking in reverse and has the same inflation problem.
+
+---
+
+## Rule 3 — Novelty and Primacy Effects
+
+Both are threats to external validity (Kohavi, Tang & Xu, ch. 3; Sadeghi et al., arXiv:2102.12893):
+
+- **Novelty effect:** a change is initially intriguing — engagement spikes, then decays as users return to habit. First-week wins on visible UI changes, subject-line gimmicks, and new ad formats are the classic case. Note this is distinct from paid-social **creative fatigue**, which the creative-test protocol handles as a control-validity problem.
+- **Primacy effect:** the mirror image — experienced users initially do worse with a change (relearning cost), then improve. First-week losses on navigation, checkout-flow, and workflow changes may reverse.
+
+Detection and decision rules:
+
+1. **Plot the treatment effect by day.** A trending effect (up or down) means the point estimate at read time does not represent the long-run effect.
+2. **Compare early cohorts over time.** Take users first exposed on day 1–2 and track their treatment effect across the window; decay indicates novelty (Kohavi, Tang & Xu).
+3. Do not read habit-sensitive changes in under two full weeks.
+4. For changes intended to alter long-run behavior (pricing display, subscription flows, major redesigns), keep a **long-term holdout** — a small control group held for weeks or months — before promoting the lesson to memory (Sadeghi et al. 2021).
+5. New-user segments are novelty-immune (they have no prior habit): if the lift exists only for returning users and decays, suspect novelty.
+
+---
+
+## Rule 4 — Twyman's Law: Surprising Results Are Usually Errors
+
+"Any figure that looks interesting or different is usually wrong." Kohavi's teams found that extreme or shocking results were far more often instrumentation and design bugs than breakthroughs (Kohavi & Longbotham, *Unexpected Results in Online Controlled Experiments*, SIGKDD Explorations 2010; Kohavi, Tang & Xu, ch. 1).
+
+Before believing any surprising result — good or bad — run this checklist:
+
+1. **Sample ratio mismatch (SRM).** If the split was designed 50/50, check the actual counts with a chi-square test. Even a small skew (e.g., 50.2/49.8 at scale) signals broken assignment, redirects, or bot filtering, and **invalidates the experiment** (Kohavi, Tang & Xu).
+2. **Instrumentation.** Did tracking fire equally in both arms? Pixel/CAPI changes, consent banners, ad blockers, and redirect latency routinely create fake lifts.
+3. **Bots and outliers.** Robot traffic and a single whale order can flip a mean-based metric (Kohavi et al., *Seven Pitfalls*, KDD 2009). Re-read with bots excluded and revenue capped.
+4. **Attribution window and lag.** Conversions arriving after the read window undercount the newer arm.
+5. **Replicate.** The cheapest cure for an unbelievable win is rerunning the test. A true effect replicates; a bug or fluke usually does not.
+
+Ledger tie-in: surprising results enter the ledger as `retest` or `invalid` until this checklist passes — never straight to `win`.
+
+---
+
+## Rule 5 — Simpson's Paradox in Segment Reads
+
+A treatment can win in every segment yet lose overall — or win overall yet lose in every segment — whenever traffic is unevenly split across segments with different baseline rates. Kohavi documented this in real experiments, especially during **ramp-up**: results pooled across a 1%-traffic phase and a 50%-traffic phase weight the phases wrongly and can reverse the true winner (Kohavi & Longbotham, *Unexpected Results*, SIGKDD Explorations 2010).
+
+Decision rules:
+
+1. **Never pool across ramp phases.** Read only the data from the final allocation, or analyze phases separately.
+2. **Segments generate hypotheses, not shipping decisions** (Optimizely guidance). A post-hoc "it won on mobile!" read is both multiple-comparison-inflated and Simpson-vulnerable.
+3. Pre-register at most 2–3 segments that have a causal story. With 10 unplanned segments at α = 0.05, expect at least one false "significant" segment by chance alone.
+4. A segment finding ships only after a follow-up experiment targeted at that segment confirms it.
+
+---
+
+## Rule 6 — When A/B Testing Is Impossible (Low Traffic)
+
+Run the Rule 1 math first. **If the required sample takes more than ~8 weeks to collect, do not run the A/B test** — seasonality, fatigue, and drift will corrupt the read before it matures. Switch methods instead of lowering standards (CXL, *A/B Testing Alternatives*):
+
+| Method | What it is | Use when | Weakness |
+|---|---|---|---|
+| **Bigger swings** | Test radical page/offer changes, not button colors — larger true effects need far fewer conversions (Rule 1 table) | Always the first move on low traffic | Can't attribute the win to one element |
+| **Earlier signal metrics** | Read qualified clicks, form starts, call clicks instead of purchases | Conversion volume too low; see the Meta framework's budget reality check | Proxy may not correlate with revenue — validate periodically |
+| **Painted-door test** | Ship the button/link/offer promise only; measure clicks on the not-yet-built thing | Demand validation before building | Measures interest, not satisfaction; brief user apology/waitlist required |
+| **Sequential cohorts (pre/post)** | Run A for a period, then B; compare cohorts | Site-wide changes that can't be split | Time confounds (seasonality, promos, news) — never compare across a holiday boundary |
+| **Pre/post with controls (diff-in-diff / interrupted time series)** | Model the pre-period trend with an untouched control series (another page, region, or product line); measure deviation after the change | You have stable history and a comparable control | Needs multiple pre-period data points and a truly untouched control (ITS methodology: Hudson et al. 2019) |
+| **Geo experiments** | Assign matched regions to treatment/control; measure incrementality between them | Offline channels, brand spend, channels without user-level splits (Wayfair tech blog) | Needs enough comparable geos; spillover between regions |
+| **Qualitative + heuristic review** | Moderated user tests, session recordings, five-second tests | Understanding *why* before betting the traffic | Not a quantitative read; feeds hypotheses, not verdicts |
+
+Log all of these in the experimentation ledger with `confidence: low/medium` — quasi-experimental reads never earn the confidence of a randomized read, and their limitations field must name the confound risks.
+
+---
+
+## Rule 7 — Prioritization Scoring (ICE/RICE) and Its Failure Modes
+
+**ICE** (Sean Ellis): score Impact × Confidence × Ease, each 1–10. **RICE** (Sean McBride, Intercom): (Reach × Impact × Confidence) / Effort — adds Reach so a change on a high-traffic page outranks the same change on a dead page (Growth Method; Railsware).
+
+Known failure modes — correct for each explicitly:
+
+| Failure mode | What happens | Kai correction |
+|---|---|---|
+| Feelings dressed as integers | Three scorers, three different Impact/Confidence numbers | One named scorer per batch; score definitions written down; re-score quarterly |
+| Confidence inflation | Enthusiasm becomes a 9/10 confidence | Tie confidence to evidence tier: 10 = our own prior experiment; 7 = strong published evidence; 5 = qualitative signal; ≤3 = opinion. Opinion-only ideas cap at 3 |
+| Reach ignores intensity | One-time reach of 1M scores over daily reach of 1K power users | Score reach as exposures per quarter, not unique users |
+| No cost of delay | A time-sensitive idea scores the same as an evergreen one | Add a deadline flag outside the score; deadline items bypass rank order with owner approval |
+| Score worship | The spreadsheet decides; nobody re-examines inputs | Scores order the backlog; a human approves the run order (approval doctrine applies) |
+| Low-traffic blindness | Ease-heavy small tests win the ranking but can never reach a read | On low-traffic properties, weight Impact and Confidence over Ease — each test slot is expensive (CXL) |
+
+Given the base rates in the Core Thesis, Confidence is the highest-information input: calibrate it against your own ledger's historical win rate, not gut feel.
+
+---
+
+## Anti-Patterns (Quick Reject List)
+
+- Calling a test at p < 0.05 on day 2 of a planned 14-day run (Rule 2).
+- Shipping a first-week engagement spike on a visible UI change without a decay check (Rule 3).
+- Believing a 40% lift without an SRM and instrumentation check (Rule 4).
+- Shipping to mobile because a post-hoc mobile segment "won" (Rule 5).
+- Running a 30-week A/B test instead of switching methods (Rule 6).
+- A backlog where every idea has Confidence 8+ (Rule 7).
+- Pooling ramp-up data with full-allocation data (Rule 5).
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Loads this doc for |
+|---|---|
+| `knowledge/playbooks/experimentation-ledger.md` | The statistical meaning of `sample_floor`, `confidence`, and when `result` may be read as win/loss vs. inconclusive |
+| `knowledge/playbooks/creative-test-resolution-protocol.md` | Why its data floors are directional, and what lift sizes those floors can actually resolve (Rule 1 table) |
+| `knowledge/playbooks/meta-creative-testing-decision-framework.md` | Statistical grounding for the budget reality check and earlier-signal downgrade (Rules 1, 6) |
+| `kai-cro` / CRO recommendations | Whether a proposed test is readable on the site's traffic; which Rule 6 alternative to recommend instead |
+| `kai-retro` / 30-day content checks | Twyman screening and novelty screening before a winner feeds `knowledge/playbooks/what-works.md` |
+| Campaign planning / goals review | RICE scoring with the corrected confidence tiers when decomposing behind-pace goals into test backlogs |
+
+Approval doctrine: every live-channel action this doc informs — launching, stopping, extending, or scaling a test on a real ad account, site, or email list — requires human approval first. Statistical validity is necessary, never sufficient, to ship.
+
+---
+
+## Sources
+
+- Kohavi, Tang & Xu, *Trustworthy Online Controlled Experiments: A Practical Guide to A/B Testing* (Cambridge, 2020) — https://assets.cambridge.org/97811087/24265/frontmatter/9781108724265_frontmatter.pdf
+- Kohavi & Thomke, "The Surprising Power of Online Experiments," *Harvard Business Review* (2017) — https://hbr.org/2017/09/the-surprising-power-of-online-experiments
+- Kohavi & Longbotham, "Unexpected Results in Online Controlled Experiments," *SIGKDD Explorations* 12(2) (2010) — https://kdd.org/exploration_files/v12-02-8-UR-Kohavi.pdf
+- Crook, Frasca, Kohavi & Longbotham, "Seven Pitfalls to Avoid when Running Controlled Experiments on the Web," KDD 2009 — https://www.exp-platform.com/Documents/2009-ExPpitfalls.pdf
+- Kohavi et al., "Trustworthy Online Controlled Experiments: Five Puzzling Outcomes Explained," KDD 2012 — https://exp-platform.com/Documents/puzzlingOutcomesInControlledExperiments.pdf
+- Johari, Koomen, Pekelis & Walsh, "Peeking at A/B Tests: Why It Matters, and What To Do About It," KDD 2017 — https://doi.org/10.1145/3097983.3097992
+- Johari, Pekelis & Walsh, "Always Valid Inference: Bringing Sequential Analysis to A/B Testing," arXiv:1512.04922 — https://arxiv.org/abs/1512.04922
+- Miller, "How Not To Run an A/B Test" (2010) — https://www.evanmiller.org/how-not-to-run-an-ab-test.html
+- Molas, "Bayesian A/B testing is not immune to peeking" (2025) — https://www.alexmolas.com/2025/10/30/bayesian-ab-test-peeking.html
+- Sadeghi et al., "Novelty and Primacy: A Long-Term Estimator for Online Experiments," arXiv:2102.12893 — https://arxiv.org/pdf/2102.12893
+- Optimizely, "Simpson's Paradox: Discover possibilities with your segments, not shipping decisions" — https://support.optimizely.com/hc/en-us/articles/18208725352589-Simpson-s-Paradox-Discover-possibilities-with-your-segments-not-shipping-decisions
+- CXL, "A/B Testing Alternatives for Low-Traffic Websites" — https://cxl.com/blog/ab-testing-alternatives/
+- Wayfair Tech Blog, "How Wayfair Uses Geo Experiments to Measure Incrementality" — https://www.aboutwayfair.com/careers/tech-blog/how-wayfair-uses-geo-experiments-to-measure-incrementality
+- Hudson, Fielding & Ramsay, "Methodology and reporting characteristics of studies using interrupted time series design in healthcare," *BMC Medical Research Methodology* (2019) — https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6609377/
+- Growth Method, "ICE Framework" and "RICE Framework" — https://growthmethod.com/ice-framework/ · https://growthmethod.com/rice-framework/
+- Railsware, "How to Prioritize with the RICE Framework" — https://railsware.com/blog/rice-framework/

--- a/knowledge/frameworks/marketing-science/growth-metrics-and-pmf.md
+++ b/knowledge/frameworks/marketing-science/growth-metrics-and-pmf.md
@@ -1,0 +1,188 @@
+# Growth Metrics & PMF: Instrumentation, North Star Selection, and Fit Verification
+
+> **Use when:** Setting up measurement for a new product or channel, choosing a North Star Metric, deciding whether a business has product-market fit before recommending growth spend, reading a retention curve or cohort table, or building a stage-appropriate dashboard.
+>
+> This is the **measurement-architecture layer** underneath two operational playbooks. Metric formulas, SaaS benchmarks, and dashboard templates live there, not here:
+> - `knowledge/playbooks/saas-metrics-guide.md` — MRR waterfall, churn/NRR/CAC/LTV formulas, benchmarks by funding stage, board dashboard.
+> - `knowledge/playbooks/growth-loops-applied.md` — loop archetypes and loop-health measurement.
+
+---
+
+## Core Thesis: Measure Fit Before You Fund Growth
+
+Most growth-metric mistakes are sequencing mistakes: teams optimize acquisition metrics on a product that does not retain, or pick a revenue North Star that lags the customer value creating it. The correct order is (1) instrument the full funnel, (2) verify fit with behavior (retention curves), triangulated with sentiment (PMF survey), (3) only then select a North Star and scale the loops that feed it. Spending against a leaky product just measures the leak faster.
+
+---
+
+## 1. Pirate Metrics (AARRR) — Per-Stage Instrumentation
+
+Dave McClure introduced AARRR in his 2007 "Startup Metrics for Pirates" talk as an antidote to vanity metrics — five customer-lifecycle stages, each with its own conversion question (McClure 2007; Mind the Product).
+
+| Stage | Question | Example metrics | Instrument (events to log) | Classic failure |
+|---|---|---|---|---|
+| **Acquisition** | How do people find us? | Visits by channel, CTR, CPC, signup rate by source | UTM-tagged landing event, `signup_started`, `signup_completed` with source attribution | Reporting blended signups; channel mix hides which source retains |
+| **Activation** | Do they reach first value? | % of signups completing the key action within a timeframe (see activation examples in `saas-metrics-guide.md`) | `activation_event` — one named action, one deadline (e.g., "first project created within 24h") | Defining activation as "logged in" instead of a value moment |
+| **Retention** | Do they come back? | Cohort retention at the product's natural frequency, DAU/MAU, resurrection rate | Recurring `key_action` event with user + cohort date; never rely on logins | Measuring at the wrong frequency (daily retention for a monthly-use product) |
+| **Referral** | Do they bring others? | Invite rate, invite→signup conversion, viral/loop cycle metrics (owned by `growth-loops-applied.md`) | `invite_sent`, `invite_accepted`, artifact-share events | Counting shares without tracking whether shared artifacts convert |
+| **Revenue** | Do they pay? | Trial→paid, ARPU, expansion (formulas in `saas-metrics-guide.md`) | `checkout_started`, `subscription_created`, `upgrade`, `downgrade`, `cancel` | Celebrating top-line MRR while cohort revenue decays |
+
+Decision rules:
+
+1. **One metric per stage on the operating dashboard.** AARRR's job is diagnosis, not exhaustiveness — when growth slows, walk the stages in order using the diagnostic tree in `saas-metrics-guide.md` ("Growth is slowing").
+2. **Instrument before you optimize.** Every stage needs a named event with a timestamp and an attribution property. A stage you cannot segment by cohort is a stage you cannot diagnose.
+3. **Order of optimization is not the order of the acronym.** The RARRA critique (Mind the Product) holds: fix Retention and Activation before scaling Acquisition. Acquisition spend on an unretentive product buys churn.
+4. **Conversion rates between stages, not absolute counts.** Absolute counts are vanity by default; McClure's original point was that stage-to-stage conversion is what you can act on.
+
+---
+
+## 2. North Star Metric Selection
+
+A North Star Metric (NSM) is the single metric the whole company aligns on — defined in Amplitude's North Star Playbook (Cutler & Scherschligt) as a metric that (a) expresses the value customers get, (b) sits within the team's sphere of influence, and (c) leads revenue rather than reporting it.
+
+### The three-test selection method
+
+Run every candidate through all three. Two of three is a supporting metric, not a North Star.
+
+**Test 1 — Value proxy.** If this number goes up, did customers necessarily receive more value? "Weekly active users" fails for a product whose value is output, not visits; "messages sent" (Slack), "nights booked" (Airbnb), "weekly learners completing a lesson" pass because the metric *is* the value event, counted.
+
+**Test 2 — Leading, not lagging.** Revenue, MRR, and LTV are lagging outcomes — they confirm value that was delivered months ago. A good NSM predicts revenue ahead of time. Cutler's inversion test: "If you can move your North Star directly, it's probably not a good North Star" (Amplitude) — teams should move it only through **input metrics** (3–5 drivers they can act on directly, e.g., breadth × frequency × depth of the value action).
+
+**Test 3 — Counter-metric pairing.** Every NSM gets at least one paired metric measuring the damage its pursuit could cause. This is Andy Grove's paired-indicators principle from *High Output Management*: indicators steer attention like a bicycle steers where you look, so pair effect with counter-effect (Grove; Holistics).
+
+| North Star candidate | Gaming risk | Counter-metric to pair |
+|---|---|---|
+| Weekly active users | Notification spam inflates opens | Unsubscribe/notification-disable rate |
+| Content published per week | Volume over quality | 30-day winner rate (`what-works.md` feed) |
+| Trials started | Junk trials from broad ads | Trial→paid conversion |
+| Messages/actions per user | Dark-pattern engagement | Session-level task completion, churn |
+| Leads captured | Form-gating everything | Lead→qualified rate, bounce rate |
+
+### Disqualified candidates
+
+- **Revenue as NSM** — lagging (fails Test 2); acceptable only as the outcome the NSM is validated against.
+- **Cumulative anything** ("total registered users") — can never go down, so it cannot inform decisions; classic vanity metric (Amplitude, Cutler).
+- **Averages across mixed populations** — hide segment decay; use cohorted medians or rates.
+
+**Worked example.** A phone-led local-services client (KaiCalls fit profile): candidate NSM "calls answered" fails Test 1 (an answered spam call is not value). "Qualified calls converted to booked jobs per week" passes all three — it is the value event (Test 1), it leads revenue by weeks (Test 2), and it pairs with counter-metrics "missed-call rate" and "caller complaint rate" (Test 3). Inputs: call-answer rate, after-hours coverage, qualification accuracy.
+
+---
+
+## 3. The PMF Survey (Sean Ellis Test)
+
+### Protocol
+
+1. Ask users one question: **"How would you feel if you could no longer use [product]?"** — answers: *Very disappointed / Somewhat disappointed / Not disappointed*.
+2. Survey people who have **experienced the core product recently** (used it at least twice, within the last two weeks) — not raw signups, not only power users.
+3. Read the % answering "very disappointed." Rahul Vohra's Superhuman team treated ~40 responses as the floor for a meaningful read (First Round Review).
+4. Re-run quarterly and segment the result (by persona, plan, acquisition channel) — a blended score hides which segment has fit.
+
+### The 40% benchmark — origin
+
+Sean Ellis developed the method by running the question across the many startups he advised and benchmarked (roughly a hundred, per First Round) and observing a dividing line: companies above roughly **40% "very disappointed"** grew relatively easily with strong word-of-mouth; those below struggled to grow regardless of tactics (Ellis, pmfsurvey.com; Fitsignal). Superhuman is the canonical application: they started at 22%, segmented on why "somewhat disappointed" users held back, rebuilt the roadmap around the high-expectation user's objections, and reached 58% (Vohra, First Round Review 2019).
+
+### The critics — and how to use the test anyway
+
+The 40% rule is contested. Treat these as real limits, not footnotes:
+
+- **Response bias.** Only engaged users answer surveys; the disengaged already left. Buffer surveyed an ultra-engaged group, scored 78%, and the broader base still retained poorly (Fitsignal). Mitigation: sample by cohort, not by newsletter list, and report the response rate next to the score.
+- **The threshold is a heuristic, not a law.** 40% came from one practitioner's benchmark set; categories sit naturally higher (daily-use tools) or lower (infrequent-purchase products). A 38% is not failure and a 42% is not proof (Fitsignal; Learning Loop).
+- **Self-report vs behavior.** People overstate attachment. A 45% score with a retention curve declining to zero is a false positive — behavior wins (Lenny's Newsletter; leanb2bbook).
+- **It can lag segment shifts.** Scores routinely drop as a company broadens beyond its early-adopter niche — that is a targeting signal, not necessarily product decay (Fitsignal).
+
+**Kai decision rule:** the survey is a cheap **leading, directional** instrument — use it pre-retention-data and for segment discovery (the Superhuman "somewhat disappointed" mining move). Never certify PMF on the survey alone; certify on the retention curve below. If survey and retention disagree, trust retention.
+
+---
+
+## 4. Retention-Curve Reading
+
+Plot, per acquisition cohort, the % of users still doing the **key value action** at its **natural frequency** over time. Both choices matter: measuring logins instead of the value action, or daily retention for a weekly-use product, produces unreadable curves.
+
+### The three shapes
+
+| Shape | Reading | Action |
+|---|---|---|
+| **Declines toward zero** | No PMF — nobody finds durable value | Stop scaling acquisition; return to activation and product work |
+| **Flattens at a plateau** | PMF for the segment on the plateau — a group finds long-term value (Balfour) | Identify who plateaus; concentrate acquisition on lookalikes of that segment |
+| **Newer cohorts flatten higher than older ones** | Fit is improving — product/onboarding changes are working | Keep shipping; protect whatever changed between cohorts |
+
+Brian Balfour's rule: a retention curve that flattens means you have probably found product-market fit *for some market* — the plateau height tells you how big the fit is (brianbalfour.com). Casey Winters sharpens it into a two-part test: **PMF = a flattened retention curve of the key action at its natural frequency, plus month-over-month growth in new users** (caseyaccidental.com). The second clause matters — a flat curve over a shrinking top of funnel is a lifestyle niche, not fit that supports growth.
+
+Decision rules:
+
+1. **Where the curve flattens is the fit boundary.** A curve flattening at 30% means 70% of acquisitions were mis-targeted or mis-activated — that is the acquisition-quality and activation backlog.
+2. **A cliff at a specific period is an event, not a trend.** Month-3 cliffs often map to billing renewals or onboarding-credit expiry; diagnose the event before touching the product.
+3. **Wait for the curve to mature.** Early points on a young cohort's curve are noisy; do not call flattening until at least 2–3× the natural frequency has elapsed. Novelty effects inflate early points (see `experiment-rigor.md`, Rule 3).
+
+---
+
+## 5. Cohort Analysis Basics
+
+The revenue-cohort worked example and "what to look for" list live in `saas-metrics-guide.md` — this section owns the reading method.
+
+- **Cohort types.** Acquisition cohorts (grouped by start date) answer *when* retention changed; behavioral cohorts (grouped by an action taken, e.g., "invited a teammate in week 1") answer *why* — compare a behavior cohort's curve against the baseline to find candidate activation levers (Amplitude). Behavior cohorts generate hypotheses; confirm causality with an experiment (`experiment-rigor.md`).
+- **N-day vs unbounded retention.** N-day (bounded) retention counts a user as retained only if active in period N exactly — right for products with an expected usage rhythm (most SaaS) and for onboarding reads. Unbounded retention counts a user as retained if they return *at any point after* period N — right for infrequent, transactional, or consumer products (Amplitude; Lenny's Newsletter/Berezovsky). Declare which one a chart uses; the two are not comparable.
+- **Reading the triangle.** In the standard cohort table (rows = cohorts, columns = periods): read **across a row** to see one cohort age (find the flattening point); read **down a column** to compare cohorts at the same age (find whether the product is improving); the **diagonal** is calendar time (find seasonality and one-off events).
+- **Pitfalls.** (1) Partial periods — the newest cohort's latest cell is incomplete; grey it out. (2) Small cohorts — percentage swings on a 12-user cohort are noise; set a minimum cohort size before reading. (3) Mixed populations — a "stable" blended curve can hide a decaying segment offset by a growing one; segment before concluding. (4) Averaging across cohorts of different ages weights old cohorts arbitrarily.
+
+---
+
+## 6. Which Metrics Matter by Stage
+
+Stage benchmarks (growth rates, churn, LTV:CAC by funding stage) live in `saas-metrics-guide.md`; this table is about **which instruments to even look at**.
+
+| | Pre-PMF | Growth (post-PMF) | Scale |
+|---|---|---|---|
+| **Primary question** | Does anyone need this repeatedly? | Which loops compound fastest? | Is the machine efficient and durable? |
+| **Metrics that matter** | Retention curve of the key action; activation rate; PMF survey score by segment; qualitative "why" | North Star + input metrics; per-stage AARRR conversion; loop cycle metrics (`growth-loops-applied.md`); CAC payback by channel | NRR, LTV:CAC, burn multiple, Rule of 40 (`saas-metrics-guide.md`); counter-metrics; brand/category share |
+| **Metrics to ignore** | Revenue growth, CAC optimization, share of voice — premature | Blended vanity totals; board-only lagging metrics as daily steering | Raw signup counts; any un-cohorted average |
+| **PMF instruments** | Survey (leading) + early cohort curves | Curve flattening confirmed; watch newer-cohort plateaus as segments broaden | Per-segment retention — PMF erodes segment by segment, and NRR is the early warning |
+| **Failure mode** | Scaling spend on an unflattened curve | North Star gaming without counter-metrics | Optimizing lagging metrics while leading indicators decay |
+
+---
+
+## Anti-Patterns (Quick Reject List)
+
+- Recommending acquisition spend before seeing a retention curve (Core Thesis).
+- A North Star the team can move directly, or with no counter-metric paired (Section 2).
+- Certifying PMF from a survey score alone, or from a survey sent only to fans (Section 3).
+- Calling a curve "flat" before 2–3 natural-frequency periods have elapsed (Section 4).
+- Comparing an N-day retention chart against an unbounded one (Section 5).
+- A single blended dashboard number where a cohorted, segmented read exists (Sections 4–5).
+- Stage mismatch: Rule-of-40 talk pre-PMF, or PMF-survey theater at scale (Section 6).
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Loads this doc for |
+|---|---|
+| `knowledge/playbooks/saas-metrics-guide.md` users (dashboards, investor reporting) | The framework layer above the formulas: NSM selection, stage-appropriate metric choice, cohort reading method |
+| `knowledge/playbooks/growth-loops-applied.md` / growth-loop design | Verifying fit (Sections 3–4) before designing loops; NSM + inputs as the loop's output metric |
+| `kai-audit` / marketing audits, growth plans | The stage table (Section 6) to match recommendations to the client's actual stage; refusing acquisition recommendations pre-fit |
+| `kai-cro` / CRO work | Activation-metric definition (Section 1) and behavior-cohort hypothesis generation (Section 5) |
+| Goals & weekly CMO review (`scripts/harness_cli.py goals`) | Choosing goal KPIs that pass the three NSM tests and carry a counter-metric |
+| `knowledge/playbooks/growth-hacker-first-hire-os.md` | What the first growth hire should instrument, in what order |
+| Audit provenance rule | Every retention %, survey score, or cohort figure in client-facing work must come from collected data (`harness/references/audit-data-provenance.md`) — never from this doc's examples |
+
+Approval doctrine: this doc informs analysis and recommendations only. Any live-channel action it motivates — launching surveys to a client's user base, changing ad spend, modifying tracking on a production site — requires human approval first.
+
+---
+
+## Sources
+
+- Dave McClure, "Startup Metrics for Pirates: AARRR!" (2007 talk) — https://www.youtube.com/watch?v=irjgfW0BIrw
+- Mind the Product, "AARRR vs RARRA: Pirate Metrics Explained" — https://www.mindtheproduct.com/aarrr-vs-rarra-pirate-metrics-explained/
+- Amplitude, *The North Star Playbook* (John Cutler & Jason Scherschligt) — https://info.amplitude.com/rs/138-CDN-550/images/Amplitude-The-North-Star-Playbook.pdf
+- Amplitude, "What Makes a Good vs Bad North Star Metric" — https://amplitude.com/blog/good-bad-north-star-metric
+- Amplitude, "About the North Star Framework" — https://amplitude.com/books/north-star/about-north-star-framework
+- Andrew Grove, *High Output Management* — paired-indicators principle; summary: Holistics, "Beware What You Measure: The Principle of Pairing Indicators" — https://www.holistics.io/blog/beware-what-you-measure-the-principle-of-pairing-indicators/
+- Sean Ellis & GoPractice, Product/Market Fit survey — https://pmfsurvey.com/
+- First Round Review, "How Superhuman Built an Engine to Find Product-Market Fit" (Rahul Vohra, 2019) — https://review.firstround.com/how-superhuman-built-an-engine-to-find-product-market-fit/
+- Fitsignal, "The Sean Ellis 40% Test: The Ultimate Guide" (origin, Buffer 78% case, threshold critique) — https://www.fitsignal.com/blog/sean-ellis-40-percent-test
+- Learning Loop, "Product-Market Fit Survey Guide" — https://learningloop.io/plays/product-market-fit-survey
+- Brian Balfour, "The Never Ending Road To Product Market Fit" — https://brianbalfour.com/essays/product-market-fit
+- Casey Winters, "Casey's Guide to Finding Product/Market Fit" — https://www.caseyaccidental.com/p/caseys-guide-to-finding-product-market-fit
+- Lenny's Newsletter, "How to know if you've got product-market fit" — https://www.lennysnewsletter.com/p/how-to-know-if-youve-got-productmarket
+- Olga Berezovsky (Lenny's Newsletter), "How to measure cohort retention" (N-day vs unbounded) — https://www.lennysnewsletter.com/p/measuring-cohort-retention
+- Amplitude, "What Is Cohort Retention Analysis" — https://amplitude.com/explore/analytics/cohort-retention-analysis
+- Lean B2B, "How to Evaluate Product/Market Fit by Analyzing Retention Cohorts" — https://leanb2bbook.com/blog/retention-cohorts-product-market-fit/

--- a/knowledge/playbooks/community-as-channel.md
+++ b/knowledge/playbooks/community-as-channel.md
@@ -1,0 +1,230 @@
+# Community as a Growth Channel
+
+> **Use when:** Deciding whether to invest in community as a growth motion, diagnosing a stalled community, or wiring an existing community into pipeline and content loops. This is the strategy layer — when community is the right motion, community-market fit, the member journey, growth loops, and measurement.
+>
+> **Read alongside:** [`channels/community-building.md`](../channels/community-building.md) (tactics: platform tables, channel architecture, rituals, moderation — that doc owns execution detail), [`playbooks/growth-distribution-engine.md`](./growth-distribution-engine.md) (community is 1 of 19 traction channels — test it like any other), [`playbooks/growth-loops-applied.md`](./growth-loops-applied.md) (loop mechanics), [`playbooks/referral-and-word-of-mouth.md`](./referral-and-word-of-mouth.md) (referral program mechanics).
+
+Community is the slowest channel to compound and the easiest to fake with vanity metrics. It is also one of the few channels a competitor cannot copy in a quarter. The failure mode is symmetric: companies that need community skip it because it's slow, and companies that don't need it launch a Slack because a board member mentioned Notion. This doc is the decision framework for telling those apart — and for running community as a channel with loops and numbers, not as a cost center with vibes.
+
+---
+
+## 1. The Decision: Right Motion vs Money Pit
+
+Community building appears in the 19 traction channels of *Traction* (Weinberg & Mares) — meaning it competes for test budget against every other channel and must win on evidence, not sentiment. Run this gate before any community investment.
+
+### Community is the right motion when ≥2 of these hold
+
+| Fit signal | Why it works | Examples of the pattern |
+|------------|--------------|------------------------|
+| **Practice-based product** | Users are building a *skill or craft* with the product; peers accelerate mastery and mastery drives retention | Design tools, dev tools, no-code builders, fitness programs, trading platforms, creator tools |
+| **Identity-dense niche** | Members see the topic as part of who they are; belonging is the draw, product is the context | Homelab, mechanical keyboards, ultrarunning, indie SaaS founders, specialty coffee |
+| **High-touch B2B with a definable role** | Buyers share a job title with real professional loneliness; peer benchmarking is worth more than your content | RevOps, community managers themselves (CMX), CISOs, heads of remote |
+| **Template/extension surface** | The product improves when members share artifacts (templates, plugins, configs) — contribution has built-in utility | Notion templates, Figma plugins, game mods |
+| **Support-heavy product** | Question volume is high and answers are reusable; peer answers deflect tickets and become searchable content | Complex SaaS, hardware, open source |
+
+### Community is a money pit when
+
+- **The product is transactional or low-frequency.** Nobody joins a community for their tax filing tool or one-time purchase. There is no ongoing practice to discuss.
+- **The category is spend-based, not identity-based.** People buy it but don't identify with it. Test: would a user voluntarily put the topic in their social bio? If not, expect a ghost town.
+- **You cannot name the non-product conversation.** If every plausible thread is about your product (bugs, feature requests), you want a support forum, not a community. Support forums are fine — just budget them as support, not growth.
+- **Leadership wants pipeline in one quarter.** Community pipeline lags quarters behind investment — plan on 6-12 months as a working assumption, not a measured benchmark (see §7 on lag). If the mandate is this-quarter leads, run outbound or paid instead ([`playbooks/demand-generation.md`](./demand-generation.md)).
+- **No human owner exists.** See §8. A community with no host is a liability: dead channels are publicly visible negative social proof, worse than no community.
+- **A great community already owns the niche.** If a subreddit or independent forum is the acknowledged home, participate there (see social-native strategy, §5) instead of fragmenting it. You will lose a head-to-head against an incumbent community.
+
+**Decision rule:** ≥2 fit signals AND zero money-pit conditions → proceed to a community-market-fit test (§2). Otherwise, put the budget into a channel with faster feedback and revisit at the next stage gate ([`playbooks/marketing-by-stage.md`](./marketing-by-stage.md)).
+
+The base rates justify caution: in CMX's 2025 Community Industry Report, ROI remains the #1 reported challenge for community professionals, and only 24% can quantify their community's value in financial terms — though nearly half of those who can report over $1M in impact ([CMX 2025](https://www.cmxhub.com/community-industry-report)). Community pays, but mostly for teams that picked the right motion and instrumented it.
+
+---
+
+## 2. Community-Market Fit
+
+Community-market fit is the community analog of product-market fit: a specific group of people repeatedly shows up, talks to *each other* (not just to you), and would object loudly if you shut it down. David Spinks (*The Business of Belonging*, CMX founder) frames the method as **constraining the group first**: run the smallest viable community for one tight segment, iterate cheaply until it self-sustains, and only then spend on growth ([Spinks](https://www.amazon.com/Business-Belonging-Community-Competitive-Advantage/dp/1119766125)).
+
+### The constrained pilot (8-12 weeks)
+
+1. **Pick one segment, not "our users."** One role, one skill level, one use case. 20-40 hand-picked people, personally invited.
+2. **Declare the business objective before launch.** Use Spinks' SPACES taxonomy — Support, Product (feedback/ideation), Acquisition, Contribution, Engagement/retention, Success — and pick **one** primary driver. A community asked to do all six does none.
+3. **Run minimum programming** (§4) with the founder or a senior operator hosting. No paid tooling, no public launch, no logo contest.
+4. **Measure member-to-member ratio weekly** (conversations not involving staff / total conversations).
+
+### Verdicts at week 8-12
+
+| Signal | Verdict |
+|--------|---------|
+| Member-to-member ratio >50% and rising; members start threads unprompted; someone organizes something you didn't plan | **Fit.** Open the doors, add programming, assign the owner. |
+| Activity exists but every thread starts with staff; ratio <30% | **No fit yet.** Change the segment or the format (maybe this audience wants events, not chat) before spending more. |
+| Silence within 2 weeks of staff stepping back | **No fit.** Archive gracefully, tell the pilot members why, log the lesson. Do not "relaunch" the same design. |
+
+Treat this exactly like a Bullseye middle-ring channel test ([`playbooks/growth-distribution-engine.md`](./growth-distribution-engine.md)): cheap, time-boxed, with a kill criterion written down before you start.
+
+---
+
+## 3. The Member Journey: Lurker → Contributor → Leader
+
+Participation inequality is a law, not a bug. Nielsen's 90-9-1 rule: in most online communities ~90% of members lurk, ~9% contribute occasionally, ~1% produce most of the activity ([NN/g](https://www.nngroup.com/articles/participation-inequality/)). You cannot repeal it — Nielsen's own guidance is to *shift* the curve slightly, not fight it. Design one ladder rung per tier:
+
+| Stage | Who they are | What moves them up one rung | What kills the move |
+|-------|--------------|----------------------------|---------------------|
+| **Lurker** (~90%) | Reads, gets value silently, may still buy | Zero-effort participation: polls, emoji reactions, "reply with one word" prompts; direct @-welcome within 48h of joining | Walls of text, "introduce yourself with your full story" as first ask, guilt-tripping lurkers |
+| **Contributor** (~9%) | Answers questions, shares occasionally | Recognition within hours of first post (named, specific); being *asked* for their take on a thread in their wheelhouse | First post ignored (the single biggest drop-off); pedantic moderation of early attempts |
+| **Leader** (~1%) | Starts threads, welcomes others, organizes | Real responsibility: mod status, event hosting, early access, direct founder line; public credit | Treating them as free labor with no input on direction; hiring a stranger over them |
+
+Two operating rules from the distribution:
+
+- **First-reply SLA is the highest-ROI intervention.** A first-time poster who gets a substantive reply within hours is the contributor pipeline; one who gets silence lurks forever. Staff the SLA (target <4h, see metrics in [`channels/community-building.md`](../channels/community-building.md)) before staffing anything else.
+- **Count lurkers as reached, not failed.** Lurkers read, learn, and buy. Measure their consumption (readers per thread) separately from contribution.
+
+For teams that want a finer-grained model, the open-source **Orbit Model** formalizes this as orbit levels (observers → users → contributors → advocates) with "love" (involvement) and "reach" (influence) per member ([Orbit Model](https://github.com/orbit-love/orbit-model)). Useful for instrumenting who is drifting inward vs outward.
+
+---
+
+## 4. Programming Cadence
+
+Programming is the schedule of things that happen whether or not conversation happens organically. Communities die from irregularity faster than from small size.
+
+**The minimum viable cadence (pilot through ~500 members):**
+
+| Cadence | Item | Owner |
+|---------|------|-------|
+| Daily | Welcome new members; enforce first-reply SLA | Community owner (human) |
+| Weekly | One recurring anchor ritual (wins thread, weekly question) — same day, same format, every week | Owner hosts; Kai drafts |
+| Biweekly-monthly | One live event: AMA, workshop, member spotlight call | Owner or member-leader hosts |
+| Monthly | One contribution ask (challenge, template swap, feedback thread mapped to your SPACES objective) | Owner |
+
+Rules:
+
+1. **Consistency beats volume.** One ritual that fires 52 weeks straight builds more habit than five that fire sporadically. Add a second ritual only when the first runs without staff prompting.
+2. **Programming is a hypothesis.** Each ritual serves a journey transition (§3) or the SPACES objective (§2). A ritual nobody engages with for 4 consecutive runs gets redesigned or cut — log it in the experimentation ledger ([`playbooks/experimentation-ledger.md`](./experimentation-ledger.md)).
+3. **Kai drafts, humans host.** Kai can generate the full programming calendar, prompt copy, event run-of-show, and recap posts. A human posts and hosts them (§8). Full ritual menu with formats: [`channels/community-building.md`](../channels/community-building.md).
+
+---
+
+## 5. Platform Selection
+
+The per-platform comparison table (Discord vs Slack vs Circle vs Facebook Groups vs Discourse, size sweet spots, effort) lives in [`channels/community-building.md`](../channels/community-building.md). This section owns the *strategic* axis that table doesn't: what each platform class does for growth.
+
+| Class | Growth property | Trade-off | Choose when |
+|-------|----------------|-----------|-------------|
+| **Owned forum** (Discourse, Circle w/ public spaces) | Threads are **indexable** — every answered question becomes a permanent SEO/AEO asset feeding the UGC loop (§6) | Slower-feeling, higher setup effort, needs critical mass to not look dead | Support-heavy or practice-based products with high question volume; long-horizon SEO strategy |
+| **Real-time chat** (Discord, Slack) | Highest intimacy and speed; best for belonging and identity-dense niches | Content is **unindexed and evaporates** — knowledge created today is unfindable in a month; zero SEO value | Community whose value is relationships and real-time help, not a knowledge base |
+| **Social-native** (subreddit, Facebook Group, LinkedIn Group) | Built-in discovery — the platform brings members | Rented land: algorithm and policy risk, limited data, weak ownership | Existing niche gravity is on that platform; or participating in an incumbent community instead of building (§1) |
+
+Decision rules:
+
+- **If the UGC → SEO loop is part of the thesis, you need an indexable surface.** Chat-only communities forfeit that loop entirely. A common hybrid: Discord for belonging + a public forum or docs-integrated Q&A for the searchable layer.
+- **Rented vs owned is a stage decision, not a religion.** Early: go where the audience already is. Once community-market fit is proven and the member list is an asset, migrate the core to an owned surface — and plan for most nominal members not to cross (only the engaged migrate; that is the point — size the new home on engaged-member count, not the total roster).
+- **Never split a small community across platforms.** One home until the single home is unambiguously active.
+
+---
+
+## 6. Community-Led Growth Loops
+
+A community that doesn't feed an acquisition or revenue loop is a retention amenity — sometimes worth it, but budget it honestly. Three loops turn community into a channel. Loop mechanics and modeling: [`playbooks/growth-loops-applied.md`](./growth-loops-applied.md).
+
+### Loop 1: UGC → SEO/AEO
+
+```
+Member asks question → community answers → indexable thread ranks in search
+and gets cited by answer engines → searcher lands on thread → joins community
+(or enters product funnel) → asks/answers more questions
+```
+
+Requirements: indexable platform (§5), question-shaped demand in the niche, moderation that keeps answer quality high. Compounding is slow (quarters) but the asset is durable and, unlike your blog, scales with member count instead of headcount. Distill top threads into proper articles via the content pipeline — community threads are Information Gain raw material ([`frameworks/aeo-ai-search/aeo-ai-search-playbook-2026.md`](../frameworks/aeo-ai-search/aeo-ai-search-playbook-2026.md)).
+
+### Loop 2: Member referral
+
+```
+Member gets value → invites a peer ("you should be in here") → peer joins →
+peer gets value → invites their peer
+```
+
+The strongest version is unincentivized — the invite is a gift, not a commission. Instrument "how did you hear about us?" on join. Amplifiers: member-only artifacts worth sharing (templates, benchmarks, salary surveys), public member wins, invite-a-peer prompts after high-value moments. Formal incentive mechanics belong to [`playbooks/referral-and-word-of-mouth.md`](./referral-and-word-of-mouth.md).
+
+### Loop 3: Events → content → members
+
+```
+Community hosts event (AMA, workshop) → recording + recap become public
+content → content distributed on social/SEO → viewers join community
+→ larger community attracts better speakers/attendees
+```
+
+This is the loop where community and the events channel compound each other — event mechanics: [`channels/events-experiential.md`](../channels/events-experiential.md); repurposing mechanics: [`playbooks/transcript-to-content-ops.md`](./transcript-to-content-ops.md).
+
+**Loop discipline:** pick ONE loop as primary, matched to your SPACES objective and platform class. Instrument it end to end before adding a second.
+
+---
+
+## 7. Measurement
+
+Two tiers: health metrics (is the community alive?) and business metrics (is it a channel?). Health metrics with thresholds — DAM, member-to-member ratio, first-reply time, 30-day retention — live in [`channels/community-building.md`](../channels/community-building.md). This section owns the channel tier.
+
+### Engaged-member rate (the denominator that matters)
+
+```
+engaged_member_rate = members with ≥1 contribution or event attendance in 30d / total members
+```
+
+Total member count is the vanity metric of community — it only ever goes up. Report engaged members as the real size, and expect the 90-9-1 distribution (§3) when setting targets: for a general community, ~10% engaged is normal, not failure. Track the *trend*; a falling engaged rate with rising totals means you're filling a leaky room.
+
+### Community-sourced and community-influenced pipeline
+
+- **Community-sourced:** first identifiable touch was the community (joined before any other tracked touch). Requires joining community identity to CRM — by email match, or with signal tooling such as [Common Room](https://www.commonroom.io/solutions/community/) that merges community activity with pipeline data.
+- **Community-influenced:** account had ≥1 engaged community member active before or during the deal cycle. Always report sourced and influenced as separate numbers; influenced will be several times larger and mixing them destroys credibility.
+- Add **self-reported attribution** ("how did you hear about us?") as a third lens — it consistently surfaces community/word-of-mouth touches that click-based attribution misses.
+
+Secondary value lines, mapped to SPACES: support deflection (tickets answered by peers × cost per ticket), retention delta, product feedback shipped, content produced from community threads.
+
+### Attribution caveats (state these in every report)
+
+1. **Selection effect ≠ causal effect.** Community members who buy more may have joined *because* they were already high-intent. Comparing member vs non-member conversion or retention without controlling for intent overstates the effect. Present these as correlations; a holdout or cohort-matched comparison is the honest upgrade.
+2. **Community is multi-touch by nature.** A member who lurked for 8 months then converted via a paid ad is invisible to last-click. Use sourced/influenced/self-reported side by side; never let one model be "the" number ([`playbooks/analytics-attribution.md`](./analytics-attribution.md)).
+3. **Lag makes early reads worthless.** Do not judge community pipeline before ~2 quarters of data; do not extrapolate from the first enthusiastic cohort.
+4. **The industry mostly fails at this** — ROI is the #1 challenge in CMX's 2025 report and most practitioners cannot quantify impact ([CMX 2025](https://www.cmxhub.com/community-industry-report)). Instrument sourced pipeline from day one of the pilot, or accept that the channel will lose every budget fight.
+
+**Kai Data Provenance Rule applies:** any client-facing community report must run the collector, declare its mode, and source every number. Engaged-member rates and pipeline figures come from platform exports and CRM joins, never from estimates.
+
+---
+
+## 8. Staffing Reality: Kai Drafts, Humans Host
+
+Community is the one channel in this repo that cannot be run by the agent. Belonging requires a person members recognize; an obviously synthetic host reads as astroturfing and poisons trust — and undisclosed automated personas violate the Instruction Contract outright.
+
+**Division of labor:**
+
+| Kai does (drafting, analysis) | Human owner does (live channel) |
+|-------------------------------|--------------------------------|
+| Programming calendars, ritual prompts, event run-of-shows | Posts them, hosts events, is present daily |
+| Welcome-message and recap drafts | Sends/personalizes them; builds actual relationships |
+| Thread → article distillation through the content pipeline + gates | Approves and attributes correctly |
+| Engagement analytics, journey-stage reports, pipeline joins | Judgment calls: moderation, conflicts, member disputes |
+| Member-leader candidate lists from activity data | The ask, the trust, the ongoing leader relationship |
+
+Rules:
+
+- **No community without a named human owner** who has hours budgeted for it (near-daily presence pre-scale; the scaling ratios and mod structure live in [`channels/community-building.md`](../channels/community-building.md)). "Marketing owns it" is not an owner.
+- **Approval doctrine:** every message Kai drafts for a live community surface is a live-channel action — human approval required before posting, per repo doctrine and [`harness/references/social-automation-rules.md`](../../harness/references/social-automation-rules.md). Automated posting into a community without disclosure is a Stop condition.
+- **Budget honestly:** the true cost of community is the owner's salary-hours, not the platform fee. If those hours don't exist, the answer to §1 is "not yet" regardless of fit signals.
+
+---
+
+## How This Maps Into Kai
+
+- **`kai-growth-plan` / channel selection** (`playbooks/growth-distribution-engine.md` flow) — loads §1-2 when community appears in the Bullseye outer ring: fit gate, pilot design, kill criteria.
+- **`kai-launch` / `campaign-orchestration.md`** — loads §4 and §6 when a launch or campaign includes a community component: programming calendar drafts, loop selection, event-repurposing chain.
+- **`kai-write` / `kai-social` content tasks** — community prompt and recap drafts follow §8 division of labor; every draft is gated and human-approved before it touches a live surface (`harness/skill-contracts/social-post.yaml`).
+- **`kai-weekly-audit` / `kai-monthly-audit` reviews** — load §7 for engaged-member rate and sourced-vs-influenced pipeline definitions, with the attribution caveats stated verbatim; provenance rules apply to every number.
+- **`kai-audit` / growth audits** — §1 money-pit conditions are the checklist for flagging an existing community as a cost sink; §2 verdict table for relaunch-vs-archive recommendations.
+- Tactical execution (platform setup, channel architecture, moderation, ritual formats) always defers to [`channels/community-building.md`](../channels/community-building.md).
+
+---
+
+## Sources
+
+- Jakob Nielsen — "Participation Inequality: The 90-9-1 Rule for Social Features," Nielsen Norman Group: https://www.nngroup.com/articles/participation-inequality/
+- CMX — 2025 Community Industry Trends Report: https://www.cmxhub.com/community-industry-report (landing page now serves the latest edition; 2025 PDF: https://43963373.fs1.hubspotusercontent-na1.net/hubfs/43963373/2025%20CMX%20Community%20Industry%20Report.pdf)
+- David Spinks — *The Business of Belonging* (SPACES model, community-market fit via constrained groups): https://www.amazon.com/Business-Belonging-Community-Competitive-Advantage/dp/1119766125
+- CMX — "SPACES Framework in Action": https://www.cmxhub.com/blog/spaces-framework-in-action-match-your-community-work-to-business-goals
+- Gabriel Weinberg & Justin Mares — *Traction* (community building as 1 of 19 channels, Bullseye Framework): https://www.amazon.com/Traction-Startup-Achieve-Explosive-Customer/dp/1591848369
+- The Orbit Model (open-source member-journey framework: orbit levels, love, reach): https://github.com/orbit-love/orbit-model
+- Common Room — community signals to pipeline (tooling for community-CRM joins): https://www.commonroom.io/solutions/community/

--- a/knowledge/playbooks/demand-side-research.md
+++ b/knowledge/playbooks/demand-side-research.md
@@ -1,0 +1,219 @@
+# Demand-Side Customer Research Playbook
+
+> **Use when:** You need to understand why customers actually buy (or don't) before building an offer, writing messaging, planning a campaign, or diagnosing a conversion problem. This is the research layer that feeds `/kai-offer-builder` Phase 1, persona selection, and every "what should the copy say?" question.
+
+---
+
+## The Core Shift: Supply-Side vs Demand-Side
+
+Supply-side research starts from the product and asks "who wants this?" — demographics, feature preferences, willingness-to-pay surveys. Demand-side research starts from an actual purchase and asks "what caused this?" It treats buying as a **switch**: the customer fires an old way of doing things and hires a new one to make progress in a specific struggling circumstance (Christensen's Jobs-to-be-Done theory; Moesta and Engle's *Demand-Side Sales 101*).
+
+The canonical demonstration is Christensen's milkshake case: a fast-food chain's demographic segmentation and taste research failed to move milkshake sales; interviewing actual buyers revealed morning commuters "hiring" the shake to occupy a long boring drive — competing against bananas, bagels, and donuts, not other milkshakes ([Rewired Group case study](https://therewiredgroup.com/case-studies/milkshakes/), [HBR](https://hbr.org/2016/09/know-your-customers-jobs-to-be-done)).
+
+Decision rule: **when the question is "why do people buy / why don't they buy," run this playbook. When the question is "how many / which segment is bigger," use analytics and market sizing instead.** Demand-side research is causal and qualitative; it does not produce percentages.
+
+---
+
+## Method 1: The Switch Interview
+
+A switch interview reconstructs the timeline of one real purchase (or cancellation) like a documentary, not a survey. Developed by Bob Moesta and Chris Spiek at the Re-Wired Group ([jobstobedone.org](https://jobstobedone.org/); [Business of Software talk](https://businessofsoftware.org/talks/bob-moesta-and-chris-spiek-uncovering-the-jobs-to-be-done/)). You are not asking for opinions about the product; you are extracting the causal chain of events that produced the purchase.
+
+### Who to interview
+
+- **Actual buyers only.** People who completed a real switch: bought, upgraded, cancelled, or churned. Never prospects speculating about what they *would* do — stated intent is not evidence of demand.
+- **Recent purchases.** Recent enough that the interviewee can recall concrete details (the day, the trigger, who else was involved). Practitioner heuristic: weeks to a few months old, not years.
+- **Sample size:** treat this as saturation-based qualitative work. Practitioners typically run interviews until the same timeline patterns and forces repeat (often under a dozen per segment). Do not report interview findings as statistics.
+- **Recruitment is outreach.** Emails or calls inviting customers to interviews touch a live channel — human approval required before sending, per the approval doctrine. Compensate for time; disclose who you are.
+
+### The timeline to reconstruct
+
+Every switch follows the same arc (Moesta/Spiek's buying timeline — [jobstobedone.org](https://jobstobedone.org/)):
+
+```
+FIRST THOUGHT ──▶ PASSIVE LOOKING ──▶ [Event 1] ──▶ ACTIVE LOOKING ──▶ [Event 2] ──▶ DECIDING ──▶ BUY ──▶ CONSUME/USE
+"maybe I could      aware, not          trigger      investing time      forcing       tradeoffs                first use,
+ do better"         investing                        comparing options   deadline      resolved                 satisfaction
+```
+
+- **First thought** — the moment the idea enters their head; it "creates space in the brain for the solution to fall into." Find the struggling moment behind it (*Demand-Side Sales 101*).
+- **Passive looking** — problem-aware, solution-unaware. "If something comes by, I'll look at it." No time invested.
+- **Event 1** — something happens that converts browsing into work: a breakage, a deadline, a price change, a boss's demand. Name the event.
+- **Active looking** — solution-aware. Comparing options, building a consideration set. Ask what was IN the set and what was ruled OUT and why.
+- **Event 2** — usually time-based: the thing that forced "I need to decide now."
+- **Deciding/buying** — the final tradeoffs, who signed off, what almost stopped it.
+- **Consuming** — did the product deliver the progress? This is where churn stories start.
+
+Interviewer implication: the same visible action means different things per stage. A demo request during passive looking is curiosity; during deciding it is a final check. Never read intent off behavior without the timeline position.
+
+### Interview mechanics (practitioner heuristic: budget 60-90 minutes per interview)
+
+1. **Anchor on the purchase, then rewind.** Start at the moment of purchase ("walk me through the day you bought it") and work backward to first thought. Memory retrieves better backward from a concrete event.
+2. **Demand concrete detail.** "What day of the week was it? Where were you? Who was with you? What was playing?" Vague answers signal reconstructed rationalization; specifics signal real memory. The published mattress interview shows the technique at full length ([jobstobedone.org mattress interview](https://jobstobedone.org/radio/the-mattress-interview-part-one/)).
+3. **Break down every abstract word.** "It was just easier" → "Easier than what? What did you do the time before?" Abstractions hide the job.
+4. **Chase the alternatives.** What did they use before? What else did they consider — including doing nothing and non-obvious substitutes (the milkshake competes with the banana)?
+5. **Two interviewers when possible** — one drives, one tracks the timeline for gaps.
+6. **Record and transcribe with consent.** Transcripts become sourced verbatims (see Method 3). Recording without consent is a stop condition.
+
+### Question bank (adapt, don't script)
+
+- "Tell me about the moment you first thought 'maybe there's something better than what I'm doing.' What was happening that day?"
+- "Between first thinking about it and actually looking — how long? What were you doing about it in that gap?" (measures passive looking)
+- "What happened that made you start seriously comparing options?" (Event 1)
+- "What almost stopped you from buying?" (anxiety — the highest-value question in the interview)
+- "What did you have to give up or stop doing to use this?" (habit)
+- "If this product disappeared tomorrow, what would you go back to?" (real competitive set)
+
+---
+
+## Method 2: The Four Forces of Progress
+
+Every switch is decided by four forces (Moesta/Spiek — [The Four Forces](https://jobstobedone.org/the-four-forces/); [progress-making forces diagram](https://jobstobedone.org/radio/unpacking-the-progress-making-forces-diagram/)):
+
+```
+        PROMOTING CHANGE                      BLOCKING CHANGE
+  ┌──────────────────────────┐         ┌──────────────────────────┐
+  │ 1. PUSH of the situation │         │ 3. ANXIETY of the new    │
+  │    (pain with status quo)│   VS    │    (what could go wrong) │
+  │ 2. PULL of the new       │         │ 4. HABIT of the present  │
+  │    (promise of progress) │         │    (switching cost,      │
+  └──────────────────────────┘         │     comfort, inertia)    │
+                                       └──────────────────────────┘
+```
+
+**Decision rule: a switch happens only when Push + Pull outweigh Anxiety + Habit.** Two consequences most marketing misses:
+
+1. **Pull alone rarely wins.** Feature/benefit copy is all Pull. If there is no Push (no struggling moment) the prospect stays put no matter how good the product looks. Diagnose weak demand as missing Push before rewriting benefit copy.
+2. **The blocking forces are silent.** Buyers rarely volunteer anxiety and habit; interviews must dig for them. Intercom applied this to onboarding: new users arrive carrying anxiety and old habits that the first-run experience must actively defuse ([Intercom on the four forces](https://www.intercom.com/blog/four-forces-user-onboarding/)).
+
+### Force → intervention map
+
+| Force found in research | Marketing/offer intervention |
+|---|---|
+| Strong Push, weak awareness | Problem-naming content; agitate the struggling moment in their own words (top of funnel) |
+| Weak Push | Requalify the segment — you may be selling to people without the struggle; do not manufacture fake urgency |
+| Strong Pull, stalled deals | Blocking forces dominate — find the anxiety/habit, don't add more benefits |
+| Anxiety (performance: "will it work for me?") | Proof assets, case studies (`/kai-case-study`), demos, guarantees (`/kai-offer-builder` Phase 3e) |
+| Anxiety (personal: "will I look stupid?") | De-risk the buyer socially: pilot framing, "how to sell this internally" assets |
+| Habit (workflow embedded in old tool) | Migration services, onboarding concierge, switch-cost reducers in the offer stack |
+| Habit (data/contract lock-in) | Import tools, buyout offers, contract-end timing for outreach |
+
+---
+
+## Method 3: Voice-of-Customer Mining (sourced verbatims only)
+
+Interviews are the gold source but are slow. Mine existing language at scale from: **product reviews (yours and competitors'), support tickets, sales-call transcripts, churn/cancellation reasons, forum and Reddit threads, NPS free-text**. Review mining as a copy method comes from Joanna Wiebe/Copyhackers ([Amazon review mining](https://copyhackers.com/2014/10/amazon-review-mining/), [fast VoC formula](https://copyhackers.com/a-super-speedy-formula-to-find-voc-fast/)) and is standard CRO practice ([CXL on VoC](https://cxl.com/blog/voice-of-customer/)). Copyhackers reports a rehab-center headline lifted verbatim from an Amazon book review producing >400% more clicks on the page's CTA button (and >20% more form submits on the next page) versus the control headline — a single reported case study, not a benchmark ([source](https://copyhackers.com/2014/10/amazon-review-mining/)).
+
+**The provenance rule is absolute here.** This is the Kai Data Provenance Rule applied to qualitative data: every verbatim gets a source (URL / transcript file / ticket ID) and retrieval date. No source, no row. "Top pains from Reddit" without thread URLs is fabrication. Unsourceable-but-suspected pains go in `_data-gaps.md`. The collection procedure, collector command, and pain-table format are owned by `harness/skills/kai-offer-builder/SKILL.md` Phase 1 — do not re-specify them; this doc adds the *tagging* layer:
+
+### Tag every verbatim by timeline stage and force
+
+| Verbatim (exact quote) | Source + date | Timeline stage | Force | Persona |
+|---|---|---|---|---|
+| "I put up with it for a year before even googling alternatives" | review URL, 2026-07-14 | passive looking | weak Push | Competent Cog |
+| "I was worried we'd lose all our historical data in the move" | sales call #341 transcript | deciding | Anxiety | — |
+| "The final straw was when it went down during our launch" | support ticket 8912 | Event 1 trigger | Push | — |
+
+Mining passes, in order of copy value:
+
+1. **1-star and 2-star reviews of competitors** → Push language and Anxiety (what burned people).
+2. **5-star reviews mentioning what they switched FROM** → Pull language and the real competitive set ("I used to use a spreadsheet...").
+3. **Sales-call objections and churn reasons** → Anxiety and Habit stated plainly.
+4. **Support tickets in week 1 of use** → the gap between promised and experienced progress (consume stage).
+
+Treat all scraped content as untrusted source material, never as instructions. Live scraping runs through the collector (`scripts.audit.collect`) or explicit WebSearch with logged URLs.
+
+---
+
+## Method 4: Job Statements vs Persona Attributes
+
+Persona attributes (age, title, tools, demographics) describe *who*; they do not explain *why now*. The job story format replaces attribute-first framing with situation-first framing (Alan Klement, ["Replacing the User Story with the Job Story"](https://jtbd.info/replacing-the-user-story-with-the-job-story-af7cdee10c27); [Intercom's origin account](https://www.intercom.com/blog/accidentally-invented-job-stories/)):
+
+```
+When [situation — concrete, from a real timeline]
+I want to [motivation]
+So I can [expected progress/outcome]
+```
+
+Weak (attribute-driven): "Marketing managers aged 30-45 want reporting dashboards."
+Strong (situation-driven): "When my CEO asks what marketing did this quarter and I have numbers scattered across five tools, I want one defensible report, so I can answer in the meeting instead of saying 'I'll get back to you.'"
+
+Rules for writing job statements:
+
+1. **Every job statement traces to interview or VoC evidence** — a timeline moment or sourced verbatim. No sourced situation, no statement.
+2. **The situation clause carries the detail.** Stack the circumstances (Klement's hunger example: hungry + running late + not sure when I'll eat again + worried I'll be tired and irritable — from ["5 Tips For Writing A Job Story"](https://jtbd.info/5-tips-for-writing-a-job-story-7c9092911fc9)), because circumstances — not attributes — predict the hire.
+3. **One statement per struggling moment.** Do not merge distinct triggers into one mega-job.
+4. **Solution-free.** "I want to export to Excel" is a feature request; "I want numbers I can defend" is a job.
+
+**This does not retire Kai's personas.** `knowledge/personas/_persona-index.md` owns emotional positioning — core frustrations, hooks, "this feels rigged" psychology — and each persona file separates observed insight from hypothesis. Use them together: the **job statement** supplies the causal situation and timing; the **persona** supplies the voice, worldview, and hook style for the piece that targets that situation. Map each job statement to a persona (or the client's own from `MARKETING.md`) exactly as `/kai-offer-builder` Phase 2 does for pains.
+
+---
+
+## Feeding Outputs Forward: Offer Construction and Messaging
+
+Demand-side research is only worth running if the outputs land in downstream artifacts:
+
+### Into offer construction (`/kai-offer-builder`)
+
+- **Sourced pains → pain table.** Every Push verbatim is a pain-table row candidate with its source column already filled. Hand the tagged verbatim table directly to Phase 1.
+- **Pull language → Dream Outcomes (Phase 2).** Write dream outcomes in the buyers' own switch language, not marketing language.
+- **Anxiety inventory → guarantee and proof design (Phase 3e).** The guarantee should neutralize the top anxieties found in interviews — that is what "list the top 3 buyer fears, reverse each into a promise" consumes.
+- **Habit inventory → stack components.** Migration help, onboarding concierge, import tools: each named habit becomes a candidate solution in Phase 3b, tagged `[sourced: #n]`.
+- **Value Equation inputs.** Perceived Likelihood and Effort & Sacrifice scores should cite interview evidence, not designer intuition.
+
+### Into messaging and funnel design
+
+| Timeline stage of the audience | Content that fits | Kai surface |
+|---|---|---|
+| Pre-first-thought / passive looking | Problem-naming content in Push verbatim language; persona-hook content | `/kai-write` blog/social, persona index |
+| Active looking | Comparison pages, alternatives content, evaluation criteria in their words | SEO/AEO content, `/kai-landing-page` |
+| Deciding | Proof, guarantees, objection-handling, "sell it internally" assets | `/kai-case-study`, landing page, sales enablement |
+| Post-purchase (consume) | Onboarding that defuses anxiety + habit (Intercom's four-forces onboarding) | Email lifecycle |
+
+Message-match rule: headlines built from mined verbatims beat headlines written from imagination — but any performance claim about a specific test needs its own measured result, never a borrowed benchmark (Evidence-Led Operating Rule in `knowledge/playbooks/conversion-rate-optimization.md`).
+
+---
+
+## Anti-Patterns
+
+- **Interviewing prospects about the future.** "Would you buy X?" produces politeness, not demand data. Interview completed switches only.
+- **Focus groups.** Group dynamics destroy timeline reconstruction. One buyer, one timeline.
+- **Paraphrasing verbatims into marketing-speak** during mining — you destroy the asset you came for. Quote exactly; tag; use.
+- **Inventing frequency.** "80% of interviewees said..." from 6 interviews is fabrication-by-arithmetic. Report "5 of 6 interviews" with the interview IDs, or say nothing quantitative.
+- **All-Pull messaging into a no-Push market.** If research finds no struggling moment, the honest output is a fit warning, not louder benefit copy.
+- **Skipping the blocking forces.** A pipeline full of stalled "interested" prospects is an anxiety/habit problem; adding more Pull makes it worse (eager sellers, stony buyers).
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Loads this doc for |
+|---|---|
+| `/kai-offer-builder` (`harness/skills/kai-offer-builder/SKILL.md`) | Phase 1 pain mining hands off to this method when the user has customers to interview or transcripts/tickets to mine; force-tagged verbatims feed the pain table, dream outcomes, and guarantee design |
+| `knowledge/personas/_persona-index.md` | Job statements pair with persona hooks — situation from here, voice from there |
+| `/kai-brief` / `/kai-write` | Timeline-stage table above decides awareness stage and which force the copy works on |
+| `/kai-cro` (`knowledge/playbooks/conversion-rate-optimization.md`) | Tier 4-5 evidence (message testing, interviews, sales calls, tickets) — this doc is the method behind those tiers |
+| `/kai-landing-page`, `/kai-case-study` | Anxiety inventory → objection handling and proof selection |
+| `/kai-reddit-listen` + `scripts/reddit_monitor/` | Ongoing passive VoC mining after the initial study; digests feed the verbatim table |
+| `harness/references/audit-data-provenance.md` | Governs every verbatim, source log, and `_data-gaps.md` entry produced here |
+
+Approval doctrine: interview recruitment outreach, incentive payments, and any publishing of customer quotes (which may also need the customer's written permission) require human approval before touching a live channel.
+
+---
+
+## Sources
+
+- Jobs-to-be-Done (Moesta/Spiek), switch interviews and buying timeline — https://jobstobedone.org/
+- The Four Forces of Progress — https://jobstobedone.org/the-four-forces/
+- Unpacking the Progress-Making Forces Diagram — https://jobstobedone.org/radio/unpacking-the-progress-making-forces-diagram/
+- The Mattress Interview (full published switch interview) — https://jobstobedone.org/radio/the-mattress-interview-part-one/
+- Moesta & Spiek, "Uncovering the Jobs to be Done" (Business of Software) — https://businessofsoftware.org/talks/bob-moesta-and-chris-spiek-uncovering-the-jobs-to-be-done/
+- Bob Moesta & Greg Engle, *Demand-Side Sales 101* (2020) — https://www.goodreads.com/book/show/55345571-demand-side-sales-101
+- Clayton Christensen et al., *Competing Against Luck* (2016); milkshake case — https://therewiredgroup.com/case-studies/milkshakes/
+- Christensen, Hall, Dillon & Duncan, "Know Your Customers' 'Jobs to Be Done'," HBR (Sept 2016) — https://hbr.org/2016/09/know-your-customers-jobs-to-be-done
+- Alan Klement, "Replacing the User Story with the Job Story" — https://jtbd.info/replacing-the-user-story-with-the-job-story-af7cdee10c27
+- Alan Klement, "5 Tips For Writing A Job Story" — https://jtbd.info/5-tips-for-writing-a-job-story-7c9092911fc9
+- Intercom, "How we accidentally invented Job Stories" — https://www.intercom.com/blog/accidentally-invented-job-stories/
+- Intercom, "Improve your user onboarding with Jobs-to-be-Done insights" — https://www.intercom.com/blog/four-forces-user-onboarding/
+- Joanna Wiebe / Copyhackers, "Review Mining for Customer Research" — https://copyhackers.com/2014/10/amazon-review-mining/
+- Copyhackers, "A super-speedy formula to find VoC fast" — https://copyhackers.com/a-super-speedy-formula-to-find-voc-fast/
+- CXL, "How to Use Voice of Customer Research to Boost Conversions" — https://cxl.com/blog/voice-of-customer/

--- a/knowledge/playbooks/messaging-architecture.md
+++ b/knowledge/playbooks/messaging-architecture.md
@@ -1,0 +1,204 @@
+# Messaging Architecture: The Messaging Stack
+
+> **Use when:** Building or auditing a company's messaging from scratch — deciding the category frame, writing the strategic narrative, setting positioning, and cascading it into a homepage hierarchy. Load this before any messaging engagement that spans more than one asset. For single-asset work, go straight to the owning doc (see cross-links).
+
+Retrieval baseline: 2026-07-16. Verify category-creation statistics and vendor claims against current sources before client-facing use.
+
+---
+
+## The Stack
+
+Messaging is four layers of decisions, each constraining the next. Work top-down when building; audit bottom-up when diagnosing (a weak headline is usually a symptom of a missing layer above it).
+
+```
+LAYER 1: CATEGORY FRAME        ← what market are we in? (existing / reframed / new)
+LAYER 2: STRATEGIC NARRATIVE   ← what change in the world makes us matter?
+LAYER 3: POSITIONING           ← why us vs the real alternatives, for whom?
+LAYER 4: MESSAGE HIERARCHY     ← what does each slot on the page say?
+────────────────────────────────
+VERIFICATION: MESSAGE TESTING  ← does a stranger in the ICP get it?
+```
+
+**The core rule:** every lower layer must be derivable from the layer above it. If the homepage headline can't be traced back to a positioning claim, and the positioning can't be traced to the category frame, the messaging will read as inconsistent even when each asset is individually fine.
+
+---
+
+## Layer 1: Category Frame
+
+The category is the mental folder buyers file you into. It sets the competitors you're compared against, the price band, and the features assumed by default. Three moves, in increasing order of cost and risk (April Dunford's three positioning styles — see Sources):
+
+| Move | What it is | When to pick it | Cost/risk |
+|------|-----------|-----------------|-----------|
+| **1. Compete in an existing category** | "We're a CRM, and here's why we win" | Category is understood, growing, and you can win on a dimension buyers already value | Lowest. You inherit demand and buyer education |
+| **2. Reframe / subsegment** | "We're the CRM for law firms" or shift the comparison set ("answering service" → "AI receptionist") | You lose head-to-head in the broad category but dominate a segment or a redefined comparison | Medium. Requires evidence the segment self-identifies |
+| **3. Create a new category** | Name and evangelize a market that doesn't exist yet ("subscription economy") | Product genuinely doesn't fit any existing folder AND you have years of runway to educate the market | Highest. See caveats below |
+
+### Category creation: the evidence, with caveats
+
+The headline numbers are real but easy to misread:
+
+- **HBR (Yoon & Deeken):** of Fortune's 100 fastest-growing U.S. companies 2009–2011, the 13 that were instrumental in creating their categories accounted for **53% of incremental revenue growth and 74% of incremental market-cap growth**. Caveat: this samples companies that were *already among the fastest-growing* — it says category creators who succeed win big, not that category creation usually succeeds.
+- **Play Bigger (Ramadan, Peterson, Lochhead, Maney):** analysis of VC-backed U.S. tech startups founded 2000–2015 found "category kings" capture roughly **76% of the category's market cap**, on a **6–10 year** timeline. Caveats: the analysis has no denominator of failed category-creation attempts (survivorship bias), and the book's exemplars are outliers (Apple, Salesforce, Uber, Airbnb).
+- **Dunford's practitioner caveat:** category creation means proving the market deserves to exist *and then* winning it — it takes money, time, and patient investors, so it is realistic mainly for well-funded companies; claiming a segment of an existing market gets most of the benefit at a fraction of the cost.
+
+**Decision rule:** default to move 1 or 2. Recommend category creation only when (a) the product fails the "existing folder" test in customer interviews — buyers cannot name what it replaces, (b) the client has multi-year runway and executive commitment, and (c) leadership accepts that published success rates for category creation do not exist. Say so in the deliverable. Never cite the 53%/74%/76% figures as odds of success.
+
+---
+
+## Layer 2: Strategic Narrative
+
+The strategic narrative is the company-level story used in sales decks, manifestos, keynote talks, and founder content. The canonical structure is Andy Raskin's five-element analysis of Zuora's "subscription economy" deck:
+
+1. **Name the undeniable change in the world.** Not your product — an external shift already underway ("buyers now prefer recurring services over ownership"). It must be verifiable by the prospect from their own experience. A fabricated or self-serving "shift" is the most common failure; if the prospect doesn't already half-believe it, the narrative collapses.
+2. **Show winners and losers.** The change creates stakes: companies that adapt win, those that don't lose. This converts "interesting" into "urgent" without attacking the prospect directly.
+3. **Tease the Promised Land.** The desirable future state the prospect can reach — described as an outcome for *them*, not as your product. The Promised Land must be hard to reach alone, otherwise no purchase follows.
+4. **Position capabilities as "magic gifts" for reaching it.** Only now does the product appear, and only as the bridge over named obstacles.
+5. **Present proof you can deliver.** Named customers who reached the Promised Land, before/after evidence, third-party validation. (Proof claims fall under the Kai Data Provenance Rule — source every number.)
+
+**Coupling rule with Layer 1:** the "change in the world" IS the argument for your category frame. Zuora's change (subscription economy) justified its category (subscription management). If your narrative's change doesn't logically require your category to exist, one of the two layers is wrong.
+
+**Where it applies:** sales decks, manifesto/about pages, launch keynotes, investor decks, founder LinkedIn content. Homepages borrow the *conclusion* of the narrative, not the full arc — see Layer 4.
+
+---
+
+## Layer 3: Positioning
+
+Positioning is the reasoned argument for why a specific segment should pick you over their real alternatives. The component order matters (Dunford — each component is derived from the previous one):
+
+```
+COMPETITIVE ALTERNATIVES  → what would they do without you?
+      ↓                     (include "do nothing", spreadsheets, hire someone, ask AI)
+UNIQUE ATTRIBUTES         → what do you have that the alternatives provably lack?
+      ↓
+VALUE (+ PROOF)           → what buyer outcome does each attribute enable?
+      ↓
+BEST-FIT SEGMENT          → who cares most about that value and buys fastest?
+      ↓
+MARKET CATEGORY           → the frame (Layer 1) that makes the value obvious
+```
+
+The full workflow, evidence ledger (`alternative` / `unique_capability` / `value` / `proof_source` / `confidence`), positioning-statement formula, and customer-language mining method are owned by **`knowledge/playbooks/brand-positioning.md`** — do the work there, bring the output here. Do not ship `hypothesis`-confidence positioning as live copy without a test plan.
+
+**Coupling rules:** the competitive alternatives list must match the losers implied by the narrative (Layer 2). The category component must equal the Layer 1 decision — if positioning work reveals the value is only obvious in a different frame, revisit Layer 1 rather than forcing it.
+
+---
+
+## Layer 4: Message Hierarchy (Homepage)
+
+Users routinely leave pages within 10–20 seconds; a page earns extended attention only if it makes its value clear inside roughly the first 10 seconds (Nielsen Norman Group). The hero therefore carries the whole stack in compressed form. Each slot answers one question:
+
+| Slot | Must answer | Source layer | Rules |
+|------|-------------|--------------|-------|
+| **Eyebrow** (small text above headline) | "What is this / what category?" | Layer 1 | 2–6 words. Literal, not clever: "AI receptionist for law firms". This frees the headline from having to explain the category |
+| **Headline** | "Why should I care?" — the #1 value claim | Layer 3 (top value) | One claim, not three. Concrete outcome > abstraction. May use a Perception Engineering destabilizer for cold traffic (see cross-link) |
+| **Subhead** | "How, and for whom?" — mechanism + segment | Layer 3 (attribute + segment) | 1–2 sentences. Names the unique attribute that makes the headline credible, and signals the best-fit segment so wrong-fit visitors self-select out |
+| **Proof** | "Why should I believe you?" | Layer 3 (proof column) | Named customers, sourced metrics, third-party badges. Provenance rule applies: no number without a collector source |
+| **CTA** | "What do I do next, and is it safe?" | Buyer stage | Match commitment level to traffic temperature; permission mechanics owned by `perception-engineering.md` |
+
+Below the fold, sections descend the messaging hierarchy defined in `brand-positioning.md` (category message → value → feature → proof), one level per section.
+
+**Coupling rule:** the eyebrow states the Layer 1 category; the headline is the strongest Layer 3 value claim; the subhead contains the Layer 3 unique attribute; proof is the Layer 3 proof column. If any hero slot cannot be traced to a stack layer, it's decoration — cut it.
+
+Full variant-generation and headline/subhead/CTA test-matrix workflow: **`knowledge/playbooks/landing-page-messaging-workflow.md`**. Persuasion mechanics (destabilizers, context shifts, permission): **`knowledge/frameworks/content-copywriting/perception-engineering.md`**.
+
+---
+
+## Coherence: The Agreement Audit
+
+Run this after drafting, and quarterly on live messaging. Any NO means fix the upper layer first.
+
+| # | Check | Question |
+|---|-------|----------|
+| 1 | Narrative → Category | Does the named change in the world logically require this category to exist? |
+| 2 | Narrative → Positioning | Are the narrative's "losers" using the positioning's competitive alternatives? |
+| 3 | Positioning → Category | Is the category component of the positioning identical to the Layer 1 decision? |
+| 4 | Positioning → Hierarchy | Can every hero slot be traced to a named positioning component? |
+| 5 | Hierarchy → Narrative | Is the headline a compressed Promised-Land outcome, not a feature? |
+| 6 | Cross-channel | Do sales deck, homepage, and ads use the same category noun and the same #1 value claim? |
+| 7 | External | Do customers describe you (calls, reviews) in the frame you chose? |
+
+---
+
+## Worked Example: One Product Through All Four Layers
+
+Product: **KaiCalls** (AI phone receptionist for small law firms — the repo's standing example; disclose Kai ownership in any client-facing use per the KaiCalls Fit Rule).
+
+**Layer 1 — Category frame: REFRAME (move 2).** The existing folder is "answering service" — a folder that carries assumptions of human operators, per-minute billing, message-taking without qualification. KaiCalls loses in that folder (no human warmth) but wins in a reframed one: "AI receptionist," which shifts the comparison set from answering services to *missed calls and voicemail*. Not category creation: "AI receptionist" already exists as a searched, understood term; we adopt the frame, we don't have to build it.
+
+**Layer 2 — Strategic narrative.**
+- *Change:* clients now expect an immediate answer at first contact — after-hours callers reach a competitor before a callback happens.
+- *Winners/losers:* firms answering every call at first ring capture the intake; firms routing after-hours calls to voicemail fund their competitors' growth.
+- *Promised Land:* every call answered, qualified, and summarized — without hiring night staff.
+- *Magic gifts:* AI answering, intake capture, intelligent routing, call summaries.
+- *Proof:* named client call-log evidence (collector-sourced only).
+
+**Layer 3 — Positioning** (output of the `brand-positioning.md` workflow): competitive alternatives = voicemail, traditional answering services, hiring after-hours staff, doing nothing. Unique attributes = answers 24/7, captures structured intake, routes by matter type, writes summaries. Value = fewer lost clients from unanswered calls; lower-cost coverage than staffing. Segment = small law firms losing after-hours intake calls. Category = AI receptionist (matches Layer 1 — check 3 passes). Losers in Layer 2 are voicemail/answering-service users — check 2 passes.
+
+**Layer 4 — Homepage hierarchy:**
+
+| Slot | Copy | Traced to |
+|------|------|-----------|
+| Eyebrow | "AI receptionist for law firms" | Layer 1 frame + segment |
+| Headline | "Stop losing clients to voicemail" | Layer 3 top value; compressed Promised-Land outcome (check 5 passes) |
+| Subhead | "KaiCalls answers after-hours calls, captures intake details, and routes each matter to the right attorney — so callers never reach a competitor first." | Layer 3 unique attributes + Layer 2 stakes |
+| Proof | "[Named client] went from [X]% missed calls to [Y]% in [period]" — placeholders until collector-sourced | Layer 3 proof column |
+| CTA | "Hear a sample call" (zero-commitment, cold traffic) | Buyer stage |
+
+Every slot traces to a layer; the audit passes. Note what agreement bought: the sales deck's change, the homepage headline, and the ad hook are all the same claim at different compression levels — a buyer moving between channels hears one story.
+
+---
+
+## Message Testing Methods
+
+Test the stack before scaling spend on it. Match the method to the layer:
+
+| Method | What it validates | Layer | Mechanics | Limits |
+|--------|-------------------|-------|-----------|--------|
+| **5-second test** | Comprehension of the hero: "What is this? Who's it for? Why care?" | Layer 4 (and Layer 1 frame recognition) | Show the hero for 5 seconds to people outside the project, then ask the three questions unaided. Coined by Christine Perfetti (mid-2000s); a Journal of Usability Studies validity study supports it for first-impression measurement | Measures clarity, not persuasion or purchase intent. Recall degrades past 5 seconds into analysis mode. Panelists outside your ICP can verify clarity but not relevance |
+| **ICP audience panels** (e.g., Wynter) | Clarity, relevance, and value of messaging with people matching the actual buyer profile | Layers 3–4 | Panel of verified professionals filtered to job title/industry/size scores copy on clarity/relevance/value (Likert) plus open-ended "what is this offering / what's missing" responses; 12–48h turnaround | Stated response, not behavior. Panel quality and targeting determine everything; small n gives themes, not statistics |
+| **Close-rate / win-loss feedback** | Whether the narrative and positioning hold up under real buying pressure | Layers 1–3 | Instrument sales calls: does the "change" land or get pushback? Which alternatives do prospects name unprompted? Track win rate and objection themes before vs after the messaging change, and interview both wins and losses | Slow (a sales cycle per read). Confounded by everything else that changed; treat directionally unless volume is high |
+| **Live A/B test** | Conversion effect of Layer 4 variants | Layer 4 | Split traffic across hero variants per `landing-page-messaging-workflow.md` | Needs traffic volume; tests slots, not strategy. **Approval doctrine: deploying variants to a live site or ad account requires human approval** |
+
+**Sequence rule:** run comprehension (5-second) before resonance (panel) before behavior (close rate, A/B). A message that fails clarity will fail everything downstream, and the fix is cheap at the top. If a Layer 4 test keeps failing after two revisions, the defect is usually in Layers 1–3 — escalate to a stack audit instead of writing a third headline.
+
+---
+
+## Anti-Patterns
+
+- **Tagline-first messaging.** Writing the clever line before Layers 1–3 exist. (See the positioning stack in `brand-positioning.md` — work bottom-up there, top-down here.)
+- **Category creation as default advice.** Citing the 53%/74%/76% figures without the survivorship caveat. Reframing a segment captures most of the upside at a fraction of the cost.
+- **The fake "change in the world."** A trend invented to flatter the product. If the prospect can't confirm the change from their own experience, the deck reads as a pitch, not a narrative.
+- **Three headlines in one.** Hero headlines carrying category + value + feature simultaneously. One claim per slot; the eyebrow exists so the headline doesn't have to explain what you are.
+- **Testing persuasion with a clarity tool.** A 5-second test cannot tell you a message converts — only that it's understood. Don't ship on a passed 5-second test alone.
+- **Layer drift.** Sales runs one category noun, the website another, ads a third. Check 6 of the agreement audit exists for this; run it quarterly.
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Loads this doc for |
+|-------------|--------------------|
+| `kai-brand` / brand strategy engagements | The full stack build; Layer 3 executes via `brand-positioning.md` |
+| `kai-write` / `kai-landing-page` (`landing-page.yaml` contract) | Layer 4 slot definitions and coupling rules before drafting hero copy |
+| `kai-audit` / CRO audits | The Agreement Audit as the messaging-coherence section; KaiCalls Fit Rule applies to phone-led targets |
+| Sales-deck and manifesto requests | Layer 2 five-element structure; proof slides fall under the Data Provenance Rule (`harness/references/audit-data-provenance.md`) |
+| Message-testing engagements | The method-to-layer table; live A/B deployment requires human approval per the approval doctrine |
+
+Gate pipeline applies to all output copy: Four U's (12/16 pages, 10/16 ads), banned-word check, and the skill contract for the target format.
+
+---
+
+## Sources
+
+- Eddie Yoon & Linda Deeken, "Why It Pays to Be a Category Creator," HBR March 2013 — https://hbr.org/2013/03/why-it-pays-to-be-a-category-creator
+- Eddie Yoon, Christopher Lochhead & Nicolas Cole, "The Difference Between a First Mover and a Category Creator," HBR 2019 (cites the Play Bigger 76% category-king figure) — https://hbr.org/2019/11/the-difference-between-a-first-mover-and-a-category-creator
+- Ramadan, Peterson, Lochhead, Maney, *Play Bigger* (2016; 76% category-king market-cap share, 6–10 yr timeline) — https://www.amazon.com/Play-Bigger-Dreamers-Innovators-Dominate/dp/0062407619
+- Andy Raskin, "The Greatest Sales Deck I've Ever Seen" — https://medium.com/the-mission/the-greatest-sales-deck-ive-ever-seen-4f4ef3391ba0
+- Zuora, "Best Sales Deck Ever" (the deck itself) — https://www.zuora.com/resource/best-sales-deck-ever/
+- April Dunford, *Obviously Awesome* (positioning components and three category styles) — https://www.aprildunford.com/books
+- PANBlast interview with April Dunford, "It's a Crapshoot: Category Creation & Positioning" (cost/feasibility caveats) — https://www.panblastpr.com/resources/category-creation-positioning-april-dunford/
+- STFO, "Stop Trying To Create A Category. Own A Segment Instead." — https://www.stfo.io/articles/category-creation/
+- Nielsen Norman Group, "How Long Do Users Stay on Web Pages?" — https://www.nngroup.com/articles/how-long-do-users-stay-on-web-pages/
+- Gronier, "Measuring the First Impression: Testing the Validity of the 5 Second Test," Journal of Usability Studies 12(1) — https://www.guillaumegronier.com/resources/2016_JUS_Gronier.pdf
+- Smashing Magazine, "Five-Second Testing: Taking a Closer Look at First Impressions" (method history: term coined by Christine Perfetti, mid-2000s) — https://www.smashingmagazine.com/2023/12/five-second-testing-case-study/
+- Wynter, "How to Conduct Message Testing" (clarity/relevance/value panel method) — https://wynter.com/post/message-testing

--- a/knowledge/playbooks/newsletter-growth-economics.md
+++ b/knowledge/playbooks/newsletter-growth-economics.md
@@ -1,0 +1,192 @@
+# Newsletter Growth Economics
+
+> **Use when:** Deciding where to spend the next dollar (or hour) of newsletter growth effort, pricing what a subscriber is worth, auditing an existing list's acquisition mix, or diagnosing why a fast-growing list monetizes badly.
+>
+> **Adjacent docs (cross-link, don't duplicate):** send mechanics, platform selection, suppression, and deliverability monitoring live in `knowledge/channels/email-lifecycle.md`. Edition planning and production live in `harness/skills/kai-newsletter/SKILL.md` (that skill loads this doc for growth strategy). Compliance floor for any outreach-adjacent tactic: `harness/references/cold-email-rules.md`.
+
+---
+
+## Operating Rule: Benchmarks Are Hypotheses
+
+Every number below is either **cited** (source in `## Sources`, mostly vendor-published — treat as Tier-6 evidence per the evidence tiers in `knowledge/checklists/cro-audit-checklist.md`) or **marked HEURISTIC**. Vendor benchmarks size the market; only your own cohort data prices your subscribers. Never quote a benchmark in client-facing work without the source and retrieval date, and never substitute a benchmark for missing account data (Kai Data Provenance Rule applies to any audit using these numbers).
+
+Core identity to keep in view the whole time:
+
+```
+Subscriber profit = (Revenue per subscriber per year × retention years) − Cost per subscriber
+```
+
+Growth channels differ on BOTH terms. A cheap channel that delivers subscribers who never open loses to an expensive channel that delivers readers. Rank channels on payback, not on cost per subscriber alone.
+
+---
+
+## Part 1: Acquisition Channels Ranked
+
+Ranked by **quality-adjusted cost** — cost per subscriber divided by expected engagement of that cohort. Costs are 2025–2026 vendor-published ranges; your niche will vary.
+
+| Rank | Channel | Typical cost/sub | Cohort quality | Scale ceiling |
+|------|---------|------------------|----------------|---------------|
+| 1 | **Organic social + content** (posting, SEO, guest appearances) | $0 cash; real time cost | Highest — self-selected intent | Slow; compounds |
+| 2 | **Referral program** (existing readers recruit) | Prize/reward cost amortized; often <$1/sub | Near-organic — socially vouched | Capped by list size (Morning Brew: referrals still ~30% of growth at scale — ReferralRock) |
+| 3 | **Cross-promo / swaps** (shoutout-for-shoutout with peer newsletters) | $0 cash; costs one editorial slot | High — pre-qualified newsletter readers; cross-promo cohorts are reported at 60–70% open rates vs 30–40% for paid cohorts (Growth In Reverse, vendor claim) | Capped by partner supply; find partners via Lettergrowth-style directories |
+| 4 | **Paid social** (Meta/TikTok/X ads to a landing page) | $1–$3/sub when run well (Newsletter Operator) | Medium-high — interest-targeted, but ad-clicker skew | High — budget-limited |
+| 5 | **Recommendation networks** (beehiiv Boosts, SparkLoop paid recs) | beehiiv cites a $1.63 average from Boosts early-access results; SparkLoop paid recommendations typically $2–$5/lead | Medium — reader of an adjacent newsletter, but one-click convenience subs; requires quality filtering | Medium-high |
+| 6 | **Co-registration** (bundled signup checkboxes, sweepstakes networks) | Often cheapest per raw email | Lowest — multi-list opt-ins show weaker engagement and higher complaint risk (Media Intercept; DeBounce) | High, and that's the trap |
+
+**Decision rules:**
+
+1. **Under ~5,000 subs:** spend zero cash. Organic + swaps + guest appearances. Paid channels waste money before you know your revenue per subscriber.
+2. **Add paid channels only after** you can compute allowable cost per subscriber from real revenue data (Part 2 worksheet). Buying subs before you know their value is gambling, not arbitrage.
+3. **Recommendation networks:** turn on only with per-source cohort tracking and an engagement-based rejection rule (most networks let you refuse/refund low-quality subs — use it). Budget for a higher sunset rate on these cohorts.
+4. **Co-registration:** default NO. Allow only when the economics still work at a pessimistic 50% quality haircut AND deliverability monitoring is in place — a complaint spike from a bad co-reg batch damages inbox placement for your whole list (see deliverability section of `knowledge/channels/email-lifecycle.md`).
+5. **Referral program:** launch after ~1,000 engaged subs. Reward with status/content/merch tied to your topic, not generic prizes — referral-based giveaways produce fewer but markedly higher-quality subs than "enter to win" sweepstakes (Grow My Newsletter; see Part 4).
+6. Any tactic that emails people who did not opt in is cold outreach, not newsletter growth — it falls under `harness/references/cold-email-rules.md` and its non-negotiables.
+
+---
+
+## Part 2: Unit Economics Worksheet
+
+Work top to bottom. Output: an **allowable cost per subscriber (allowable CPS)** you can hand to any acquisition channel.
+
+### Step 1 — Revenue per subscriber per year (RPSY), by monetization model
+
+**Model A: Ads / sponsorships.**
+
+```
+RPSY(ads) = sends/year × open rate × (CPM ÷ 1000) × sellable slots per send × sell-through rate
+```
+
+CPM ranges (vendor-published 2025–2026; price on OPENS for engaged-list sales, on sends only if your buyer insists):
+
+| Audience | CPM range | Source |
+|----------|-----------|--------|
+| Typical overall range | $10–$75 | beehiiv |
+| Broad consumer / lifestyle | $15–$35 | beehiiv |
+| Specialized B2B | $50–$100+ | beehiiv |
+| Finance/fintech (aggressive top end) | up to ~$70–$180 claimed | MailAdx (single vendor — verify before quoting) |
+
+Alternative structures: flat-rate per placement ($50 small lists → $10,000+ established; beehiiv) and CPA deals ($10–$100 per acquisition common; beehiiv).
+
+*Worked example:* 10,000 subs, weekly send, 40% open, $30 CPM on opens, 1 slot, 50% of weeks sold. Per send: 4,000 opens × $0.03 = $120. Per year: 26 sold sends × $120 = $3,120 ÷ 10,000 subs = **$0.31 RPSY**. A $1.50 paid subscriber takes ~5 years to pay back at that rate. Conclusion: single-slot ads at consumer CPMs cannot fund paid acquisition — you need more slots, higher sell-through, premium B2B CPMs, or near-free organic growth.
+
+**Model B: Paid subscriptions.**
+
+```
+RPSY(paid) = free→paid conversion rate × annual price × (1 + a share of expected renewal years, discounted)
+```
+
+Conversion benchmarks: Substack's own guidance says 5–10%; practitioner data puts the common range at **2–5% with a median near 3%**, and only roughly 1 in 5 publications clears 5% (Simon Owens; Yana G.Y. analysis). Small niche lists run 4–10%; big general lists 1–2%. Use 3% as the planning default unless you have your own data. Lenny's Newsletter runs ~4–5% at scale (Growth In Reverse, reported).
+
+*Worked example:* $100/yr price × 3% conversion = **$3.00 RPSY** from year-one conversion alone, before renewals — roughly 10× the ads example above. This asymmetry is why paid-subscription newsletters can afford paid acquisition channels that ad-only newsletters cannot, and why most mid-size newsletters run hybrid.
+
+Revenue per *paid* subscriber medians by vertical: roughly $83 (community topics) to $230 (investing) per year (beehiiv State of Paid Newsletters 2026).
+
+**Model C: Own product / lead gen (courses, SaaS, services).**
+
+```
+RPSY(product) = buyer conversion rate × average order value × purchase frequency ÷ list size ... 
+```
+
+No honest public benchmark exists — conversion depends entirely on offer fit. **HEURISTIC:** newsletters selling their own high-ticket product often out-earn Models A and B per subscriber by 3–10×, which is why the allowable CPS for a services firm's newsletter can be far above ad-monetized norms. Compute from your own funnel or mark the plan's revenue line as unvalidated.
+
+**Model D: Recommendation payouts** (you monetize your signup flow by recommending other newsletters): commonly ~$0.50–$3 per referred subscriber via Boosts/SparkLoop (vendor figures). This is a partial acquisition-cost offset, not a business model — and over-recommending at signup is itself an incentive-quality risk (Part 4).
+
+### Step 2 — Allowable CPS
+
+```
+Allowable CPS = RPSY × target payback (years) × gross margin on newsletter revenue
+```
+
+Decision thresholds:
+
+- **Payback ≤ 6 months:** scale the channel.
+- **Payback 6–18 months:** run it, but only with cohort retention data proving subscribers survive that long.
+- **Payback > 18 months or unknown RPSY:** cash channels off; organic/swap/referral only.
+- Recompute quarterly. RPSY moves with open rates, sell-through, and pricing.
+
+### Step 3 — Blend check
+
+Sum planned monthly spend per channel ÷ expected subs per channel, weight each cohort by its observed 90-day open rate relative to your organic baseline, and confirm the **quality-adjusted blended CPS ≤ allowable CPS**. If the blend only works because a cheap low-quality channel drags the average cost down, the plan fails — low-quality cohorts drag RPSY down too and the model double-counts them as wins.
+
+---
+
+## Part 3: List Hygiene Rules
+
+Deliverability mechanics (SPF/DKIM/DMARC, warming, monitoring thresholds, suppression tables) are owned by `knowledge/channels/email-lifecycle.md` — this section covers only the growth-economics decisions. Compliance floor for anything outreach-shaped: `harness/references/cold-email-rules.md`.
+
+**Double opt-in: default ON for paid and network-sourced cohorts.** The tradeoff is volume vs quality: you lose a chunk of signups at the confirmation step (commonly cited at ~20–30%, HEURISTIC — measure yours), but confirmed lists perform materially better. A 2011 Mailchimp analysis of ~30,000 accounts (old but still the largest public comparison; reported via Litmus/Automateed roundups) found double opt-in lists with ~72% more unique opens, ~114% higher click rates, and sharply lower bounce and unsubscribe rates than single opt-in lists. Bots and mistyped addresses can't click confirmation links, so double opt-in also filters spam traps. Rule: single opt-in is defensible only for organic, high-intent signup surfaces where you verify addresses at capture; any channel where a third party delivers the email address (co-reg, networks, giveaways) gets double opt-in, no exceptions.
+
+**Sunset policy: write it before you scale acquisition.** A subscriber who hasn't opened in N sends is a deliverability liability and an inflated denominator in every metric you sell to sponsors. Default sunset ladder (HEURISTIC — tune N to your cadence and purchase cycle, per the re-permission pattern in `email-lifecycle.md`):
+
+1. No opens in 90 days (weekly cadence) → drop to reduced frequency segment.
+2. No opens in 150 days → one re-permission email ("still want this?").
+3. No response in 30 more days → suppress. No response IS the answer.
+
+Sunset aggressively when you sell ads on opens: cutting dead weight raises open rate, which raises the CPM you can defend. A 50k list at 25% opens sells the same 12,500 opens as a 20k list at 62% — and the smaller list gets the better CPM story (audience-quality pricing per beehiiv/Paved).
+
+**Hygiene economics rule:** count expected sunset losses as part of channel cost. A $1.50 co-reg subscriber cohort that sunsets 40% within six months costs $2.50 per surviving subscriber — re-rank your channels with post-sunset survivors in the denominator.
+
+**Approval doctrine:** list purges, suppression changes, and re-permission sends are live-channel mutations — human approval required before executing any of them.
+
+---
+
+## Part 4: The Growth–Quality Tension
+
+**The mechanism:** the more the signup was driven by an incentive external to your content (prize, bundled checkbox, one-click convenience), the less the subscriber wanted the content — and engagement decays accordingly. Practitioner data points, all directionally consistent:
+
+- Sweepstakes/"enter to win" giveaways deliver cheap volume with quality that "varies dramatically" and is usually poor unless the prize selects for your exact reader (Grow My Newsletter). Referral-gated giveaways (entries earned by recruiting) deliver fewer subs at much higher quality — Morning Brew's referral engine drove ~80% of growth before paid acquisition and still accounts for almost 30% of growth at scale (ReferralRock; GrowSurf).
+- Cross-promo cohorts reportedly open at 60–70% vs 30–40% for paid cohorts (Growth In Reverse).
+- Lists grown by referral and organic search show higher recent-cohort engagement than lists inflated by sweepstakes or co-registration traffic (Media Intercept).
+- Multi-list co-reg opt-ins correlate with overwhelm, disinterest, and complaint/unsubscribe behavior across all lists involved (DeBounce).
+
+**Operating rules:**
+
+1. **Tag every subscriber with an acquisition source at capture** (`email_subscribed` event with `source` property — the taxonomy already exists in `email-lifecycle.md`). Untagged growth is unauditable growth.
+2. **Cohort-report engagement by source at 30/90/180 days.** Kill or renegotiate any paid source whose 90-day open rate is below ~60% of your organic cohort's (HEURISTIC threshold — the principle, comparing each cohort to your own baseline rather than a generic benchmark, is the same evidence rule as `knowledge/checklists/cro-audit-checklist.md`).
+3. **Never sell sponsors a subscriber count you wouldn't defend cohort-by-cohort.** Inflated lists produce bad sponsor results, which produce churned sponsors — the decay shows up in revenue with a one-quarter lag.
+4. **Incentives should point at the content, not away from it.** Prize = more of what the newsletter already is (premium editions, tools, access), not a MacBook. If the incentive would excite someone who'd never read you, it recruits people who never will.
+5. **Watch the vanity-metric spiral:** subscriber count is the one metric that only goes up if you let it. Growth reporting in Kai should always pair list size with 90-day-cohort open rate and quality-adjusted CPS.
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Loads this doc for |
+|-------------|--------------------|
+| `harness/skills/kai-newsletter/SKILL.md` | Growth-strategy questions in Phase 1–2: channel selection, budget sizing, referral/cross-promo planning, list-quality diagnosis |
+| `knowledge/channels/email-lifecycle.md` | Owns the send/deliverability/suppression layer this doc's hygiene rules hand off to |
+| `harness/references/cold-email-rules.md` | Compliance floor whenever a growth tactic touches non-opted-in recipients |
+| Audit workflows (`kai-*-audit`) | Allowable-CPS math and channel ranking when auditing a client newsletter — provenance rule applies: pull the account's real cohort data via the collector, never quote this doc's benchmark ranges as the client's numbers |
+| `knowledge/playbooks/growth-loops-applied.md` | Referral-loop design detail beyond the economics treated here |
+| `knowledge/playbooks/partnership-comarketing.md` | Cross-promo partner sourcing and deal mechanics |
+
+Anything here that touches a live list — purges, re-permission sends, launching paid acquisition, turning on a recommendation network — goes through human approval first, per the harness approval doctrine.
+
+---
+
+## Sources
+
+Vendor and practitioner sources retrieved 2026-07-16. Treat all benchmark figures as Tier-6 evidence (hypothesis-generating, not account truth).
+
+- beehiiv — How Much Do Newsletter Ads Cost: https://www.beehiiv.com/blog/newsletter-sponsorship-cost
+- beehiiv — The State of Paid Newsletters 2026: https://www.beehiiv.com/blog/the-state-of-paid-newsletters-2026
+- SparkLoop — Grow on beehiiv (paid recommendation pricing): https://sparkloop.app/grow-on-beehiiv
+- Newsletter Supply — beehiiv Boosts explained: https://newsletter.supply/blog/how-does-beehiiv-boosts-work
+- Simon Owens — What's a realistic conversion rate for paid newsletters: https://simonowens.substack.com/p/whats-a-realistic-conversion-rate
+- Yana G.Y. — Substack free-to-paid conversion rate, what's actually average: https://www.yana-g-y.com/p/substack-free-to-paid-conversion-rate
+- Newsletter Operator — Growth tactics tier list: https://www.newsletteroperator.com/p/growth-tier-list
+- Newsletter Operator — 26 newsletter growth channels: https://www.newsletteroperator.com/p/26-newsletter-growth-channels
+- Growth In Reverse — Doing cross promotions the right way: https://growthinreverse.com/cross-promotions/
+- Growth In Reverse — How Lenny Rachitsky gets 18k people to pay (conversion figure): https://growthinreverse.com/lennys-paid-newsletter/
+- Lettergrowth — cross-promotion partner directory: https://lettergrowth.com/
+- ReferralRock — How the Morning Brew referral program created wild growth: https://referralrock.com/blog/morning-brew-referral-program/
+- GrowSurf — How Morning Brew grew to 2.5M subscribers: https://growsurf.com/blog/how-morning-brew-grew-its-subscribers/
+- Grow My Newsletter — Giveaways, sweepstakes and competitions: https://www.growmynewsletter.com/growth-methods/giveaways
+- Litmus — Single vs double opt-in: https://www.litmus.com/blog/single-opt-in-vs-double-opt-in-case-for-soi
+- Automateed — Double opt-in vs single opt-in (Mailchimp study figures): https://www.automateed.com/double-opt-in-vs-single-opt-in
+- Mailjet — Double opt-in and deliverability: https://www.mailjet.com/blog/deliverability/double-opt-in-should-i-or-shouldnt-i/
+- Media Intercept — Publisher newsletter growth strategies: https://www.mediaintercept.com/post/publisher-newsletter-growth-strategies
+- DeBounce — Co-registration glossary (quality risks): https://debounce.com/glossary/co-registration/
+- Paved — Newsletter sponsorship rate benchmarks: https://www.paved.com/blog/newsletter-sponsorship-rates/
+- MailAdx — Newsletter ad rates and CPM benchmarks 2026: https://www.mailadx.com/blog/newsletter-ad-rates-cpm-benchmarks-2026
+- Inbox Collective — The four newsletter growth quadrants: https://inboxcollective.com/the-four-newsletter-growth-quadrants/

--- a/knowledge/playbooks/product-led-seo.md
+++ b/knowledge/playbooks/product-led-seo.md
@@ -1,0 +1,181 @@
+# Product-Led & Programmatic SEO Playbook
+
+> **Use when:** Deciding whether to build a programmatic page section (integration pages, location pages, template galleries, comparison pages, calculator/data pages), designing the template and data pipeline for one, or auditing an existing programmatic section for scaled-content risk.
+>
+> **What this doc owns:** the programmatic/product-page motion — demand math, data requirements, template quality bar, scale gating.
+> **What adjacent docs own (cross-link, don't duplicate):**
+> - Topical maps, quality vs trending nodes, site-wide semantic architecture → `knowledge/playbooks/semantic-seo-methodology.md`
+> - AI-search retrievability, entity clarity, evidence tiers for AI engines → `knowledge/frameworks/aeo-ai-search/aeo-ai-search-playbook-2026.md`
+> - General internal-linking mechanics (hub-and-spoke, anchor rules) → `knowledge/playbooks/seo-internal-linking.md`
+> - Crawl/index troubleshooting → `knowledge/checklists/technical-seo-audit-sop.md`
+
+---
+
+## 1. The Core Idea
+
+Product-led SEO (term popularized by Eli Schwartz's book *Product-Led SEO*, 2021) builds pages that ARE the product experience, not content ABOUT the product. The page itself does a job: converts a currency, shows an integration, renders a template, answers "salary for X at Y." Programmatic SEO is the production method: one template × one dataset × N entities = N pages.
+
+The method is neutral. The same machinery built Zapier's integration pages and a million doorway-page penalties. The difference is a three-factor test, and all three factors must pass:
+
+```
+SHIP = Real Search Demand × Unique Data × Genuine Utility
+       (any factor = 0 → the product is 0 → do not build)
+```
+
+| Factor | Question | Pass looks like | Fail looks like |
+|--------|----------|-----------------|-----------------|
+| **Real search demand** | Do people actually search this pattern, entity by entity? | Head terms + a repeating modifier pattern with volume across the long tail ("[app A] + [app B] integration", "[currency] to [currency]") | Volume exists only at the head; long-tail permutations are zero-volume guesses |
+| **Unique data** | Does each page contain facts only we (or our licensed source) can publish? | Proprietary product data, user-generated content, licensed feeds, first-party measurements | Scraped competitor content, respun Wikipedia, LLM-generated "descriptions" of things you have no data on |
+| **Genuine utility** | Would a user landing here get the job done without clicking back? | Interactive tool, live data, complete answer, transactable inventory | A paragraph of filler wrapped around one templated sentence, funneling to a signup form |
+
+Schwartz's stronger claim: the best programmatic plays create demand categories competitors ignored, rather than fighting over existing keyword lists. Validate that with real query data before believing it for your case (see Section 6, Stage 1).
+
+---
+
+## 2. When Programmatic Pages Work — Reference Patterns
+
+Third-party page counts below are vendor estimates (Tier 5-6 evidence per the AEO playbook's evidence ladder) — use as pattern references, not benchmarks to promise.
+
+| Pattern | Example | Why it passes the three-factor test |
+|---------|---------|-------------------------------------|
+| **Entity-pair pages** | Zapier: an indexed page per app and per app-pair (~25,000+ pages per practitioner analyses) | Demand: people search "connect X to Y." Data: Zapier's own integration catalog. Utility: page starts the actual workflow |
+| **Live-data utility pages** | Wise currency pages (~3,000+ pages) | Demand: "usd to eur" class queries. Data: Wise's own live rates. Utility: the converter works on the page |
+| **Inventory pages** | Zillow (tens of millions of listing pages), Tripadvisor (location × category pages) | Demand: address/city-level queries. Data: proprietary or licensed listing inventory. Utility: the listing is the answer |
+| **Template/asset galleries** | Canva template pages (~30,000+ per third-party counts) | Demand: "[occasion] invitation template." Data: Canva's own asset library. Utility: one click into the editor |
+| **UGC-review pages** | G2, Glassdoor | Demand: "[product] reviews," "[company] salary." Data: user submissions no competitor holds. Utility: the reviews themselves |
+
+Common denominator: in every winner, the dataset is the moat and the page is a working surface of the product. None of them could be replicated by a competitor with a scraper and a template.
+
+---
+
+## 3. When It's Spam — Google's Published Line
+
+Google's [spam policies](https://developers.google.com/search/docs/essentials/spam-policies) define three failure modes that map directly onto bad programmatic builds. Quote-level definitions (Tier 1 evidence — official policy):
+
+**Scaled content abuse** — "when many pages are generated for the primary purpose of manipulating search rankings and not helping users." Listed examples include: "using generative AI tools or other similar tools to generate many pages without adding value for users" and "scraping feeds, search results, or other content to generate many pages... where little value is provided to users." The March 2024 policy update deliberately made this method-agnostic: human-written, AI-written, or hybrid — scale without value is the violation ([Google Search Central blog, March 2024](https://developers.google.com/search/blog/2024/03/core-update-spam-policies)). Google projected the accompanying core + spam updates would cut low-quality, unoriginal content in results by 40% ([Google blog, March 2024](https://blog.google/products-and-platforms/products/search/google-search-update-march-2024/)); after the rollout completed in April 2024, Google said the actual reduction was 45% ([Search Engine Land, April 2024](https://searchengineland.com/google-march-2024-core-update-rollout-is-now-complete-438713)).
+
+**Doorway abuse** — pages "created to rank for specific, similar search queries" that "lead users to intermediate pages that are not as useful as the final destination." The listed example is the classic bad-programmatic build: "having multiple domain names or pages targeted at specific regions or cities that funnel users to one page." A location-page section where every city page is the same pitch with a swapped city name is a doorway section.
+
+**Thin affiliation** — product pages "where the product descriptions and reviews are copied directly from the original merchant without any original content or added value." Programmatic affiliate builds fail here by default unless each page adds original data.
+
+**Decision rule:** if the honest description of your build is "we generated N pages so we'd rank for N queries," you are inside the scaled-content-abuse definition. If the honest description is "we have N things (integrations, listings, datasets, templates) and each gets a page," you are outside it. Write that sentence down before building; it is the fastest audit.
+
+---
+
+## 4. Template-Page Quality Bar
+
+A programmatic page must survive being read alone, as if it were the only page on the site. Minimum bar, checked on the prototype (Section 6, Stage 3) and re-checked on random samples at scale:
+
+1. **Majority-unique content test.** More than 50% of the rendered visible content must be entity-specific data that differs page to page (numbers, inventory, reviews, screenshots, structured facts). Template boilerplate — intro paragraph, FAQ shell, CTA blocks — stays under 50%. If two random pages diff to near-identical text with nouns swapped, the section fails.
+2. **The zero-data rule.** No page ships for an entity you have no real data on. An integration page for an integration that doesn't exist, a city page for a city with no inventory, a stats page with "data coming soon" — these are doorway/thin pages. Suppress (noindex or don't generate) any page below a data-completeness threshold you set per section (e.g., "≥3 reviews," "≥1 live listing," "rate feed present").
+3. **On-page task completion.** The searcher's job finishes on the page: converter converts, template opens, listing is viewable, comparison table is complete. If the page's only affordance is "sign up to see the answer," it's a doorway.
+4. **Unique metadata + one unique human-readable insight.** Title, H1, and meta description are generated from data, not from one string with a variable. Where feasible, add a per-page derived insight ("Rates for X dropped 12% this quarter" — computed, not hallucinated).
+5. **Standard content gates still apply.** Copy blocks in the template pass `four_us_score.py` (12/16, SEO threshold), `banned_word_check.py`, and `seo_lint.py` — gate the template once, then gate rendered samples, because data merges create new sentences.
+6. **AI-retrievability.** Each page's core fact block should be a self-contained, extractable passage (answer-first, visible HTML, eligible schema) — mechanics owned by `aeo-ai-search-playbook-2026.md` §3 (Content Optimization Checklist); apply them to the template, and they replicate everywhere.
+7. **No hallucinated attributes.** LLM-assisted copy may rephrase and structure the data you have; it may not invent attributes, counts, reviews, or comparisons. This is the same line Google draws (AI is fine; valueless scale is not) and the same line Kai's provenance rules draw.
+
+---
+
+## 5. Data-Source Requirements (Kai provenance rules apply)
+
+Programmatic SEO is a data product. The data pipeline is governed before the template is designed:
+
+- **Allowed sources:** proprietary product data, first-party measurements, user submissions you have rights to display, licensed feeds/APIs used within license terms, and public government/open datasets with attribution.
+- **Banned sources:** scraped competitor content, republished merchant feeds with no added value (thin affiliation), fabricated or LLM-imagined data points, and review/rating counts you didn't collect. Google's scaled-content examples name scraping-plus-transformation ("synonymizing, translating, or other obfuscation") explicitly.
+- **Kai Data Provenance Rule applies in full** (see `AGENTS.md` and `harness/references/audit-data-provenance.md`): every quantitative claim rendered into a page traces to a collector source; missing data goes to `_data-gaps.md` — or the page doesn't generate — never to a guess. Run `audit_provenance_lint.py` on any client-facing audit of a programmatic section.
+- **Freshness contract:** define per-section how stale data can get before pages are updated or suppressed (live rates: minutes; salary data: quarterly; static templates: on change). A programmatic section with dead data decays into thin content without anyone touching it.
+- **License audit:** record the license/terms for every third-party feed in the section's data manifest. "We found an API" is not a license.
+
+---
+
+## 6. Build Order: Demand → Data → Prototype → Gate → Scale
+
+Never invert this order. Building the generator first is how 50,000 thin pages happen.
+
+### Stage 1 — Demand validation (kill ~half of ideas here)
+- Enumerate the query pattern: `[modifier] + [entity]` or `[entity A] + [entity B]`. Pull volume for the head term AND a random sample of ≥50 long-tail permutations (GSC if you rank for adjacent terms, keyword tools otherwise; label the evidence tier).
+- **Pass:** demand is distributed across the tail, intent matches the page's job, and SERP inspection shows the pattern rewards dedicated pages (competitors' entity pages rank, not one mega-page).
+- **Fail:** volume concentrates in the head → build one strong page instead (the semantic-SEO doc's rule: one continuously updated evergreen page, not thousands of individual pages). Zero-volume tails can still be worth building only when there's a documented creation-of-demand thesis (Schwartz's argument) plus a non-search value for the pages — write the thesis down and set a review date.
+
+### Stage 2 — Data audit
+- Inventory: entity count, attributes per entity, % completeness per attribute, source + license per attribute, refresh cadence.
+- Set the generation threshold (Section 4, rule 2). Count how many entities clear it — **that number, not the entity count, is your page count.**
+- If <100 entities clear the bar, question whether this is a programmatic section at all; a hand-built hub may win.
+
+### Stage 3 — Template prototype
+- Hand-build 3-5 pages for representative entities (best-case, median, worst-case data completeness). The worst-case page decides the design.
+- Design the empty-state behavior: what does the template do when an attribute is missing? (Omit the module — never render placeholder text.)
+- Run the quality bar (Section 4) and standard gates on all prototypes.
+
+### Stage 4 — Quality gate at small scale
+- Generate 50-200 pages. Index them. Human-review a random 10% against Section 4. Diff random page pairs for boilerplate ratio.
+- Instrument: GSC indexation coverage, impressions per page, engagement. Wait one full crawl-index-rank cycle (typically 4-8 weeks) before judging.
+- **Go/no-go:** majority of the batch indexed, impressions distributed across pages (not just the index page), no manual action, no "Crawled — currently not indexed" pile-up. Indexation refusal at small scale is Google grading your quality bar — fix the template, don't scale past it.
+
+### Stage 5 — Scale, in tranches
+- Release in tranches (e.g., 500 → 2,500 → 10,000), each gated on the previous tranche's indexation and engagement. Never dump the full dataset in one deploy.
+- Standing monitors: indexation ratio per tranche, sample re-reviews each quarter, data-freshness alarms, and the section's rollback plan (ability to noindex a tranche in one change).
+- **Human approval is required before each tranche goes live** — publishing programmatic pages is a live-channel mutation and follows the same approval doctrine as everything else in this harness (publishing default OFF).
+
+---
+
+## 7. Internal-Linking Architecture for Programmatic Sections
+
+General linking mechanics live in `seo-internal-linking.md`; semantic-node strategy in `semantic-seo-methodology.md`. Programmatic-specific rules:
+
+1. **Every programmatic page must be reachable through a browsable hierarchy** — home → section hub → (category index) → detail page, ≤4 clicks. Google's doorway definition flags "substantially similar pages that are closer to search results than a clearly defined, browseable hierarchy"; orphaned pages fed to Google only via XML sitemap fit that description.
+2. **Hub + paginated category indexes, not a flat dump.** The section hub is a quality node (it earns external links); category indexes (by letter, geography, type) carry PageRank down to detail pages. Detail pages cross-link laterally to genuinely related entities (same category, same pair-member, nearby location) — capped at a fixed, small number (5-10) chosen by relevance rules, not "all 40,000 siblings" footers.
+3. **Link programmatic detail pages UP to commercial quality nodes.** The section exists to feed authority and users to the pages that convert (the semantic-SEO doc's trending-node → quality-node pattern).
+4. **Control combinatorial crawl explosion.** Entity-pair and faceted sections multiply URLs; Google calls faceted navigation "by far the most common source of overcrawl issues" site owners report ([Google Search Central blog, Dec 2024](https://developers.google.com/search/blog/2024/12/crawling-december-faceted-nav)). Follow Google's faceted-navigation guidance: robots-disallow filter permutations you don't want indexed, keep filter parameter order consistent, and return 404 for empty combinations ([Google Search Central docs](https://developers.google.com/search/docs/crawling-indexing/crawling-managing-faceted-navigation)). Decide index/noindex per URL class before launch, not after the crawl budget is gone.
+5. **Segmented XML sitemaps per tranche/category** so indexation can be monitored per segment in GSC (pairs with `harness/references/google-indexation-monitoring.md`).
+
+---
+
+## 8. UGC-SEO Loops
+
+The strongest programmatic moat is data that users create for you (G2 reviews, Glassdoor salaries, Tripadvisor reviews, Stack Overflow answers): every user contribution improves a page, better pages rank and attract more users, who contribute more. Loop design requirements:
+
+- **Contribution → page mapping:** each contribution must land on a determinate page (entity page, question page) — that's what compounds. Feeds and profiles don't build search equity.
+- **Cold-start honesty:** pages below the contribution threshold stay noindexed until they clear it (Section 4, rule 2). A UGC section at launch is mostly empty pages — suppressing them is the difference between a loop and a spam section.
+- **Moderation as a quality gate:** unmoderated UGC imports spam, defamation risk, and policy violations into your index. Budget moderation (human or model-assisted with human escalation) as a permanent cost of the loop.
+- **Prompted structure beats free text:** structured contribution forms (ratings by dimension, pros/cons fields) generate extractable, passage-retrievable content that both classic SERPs and AI engines can cite (AEO playbook, passage-retrievability principle).
+- **Rights:** terms of service must grant display rights; UGC counts as first-party data only when they do.
+- Loop mechanics and incentive design beyond SEO → `knowledge/playbooks/growth-loops-applied.md` and `knowledge/playbooks/community-as-channel.md`.
+
+---
+
+## 9. Kill Criteria & Anti-Patterns
+
+Kill or noindex a programmatic section when any of these holds:
+
+- Indexation ratio for a tranche stays under ~50% after two crawl cycles and template fixes (Google is refusing the quality bar).
+- The data source dies or the license lapses (pages will rot into thin content).
+- Manual action or visible post-core-update section-wide demotion — noindex first, remediate against Section 4, request review only after the fix is real.
+- The section's pages cannibalize a stronger evergreen page for the same intents.
+
+Anti-patterns (log recurrences to `memory/what-doesnt-work.md`): city-swap doorway pages; LLM-generated "reviews" of products never touched (fabricated proof — Stop condition under the Instruction Contract); publishing the full entity list on day one; template intros longer than the data they introduce; "we'll add the data later" launches.
+
+---
+
+## How This Maps Into Kai
+
+- **`kai-seo-audit` / technical SEO audits** load this doc when the target site has (or plans) programmatic sections — Sections 3-4 supply the scaled-content risk rubric, Section 7 the crawl/linking checks. Pair with `knowledge/checklists/technical-seo-audit-sop.md` and `knowledge/checklists/seo-checklist.md`.
+- **Growth/SEO strategy work** (`kai-growth-plan`, content strategy briefs) uses Section 1's three-factor test and Section 6's build order to decide whether to recommend a programmatic motion at all.
+- **Provenance enforcement:** any audit or plan quoting a section's traffic, page counts, or indexation runs the Kai Data Provenance Rule (`harness/references/audit-data-provenance.md`, `audit_provenance_lint.py`). Never quote this doc's third-party example numbers as client benchmarks.
+- **Quality gates:** template copy and rendered samples go through `four_us_score.py`, `banned_word_check.py`, `seo_lint.py` like any SEO content; algorithmic-authorship rules (`knowledge/frameworks/content-copywriting/algorithmic-authorship.md`) apply to template prose.
+- **Approval doctrine:** generating pages is content work; publishing/indexing them is a live-channel mutation — human approval per tranche, publishing default OFF.
+- **Adjacent strategy docs:** semantic architecture → `semantic-seo-methodology.md`; AI-engine visibility of programmatic pages → `frameworks/aeo-ai-search/aeo-ai-search-playbook-2026.md`; linking mechanics → `seo-internal-linking.md`; indexation monitoring → `harness/references/google-indexation-monitoring.md`.
+
+## Sources
+
+- Google Search Central — Spam policies (scaled content abuse, doorway abuse, thin affiliation): https://developers.google.com/search/docs/essentials/spam-policies
+- Google Search Central Blog — "What web creators should know about our March 2024 core update and new spam policies": https://developers.google.com/search/blog/2024/03/core-update-spam-policies
+- Google — "New ways we're tackling spammy, low-quality content on Search" (40% projection): https://blog.google/products-and-platforms/products/search/google-search-update-march-2024/
+- Search Engine Land — "Google March 2024 core update rollout is now complete" (45% actual reduction, per Google): https://searchengineland.com/google-march-2024-core-update-rollout-is-now-complete-438713
+- Google Search Central Blog — "Crawling December: Faceted navigation" (overcrawl quote): https://developers.google.com/search/blog/2024/12/crawling-december-faceted-nav
+- Google Search Central — Managing crawling of faceted navigation URLs: https://developers.google.com/search/docs/crawling-indexing/crawling-managing-faceted-navigation
+- Eli Schwartz — *Product-Led SEO: The Why Behind Building Your Organic Growth Strategy* (2021): https://www.elischwartz.co/book
+- Zapier — "Programmatic SEO: How to do it & if you should": https://zapier.com/blog/programmatic-seo/
+- Ahrefs — "Programmatic SEO, Explained for Beginners": https://ahrefs.com/blog/programmatic-seo/
+- Practical Programmatic — case studies (Zapier, Tripadvisor; page-count estimates, Tier 5-6): https://practicalprogrammatic.com/examples
+- SEOmatic — "Programmatic SEO Examples: 7 Real Sites Doing It at Scale" (Wise, Canva, G2 page-count estimates, Tier 5-6): https://seomatic.ai/blog/programmatic-seo-examples

--- a/knowledge/playbooks/referral-and-word-of-mouth.md
+++ b/knowledge/playbooks/referral-and-word-of-mouth.md
@@ -1,0 +1,155 @@
+# Word-of-Mouth & Referral Engineering Playbook
+
+> **Use when:** Designing a referral program, diagnosing why one underperforms, or engineering a product/content experience so customers share it unprompted.
+>
+> **Read with:** `knowledge/playbooks/growth-loops-applied.md` — a referral program is an *amplifier* on the Invitation/Network loop archetype, not a loop by itself. If the false-loop test there fails, fix the loop before building the program. Creator/influencer-driven advocacy (paid or gifted) is owned by `knowledge/playbooks/influencer-marketing.md`; this doc covers customer-to-customer sharing.
+
+---
+
+## Why This Channel Is Worth Engineering (evidence base)
+
+- **Trust:** 88% of global consumers say they trust recommendations from people they know more than any other channel (Nielsen 2021 Trust in Advertising, ~40,000 respondents).
+- **Referred customers are worth more:** In a ~10,000-customer study at a German bank tracked for nearly three years, referred customers had higher contribution margins, higher retention, and were **at least 16% more valuable** than demographically matched non-referred customers (Schmitt, Skiera & Van den Bulte 2011, *Journal of Marketing*; won the MSI/H. Paul Root Award). The margin gap eroded over time; the retention gap persisted. Follow-up work (Van den Bulte et al. 2018, *JMR*) attributes this to better matching and social enrichment — referrers pre-qualify people like themselves.
+- **Scale is possible but rare:** Dropbox's double-sided storage referral is the canonical case — reported 100K→4M users in 15 months, with ~35% of daily signups from referrals at peak. Treat these as an outlier ceiling, not a planning benchmark.
+
+**Planning rule:** model your referral program as a 5–40% amplifier on existing acquisition, not a standalone engine. K-factor above 1 is exceptional (see math below and the K-factor section of `growth-loops-applied.md`).
+
+---
+
+## Part 1 — The Six Researched Drivers of Sharing
+
+Framework: Jonah Berger's STEPPS (*Contagious*, 2013), each element backed by published studies. Use the table as a diagnostic: score your product/content 0–2 on each driver, then engineer the weakest one that's plausibly fixable.
+
+| Driver | The research | Diagnostic question | Engineering move |
+|--------|-------------|--------------------|------------------|
+| **Social currency** | People share what makes them look smart, early, or high-status; sharing is self-presentation (Berger, *Contagious*, ch. 1) | Does sharing this make the sharer look good — not us? | Give users a result worth bragging about: scores, rankings, "top 1% of users" stats, early access they can gatekeep |
+| **Triggers** | Products cued more often by the environment get more word of mouth both immediately and over months; *interesting* products get only an immediate spike (Berger & Schwartz 2011, *JMR*) | What in the customer's daily environment reminds them of us? | Tie the brand to a frequent cue (a day, a task, a phrase). Frequency of the cue beats cleverness of the message |
+| **Emotion / arousal** | High-arousal emotions (awe, anger, anxiety, amusement) increase sharing; low-arousal emotions (sadness, contentment) suppress it — held across 7,000 NYT articles plus lab experiments (Berger & Milkman 2012, *JMR*) | Does this activate people, or merely please them? | Lead with the surprising number, the injustice, the awe-inspiring result. "Interesting" is not enough; measure for activation |
+| **Public / observability** | Publicly visible products get more WOM immediately *and* ongoing (Berger & Schwartz 2011); private consumption kills transmission | Can anyone tell our customer uses us? | Make usage self-advertising: badges, watermarks, "made with X," shareable artifacts, visible defaults (see Portable Artifact design in `growth-loops-applied.md` Step 4) |
+| **Practical value** | Practically useful content is more likely to be shared, independent of emotion (control finding in Berger & Milkman 2012) | Would someone forward this to help a specific friend? | Package genuinely useful, self-contained units: checklists, calculators, templates — addressed to one job, one person |
+| **Stories** | Information travels inside narratives; the brand must be integral to the story or it gets dropped in retelling (Berger, *Contagious*, ch. 6) | If a customer retells our story, do we survive the retelling? | Build a "Trojan horse" narrative where the product is the causal hinge of the outcome, not a logo on the slide |
+
+**Sequencing rule:** Triggers and observability compound over months; emotion spikes and decays. For sustained WOM, fix triggers/observability first, use high-arousal content for launches.
+
+---
+
+## Part 2 — Referral Program Design
+
+### 2.1 Prerequisite gate (do not skip)
+
+A referral program multiplies existing advocacy; it cannot create it. Before designing incentives, verify:
+
+1. **Activation is healthy** — a meaningful share of new users reach the value moment (compare against your own baseline; see the loop metrics table in `growth-loops-applied.md`).
+2. **Organic referral exists** — some customers already refer with zero incentive. If nobody refers for free, an incentive buys low-quality invites, not advocacy.
+3. **Unit economics survive the reward** — reward cost per converted invitee must come in under blended CAC, including fraud leakage.
+
+### 2.2 Incentive structure: both-sides vs one-side
+
+The controlling research is Ryu & Feick 2007 (*Journal of Marketing*, "A Penny for Your Thoughts"): four experiments showing rewards increase referral likelihood overall, but **who should get the reward depends on tie strength and brand strength**:
+
+| Situation | What the research says | Design decision |
+|-----------|------------------------|-----------------|
+| Weak ties, weaker/unknown brand | Rewards matter most here; rewarding the **sender** is what moves behavior | Sender-weighted or both-sided; sender reward does the work |
+| Strong ties, strong brand | Sender rewards add little (they'd refer anyway) and can feel mercenary; giving at least part of the reward to the **receiver** works better | Receiver-weighted or both-sided; the receiver's gift is the sender's social cover |
+| Default when you can't segment | Both-sided splits capture both effects and protect the sender's self-image | Both-sided (Dropbox: 500MB each; Airbnb: credit each) |
+
+Two field results to apply on top:
+
+- **Frame the offer as a gift, not a bounty.** Airbnb A/B-tested "invite your friends, get $25" against "give your friends $25 to travel." The altruistic framing performed better globally (Airbnb Engineering, "Hacking Word-of-Mouth"). The sender is spending social capital; give them generosity to spend, not a commission to explain.
+- **Prefer in-kind product currency over cash where the product allows.** Dropbox's storage reward cost marginal pennies, deepened product commitment on both sides, and selected for people who actually wanted the product. Cash selects for people who want cash.
+
+### 2.3 Timing of the ask
+
+Ask **after a value peak, never before value delivery**. Concrete decision rules:
+
+- Trigger the ask on a *success event* (report generated, first result achieved, milestone hit, 5-star support resolution) — not on signup, not on a calendar schedule.
+- Embed the ask where the value is visible (on the results screen), not in a settings page. Airbnb's rebuilt program moved referrals into the product's natural flow and reported signups and bookings up over 300%/day vs. their old bolt-on version, with bookings up 25%+ in some markets.
+- Suppress the ask for users who haven't activated, have open support tickets, or just churn-signaled. An ask delivered into dissatisfaction converts badly and burns the channel.
+- One re-ask per subsequent value peak is fine; recurring nag campaigns are not.
+
+### 2.4 K-factor and cycle-time math
+
+```
+K = i × c
+  i = invites sent per user (across the WHOLE user base, not just participants)
+  c = conversion rate of invitees to activated users
+
+New users after n cycles from seed N₀ (K < 1):
+  Total ≈ N₀ × (1 + K + K² + ... + Kⁿ)  →  N₀ × 1/(1−K) as n → ∞
+```
+
+**Worked example.** Base of 10,000 active customers. Participation 15% → 1,500 senders. Senders average 4 invites → 6,000 invites → i = 0.6 invites per base user. Invitee activation c = 10%.
+
+- K = 0.6 × 0.10 = **0.06** → cycle 1 yields 600 new customers, cycle 2 yields 36, cycle 3 yields ~2. Steady-state amplification ≈ 1/(1−0.06) → **~6.4% extra acquisition**. Real, but an amplifier.
+- Double participation to 30% (better placement + timing): K = 0.12 → ~13.6% amplification.
+- Also lift invitee activation to 15% (better invitee landing experience): K = 0.18 → ~22% amplification.
+- **Cycle time sets compounding speed:** if signup→referral takes 7 days, those cycles play out in weeks; at 60 days, the same K delivers its total over quarters. Instrument median time from signup to first sent invite and shorten it (see the cycle-time table in `growth-loops-applied.md`).
+
+**Lever priority from the math:** participation rate and invitee conversion multiply; invites-per-participant has diminishing (and spammy) returns. Never optimize invite volume first.
+
+---
+
+## Part 3 — Why Most Referral Programs Fail
+
+1. **Asking before value delivery.** The ask lands at signup or day 3, before the user has experienced anything worth vouching for. Referral is spent trust; users won't spend what they haven't earned. Fix: gate the ask on a success event (2.3).
+2. **Misaligned incentive.** Cash bounties for strong-tie referrals trigger impression-management concerns — the sender looks paid, not helpful (Ryu & Feick 2007). Or the reward is generous to the sender and empty for the receiver, so invites feel like exploitation (the exact failure Airbnb's give-framing fixed). Fix: match structure to tie/brand strength (2.2 table), gift-frame, both-sided default.
+3. **Amplifying a loop that doesn't exist.** Product isn't better with more people, produces no shareable artifact, and has no organic referral — the program is a coupon engine bolted onto nothing. See "False Loop Detection" in `growth-loops-applied.md`. Fix: build one STEPPS driver into the product first (Part 1).
+4. **Friction at the handoff.** Invite buried in settings, invitee lands on a generic homepage, account required before any value is visible. Every extra step taxes both i and c. Fix: audit the share→activation path click by click (`growth-loops-applied.md` Step 6).
+5. **Reward leakage and fraud.** Self-referrals, disposable emails, reward farming. Pay the sender only on invitee *activation* (a real value event), not on signup; cap total rewards per account (Dropbox capped earned storage).
+6. **Set-and-forget.** No owner, no dashboard, stale reward. Programs decay as the offer becomes wallpaper. Fix: quarterly review of the Part 4 metrics with one lever experiment per quarter.
+
+---
+
+## Part 4 — Measurement
+
+Compare every metric to your own baseline and prior period — not to public case-study numbers (evidence doctrine: `knowledge/playbooks/conversion-rate-optimization.md`, Tier rules). Program data comes from your own instrumentation; per the Kai Data Provenance Rule, never report these numbers to a client without a collector source.
+
+| Metric | Formula | What it diagnoses |
+|--------|---------|-------------------|
+| **Referral rate** | referred new customers ÷ total new customers (period) | Overall channel contribution (Dropbox's reported peak: 35%) |
+| **Participation rate** | users who sent ≥1 invite ÷ eligible users | Ask placement, timing, and offer appeal |
+| **Invites per participant** | invites sent ÷ participants | Motivation depth; watch for spam if incentives over-reward volume |
+| **Invitee conversion** | invitees activated ÷ invites sent | Landing experience, gift value, sender targeting quality |
+| **K-factor** | (invites ÷ all users) × invitee conversion | Whole-system health; trend matters more than level |
+| **Cycle time** | median days, signup → first sent invite | Compounding speed |
+| **Referred-customer quality** | referred cohort retention/LTV vs. matched non-referred cohort | Whether incentives are attracting real customers (expect referred ≥ non-referred per Schmitt et al. 2011; if referred < baseline, the incentive is buying junk) |
+| **Cost per referred activation** | total rewards paid ÷ referred activations | Must beat blended CAC with margin for fraud |
+
+**Instrumentation minimum:** unique referral links/codes, sender-invitee join keys, activation event (not signup) as the payout trigger, and cohort tags in the analytics store so referred-vs-baseline LTV is queryable.
+
+---
+
+## Ethics Rules (hard constraints)
+
+- **No fake scarcity or fake social proof.** No invented "only 2 referral spots left," no fabricated "X friends already joined" counts. Real caps and real counts only.
+- **No undisclosed incentivized endorsements.** A referral reward is a material connection. If the program asks customers to post publicly (reviews, social posts, testimonials), disclosure is required under the FTC Endorsement Guides — load `harness/references/creator-disclosure.md` and apply its per-surface disclosure formats. Never condition a reward on the review being positive, and never incentivize reviews on platforms that prohibit it (most do).
+- **Incentivize the referral action, not the opinion.** Pay for a converted invite; never pay for sentiment.
+- **No purchased or automated amplification** — no bought accounts, no astroturfed threads seeding "organic" recommendations (Instruction Contract stop-conditions apply).
+- **Approval doctrine:** launching a program, sending referral emails, or changing live incentives is a live-channel mutation — human approval required before anything ships. Publishing stays OFF by default.
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Loads this doc for |
+|-------------|--------------------|
+| Growth planning (`knowledge/playbooks/growth-loops-applied.md`, `growth-hacker-first-hire-os.md`) | Deciding whether/when a referral program amplifies an existing loop; K-factor and cycle-time sizing |
+| Campaign planning (`knowledge/playbooks/campaign-orchestration.md`, `scripts/campaigns/campaign_planner.py`) | Referral-ask email/in-product copy timing, incentive framing (gift vs. bounty), both-sides split |
+| CRO and marketing audits (`knowledge/playbooks/conversion-rate-optimization.md`, `/kai` audit workflows) | Auditing an existing referral program against Part 3 failure modes and Part 4 metrics; provenance rules apply to every number reported |
+| Content briefs for shareable assets (`harness/brief-schema.md` + skill contracts) | STEPPS scoring of drafts — which sharing driver the asset engineers, and the activation check (arousal, not just interest) |
+| Influencer/creator work (`knowledge/playbooks/influencer-marketing.md`) | Boundary call: paid/gifted creators route there; customer referral incentives route here; both route disclosure through `harness/references/creator-disclosure.md` |
+
+---
+
+## Sources
+
+- Berger, J. & Milkman, K. (2012). "What Makes Online Content Viral?" *Journal of Marketing Research* 49(2). https://journals.sagepub.com/doi/10.1509/jmr.10.0353
+- Berger, J. & Schwartz, E. (2011). "What Drives Immediate and Ongoing Word of Mouth?" *Journal of Marketing Research* 48(5). https://journals.sagepub.com/doi/10.1509/jmkr.48.5.869
+- Berger, J. (2013). *Contagious: Why Things Catch On*. Simon & Schuster. (STEPPS framework.)
+- Schmitt, P., Skiera, B. & Van den Bulte, C. (2011). "Referral Programs and Customer Value." *Journal of Marketing* 75(1). https://journals.sagepub.com/doi/abs/10.1509/jm.75.1.46 · PDF: https://faculty.wharton.upenn.edu/wp-content/uploads/2012/04/Schmitt-Skiera-vandenBulte-2011-Referral-Programs-Customer-Value.pdf
+- Van den Bulte, C., Bayer, E., Skiera, B. & Schmitt, P. (2018). "How Customer Referral Programs Turn Social Capital into Economic Capital." *Journal of Marketing Research* 55(1). https://journals.sagepub.com/doi/10.1509/jmr.14.0653
+- Ryu, G. & Feick, L. (2007). "A Penny for Your Thoughts: Referral Reward Programs and Referral Likelihood." *Journal of Marketing* 71(1). https://journals.sagepub.com/doi/10.1509/jmkg.71.1.084
+- Airbnb Engineering. "Hacking Word-of-Mouth: Making Referrals Work for Airbnb." https://medium.com/airbnb-engineering/hacking-word-of-mouth-making-referrals-work-for-airbnb-46468e7790a6
+- GrowSurf. "The Dropbox Referral Program: 3900% Growth in 15 Months" (secondary source for Dropbox figures, originally from Drew Houston's 2010 startup-lessons talk). https://growsurf.com/blog/dropbox-referral-program/
+- Nielsen (2021). *Trust in Advertising Study*. https://www.nielsen.com/insights/2021/beyond-martech-building-trust-with-consumers-and-engaging-where-sentiment-is-high/ · Sell sheet: https://develop.nielsen.com/wp-content/uploads/sites/2/2022/02/2021-Nielsen-Trust-In-Advertising-U.S.-sell-sheet.pdf
+- FTC. *Endorsement Guides: What People Are Asking*. https://www.ftc.gov/business-guidance/resources/ftcs-endorsement-guides-what-people-are-asking

--- a/knowledge/playbooks/retention-habit-loops.md
+++ b/knowledge/playbooks/retention-habit-loops.md
@@ -1,0 +1,193 @@
+# Behavioral Retention: Habit-Loop Design
+
+> **Use when:** Designing product/engagement mechanics that make usage recurring — habit loops, trigger systems, activation-moment definition, re-engagement programs. This is the **behavioral-psychology layer under** `knowledge/playbooks/customer-retention.md`. That playbook owns the retention *program* (dunning, onboarding sequences, health scoring, cancellation flow); this doc owns *why users come back without being pushed*, and where the ethical line sits.
+
+**Boundary rule:** if the question is "which email goes out on day 7," go to `customer-retention.md`. If the question is "why would the user open the product on day 70 with no email at all," stay here.
+
+---
+
+## The Evidence Base (what's established vs. what's synthesis)
+
+| Claim | Status | Source |
+|-------|--------|--------|
+| Variable (unpredictable) rewards produce the highest response rates and the greatest resistance to extinction | Established — lab-replicated operant conditioning | Ferster & Skinner, *Schedules of Reinforcement* (1957) |
+| Behavior occurs when Motivation, Ability, and a Prompt converge; ability is usually the bottleneck | Established model in persuasive-design literature | Fogg, "A Behavior Model for Persuasive Design" (2009) |
+| Habit automaticity builds asymptotically; median ~66 days to plateau, individual range 18–254 days | Single well-known field study (n=96, self-report); treat the 66 as a median, not a law | Lally et al., *European Journal of Social Psychology* (2010) |
+| Roughly 35–43% of daily behaviors are habitual — performed in stable contexts with minds elsewhere | Established via experience-sampling diary studies | Wood, Quinn & Kashy, *JPSP* (2002) |
+| Trigger → Action → Variable Reward → Investment as a product loop | **Practitioner synthesis**, not peer-reviewed — a packaging of the above by Nir Eyal (*Hooked*, 2014) | Eyal, nirandfar.com |
+
+Design implications you can act on:
+
+1. **Context stability is the habit substrate.** Wood et al. found habitual behavior lives in stable cues (same time, place, preceding action). Anchor product use to an existing stable moment ("after standup," "when the phone alarm fires"), not to free-floating motivation.
+2. **Plan for the 8–10 week gap.** If automaticity takes ~2 months to plateau (Lally), your externally-prompted lifecycle program must carry the user across that window. Loops that assume habit by week 2 churn.
+3. **Missing one repetition did not derail habit formation in Lally's data** — so re-engagement copy should normalize a lapse ("pick it back up"), not catastrophize it (streak-shaming; see guardrails).
+
+---
+
+## The Habit Loop (Trigger → Action → Variable Reward → Investment)
+
+The four-phase loop, per Eyal's *Hooked* model, built on the operant-conditioning and habit literature above. Charles Duhigg's cue → routine → reward loop (*The Power of Habit*, 2012) is the same skeleton minus the investment phase.
+
+```
+TRIGGER (external, then internal)
+   → ACTION (simplest behavior in anticipation of reward)
+      → VARIABLE REWARD (the itch scratched, with uncertainty)
+         → INVESTMENT (user puts something in; loads the next trigger)
+            → back to TRIGGER, cheaper each cycle
+```
+
+Run this audit for any product/feature you want to be habitual — one written answer per question:
+
+| Phase | Design question | Failure smell |
+|-------|-----------------|---------------|
+| Trigger | What *internal* discomfort (boredom, uncertainty, FOMO on work state, loneliness) should eventually cue use? What external trigger bridges until then? | Only external triggers exist; usage is 1:1 with notification volume |
+| Action | What is the smallest action that delivers relief? (Fogg: cut required ability before adding motivation) | Action requires >3 steps or a cold-start decision |
+| Variable reward | What genuinely varies each visit? | Reward is identical every time (habituation) or variance is fake (manufactured scarcity) |
+| Investment | What does the user store that makes the next cycle better — data, config, content, reputation, connections? | Value accrues to the vendor's lock-in, not the user's experience |
+
+### Step 1 — Triggers: internal vs. external
+
+- **External triggers** carry information in the environment: push notification, email, calendar slot, a teammate's @-mention, the icon itself. They start the loop but do not sustain it.
+- **Internal triggers** are associations in memory: an emotion or situation cues the product without any message. This is the definition of retained-by-habit.
+
+**Graduation rule:** external triggers are scaffolding. Instrument the ratio *unprompted sessions / total sessions* per cohort. If it is not rising month over month, you have a notification program, not a habit. If it is rising, **taper external trigger frequency for that cohort** — continuing to blast users who already return unprompted trains them to ignore you and burns consent (see re-engagement section).
+
+**Trigger-fit test before building:** name the internal trigger in one sentence — "When the user feels ___, they open ___ to get ___." If you cannot fill the blanks with a real recurring emotion or situation, the product may be episodic by nature (tax software, moving services). Episodic products should invest in *re-arrival* (SEO, brand memory, lifecycle timing) instead of forcing daily-habit mechanics that do not fit. Do not bolt streaks onto a product used four times a year.
+
+### Step 2 — Action: ability before motivation
+
+Fogg's model (B = Motivation × Ability × Prompt, all simultaneous): when a prompted behavior isn't happening, **fix ability first** — motivation is expensive and unstable, friction removal is cheap and durable. Concretely: cut steps, prefill state, restore last context on open, make the first screen the useful screen. Friction diagnosis method and evidence tiers are owned by `knowledge/playbooks/conversion-rate-optimization.md` — apply its Tier-1/Tier-2 evidence rule before claiming a friction fix worked.
+
+### Step 3 — Variable reward: variance must be real
+
+Ferster & Skinner: variable-ratio reinforcement is the most extinction-resistant schedule — which is exactly why it is both the most powerful retention mechanic and the mechanic slot machines use. Eyal's three reward types, with the legitimacy test for each:
+
+| Reward type | What varies | Legitimate when | Crosses the line when |
+|-------------|------------|-----------------|----------------------|
+| **Tribe** (social) | Acceptance, replies, recognition from others | Variance reflects real human responses | Synthetic engagement, bot inflation, engineered outrage |
+| **Hunt** (resources/information) | What you find this session (feed, search, marketplace) | The underlying inventory genuinely varies | Infinite-scroll padding, withheld results to extend sessions |
+| **Self** (mastery/completion) | Progress, competence, finishing | Progress maps to real capability or output | Progress bars measuring nothing; levels that exist only to be leveled |
+
+**Decision rule:** if you removed the variability, would the user still have gotten value this session? If no — the variance *was* the product — you are building a slot machine. Stop and route to the guardrails section.
+
+### Step 4 — Investment: stored value loads the next trigger
+
+Investment is work the user puts in that improves *their* next cycle: preferences set, data imported, content created, reputation earned, teammates invited. Two properties to design for:
+
+1. **It must improve the service for the user**, not merely raise their exit cost. Data hostage-taking is switching-cost lock-in wearing a habit costume — and it shows up in cancellation-flow complaints.
+2. **It should load the next trigger:** an invited teammate generates future mentions; a saved search generates future alerts; a posted question generates future answers. Ask of every investment feature: *what external trigger does this schedule?*
+
+---
+
+## Activation-Moment Identification
+
+The activation event is the earliest measurable moment that separates users who retain from users who vanish. Three distinct moments — do not conflate them:
+
+| Moment | Definition | Metric |
+|--------|-----------|--------|
+| **Setup moment** | Account is technically able to get value (data connected, app installed, team invited) | Setup completion rate |
+| **First-value moment** | User first receives the core value once (first report seen, first call answered) | Time-to-first-value (TTFV) |
+| **Habit moment** | Usage recurs without prompting (e.g., 3+ unprompted sessions/week for 2+ weeks) | Unprompted-session frequency |
+
+Per-product-type activation targets and the onboarding sequence that drives them are owned by `customer-retention.md` (Layer 2) — this doc owns how you *find and validate* the moment.
+
+**Method:**
+
+1. List 5–10 candidate events a new user can complete in week 1.
+2. For each, plot retention curves of users who did vs. didn't complete it (cohorted by signup week).
+3. Pick the **earliest** event with the **largest, most stable separation** — earliest matters because it's the one you can still influence during onboarding.
+4. **Validate causally before spending against it.** The correlation caveat is not optional: Facebook's famous "7 friends in 10 days" was a rallying metric derived from retrospective correlation (Palihapitiya; see Mode's analysis), and Mixpanel's own analysis calls a magic number "to a large extent, an illusion. But a very useful one" — users who were going to retain anyway also complete more milestones. Run the experiment: push a random holdout of new users toward the milestone; if their retention doesn't move, the milestone was a *marker* of good-fit users, not a *lever*. Markers are still useful — for health scoring and forecasting — but don't buy ads or rebuild onboarding around one.
+5. Re-derive annually or after major product changes; activation events go stale.
+
+**Data provenance:** activation analysis published to a client is quantitative/client-facing work — the Kai Data Provenance Rule applies (run the collector, declare mode, cite sources; never estimate a client's activation rate).
+
+---
+
+## Guardrails: The Line Between Habit and Manipulation (non-negotiable)
+
+**Kai does not design dark patterns.** Full doctrine: `docs/system/governance-and-quality.md`. This section is the behavioral-specific application.
+
+A habit loop is legitimate when the user, fully informed, would endorse the behavior it produces. Two screening tests, then hard rules:
+
+1. **Eyal's Manipulation Matrix:** would the maker use the product themselves, and does it materially improve the user's life? Builder uses it + improves life = *facilitator* (build it). Doesn't use it + doesn't improve life = *dealer* (walk away). The middle cells (*peddler*, *entertainer*) demand extra scrutiny of the reward mechanics.
+2. **The regret test:** if users could see exactly how the mechanic works and how much time/money it will extract, would they still opt in? A mechanic that survives only through opacity fails.
+
+**Hard rules — Kai refuses to build or recommend** (aligned with the FTC's 2022 *Bringing Dark Patterns to Light* staff report, which names trick/trap design practices across e-commerce, subscriptions, and consent flows; taxonomy originated by Harry Brignull, 2010, deceptive.design):
+
+- **Roach motels:** easy in, deliberately hard out. Cancellation must be findable and no harder than signup (`customer-retention.md` cancellation flow already mandates this). Legal note: the FTC's click-to-cancel (Negative Option) rule was vacated on procedural grounds by the Eighth Circuit in July 2025, and the FTC moved in January 2026 to restart rulemaking — but FTC Act §5 and state auto-renewal laws still support enforcement. **Design to the stricter standard regardless of the rule's status.**
+- **Manufactured scarcity/urgency:** fake countdowns, false "2 left" claims, invented social proof. (Real scarcity, stated accurately, is fine.)
+- **Loss-aversion coercion:** streak mechanics whose primary emotion is fear of loss rather than pride of progress; guilt-copy on lapse ("your plant will die"). Streaks pass only with lapse-forgiveness built in — consistent with Lally's finding that a missed repetition doesn't break habit formation.
+- **Confirmshaming, forced continuity without clear disclosure, pre-checked consent boxes, buried terms, obstruction of data export.**
+- **Variable rewards aimed at minors or at compulsive-use surfaces** (gambling-adjacent mechanics, paid loot-box-style reveals) — decline regardless of client instruction.
+
+**Escalation rule:** if a client asks for any of the above, do not silently soften it — flag the request, cite this section and `docs/system/governance-and-quality.md`, and offer the compliant alternative. This is a Stop condition under the Instruction Contract in `AGENTS.md`.
+
+---
+
+## Re-engagement and Lifecycle Triggers That Respect Consent
+
+Sequencing, dunning, and win-back program mechanics live in `customer-retention.md` (Layers 1–5) and `knowledge/channels/email-lifecycle.md`. This doc adds the behavioral trigger rules:
+
+| Trigger class | Fires on | Consent basis | Cap discipline |
+|---------------|----------|---------------|----------------|
+| Transactional | User's own action (receipt, alert they configured) | Implicit in the action | No cap needed; never smuggle marketing into it |
+| Behavioral | Usage signal (lapsed 14 days, feature abandoned mid-task) | Marketing consent + honest unsubscribe | Max 1–2 per signal; stop when signal resolves |
+| Lifecycle | Calendar/stage (day-7 check-in, renewal, anniversary) | Marketing consent | Program-level frequency cap across all sequences combined |
+
+**Rules:**
+
+1. **Tie every re-engagement message to the user's internal trigger, not yours.** "You have 3 unanswered messages" (their loop) beats "We miss you" (your loop). Message content should restart the habit loop at the trigger phase — cue the itch, shrink the action ("resume where you left off" deep link), never announce features alone.
+2. **Respect the taper.** Users returning unprompted get *fewer* messages, not more. Suppress lifecycle sends for users above the habit-moment threshold except transactional and genuinely new-value announcements.
+3. **Silence is data.** Two ignored re-engagement attempts on one signal = stop that signal for that user. Escalating frequency against a non-responder is how consent turns into spam complaints.
+4. **Consent mechanics** (CAN-SPAM, GDPR, granular preference centers, sunset policies) are owned by `harness/references/advertising-compliance.md` and `harness/references/cold-email-rules.md` — load them before writing any sequence.
+5. **Approval doctrine:** any live send — email, push, in-app campaign — requires human approval before it ships. Publishing is OFF by default in this harness; drafts go through the quality gates and a human, never straight to the channel.
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails | Fix |
+|--------------|-------------|-----|
+| Notification-driven "engagement" counted as retention | Usage collapses when sends stop; you measured your own arm strength | Track unprompted-session ratio as the habit KPI |
+| Treating a correlated milestone as a causal lever | Post-hoc cohorts flatter any early action good-fit users take | Holdout experiment before investing (see Activation method, step 4) |
+| Daily-habit mechanics on an episodic product | No recurring internal trigger exists to attach to | Design for re-arrival (brand, SEO, timed lifecycle) instead |
+| Reward variance with no underlying value variance | Slot-machine dynamics; regret-test failure; churn plus reputation risk | Variance must come from real inventory/social/progress differences |
+| Investment features that only raise exit costs | Lock-in masquerading as habit; shows up in cancellation complaints and reviews | Every investment must improve the user's next session |
+| Streak mechanics without lapse forgiveness | Loss-aversion coercion; one miss converts your most engaged users to churned | Repair/freeze mechanics + normalize-the-lapse copy |
+
+---
+
+## Worked Example (compressed)
+
+B2B call-analytics tool, trial-to-paid retention problem. (1) **Internal trigger:** anxiety of "what happened on today's calls while I was in meetings" — recurring, real. (2) **Action:** open app → yesterday's digest is the first screen, zero clicks (ability fix). (3) **Variable reward:** hunt-type — which calls flagged, what objections surfaced; variance is real because call content varies. (4) **Investment:** user tags one call per day (improves tomorrow's flagging) and sets a weekly team digest (loads a tribe-reward trigger for colleagues). Activation analysis: candidate events plotted; "connected phone system + viewed 1 digest within 24h" shows earliest/largest retention separation; holdout nudge experiment confirms +retention before onboarding is rebuilt around it. External triggers: daily digest email, tapered per user once unprompted opens exceed 3/week. All sends drafted through gates, human-approved before enabling.
+
+---
+
+## How This Maps Into Kai
+
+| Kai surface | Loads this doc for |
+|-------------|--------------------|
+| `kai-retention` / retention engagements | The habit-loop audit, activation-moment method, and guardrails before any mechanic is recommended; program design stays in `customer-retention.md` |
+| `kai-cro` / `kai-funnel-audit` / CRO work | Step 2 (ability-first friction) and activation-moment definitions when the funnel extends past first conversion |
+| Lifecycle/email work (`email-lifecycle.yaml` contract) | Trigger-class table, cap discipline, and taper rules for re-engagement sequences |
+| `kai-audit` / marketing audits | Flagging dark-pattern retention mechanics on audited properties as findings (cite the Guardrails section) |
+| Onboarding/growth planning (`growth-loops-applied.md`, `demand-generation.md`) | Distinguishing setup / first-value / habit moments before setting activation KPIs |
+
+Decision it settles: **whether a proposed retention mechanic is a habit loop or a dark pattern, and which activation metric deserves investment.** Anything quantitative and client-facing that comes out of this work runs the Kai Data Provenance Rule and the standard gate pipeline; live sends require human approval.
+
+---
+
+## Sources
+
+- Eyal, N. — Hooked model overview: https://www.nirandfar.com/how-to-manufacture-desire/ (book: *Hooked: How to Build Habit-Forming Products*, 2014)
+- Fogg, B.J. (2009), "A Behavior Model for Persuasive Design," Persuasive '09: https://doi.org/10.1145/1541948.1541999 · model page: https://behaviordesign.stanford.edu/resources/fogg-behavior-model
+- Lally, P., van Jaarsveld, C., Potts, H., Wardle, J. (2010), "How are habits formed: Modelling habit formation in the real world," *EJSP* 40(6): https://onlinelibrary.wiley.com/doi/abs/10.1002/ejsp.674
+- Wood, W., Quinn, J., Kashy, D. (2002), "Habits in everyday life," *JPSP* 83(6): https://dornsife.usc.edu/wendy-wood/wp-content/uploads/sites/183/2023/10/Wood.Quinn_.Kashy_.2002_Habits_in_everyday_life.pdf
+- Ferster, C.B. & Skinner, B.F. (1957), *Schedules of Reinforcement*: https://books.google.com/books/about/Schedules_of_Reinforcement.html?id=xctyCQAAQBAJ
+- Mode Analytics, "Facebook's 'Aha' Moment Was Simpler Than You Think": https://mode.com/blog/facebook-aha-moment-simpler-than-you-think/
+- Mixpanel, "Magic numbers are an illusion": https://mixpanel.com/blog/magic-numbers-are-an-illusion/
+- FTC Staff Report (2022), *Bringing Dark Patterns to Light*: https://www.ftc.gov/reports/bringing-dark-patterns-light
+- Brignull, H., Deceptive Design pattern taxonomy (coined "dark patterns," 2010): https://www.deceptive.design/
+- WilmerHale (Aug 2025), "Eighth Circuit Vacates the FTC's 'Click to Cancel' Rule": https://www.wilmerhale.com/en/insights/client-alerts/20250801-eighth-circuit-vacates-the-ftcs-click-to-cancel-rule-but-federal-and-state-regulators-likely-to-remain-active
+- Crowell & Moring (2026), "FTC Moves to Revive 'Click-to-Cancel' Rule Following Eighth Circuit Vacatur": https://www.crowell.com/en/insights/client-alerts/clicking-all-the-right-boxes-ftc-moves-to-revive-click-to-cancel-rule-following-eighth-circuit-vacatur
+- Andrew Chen, on deriving "7 friends in 10 days"-style insights: https://andrewchen.com/my-quora-answer-to-how-do-you-find-insights-like-facebooks-7-friends-in-10-days-to-grow-your-product-faster/

--- a/knowledge/playbooks/services-value-pricing.md
+++ b/knowledge/playbooks/services-value-pricing.md
@@ -1,0 +1,204 @@
+# Services Value Pricing & Positioning
+
+> **Use when:** Pricing or repositioning a service business — agency, consultancy, freelancer, or local/home service operator (the KaiCalls-adjacent ICP). Covers escaping hourly billing, value-based pricing mechanics, three-option proposals, productized services, expertise positioning, diagnostic-first selling, and retainer design.
+>
+> **Counterpart docs:** `knowledge/playbooks/pricing-strategy.md` (product/SaaS pricing psychology, tiers, value metrics) and `knowledge/playbooks/sales-pricing-and-packaging.md` (Kai's workflow for turning client signals into approval-ready pricing recommendations — its guardrails apply to everything here). This doc is the services-side method. Home-services street-level tactics: `knowledge/people/tommy-mello-knowledge.md`.
+
+---
+
+## Core Thesis
+
+Service businesses sell outcomes but most price inputs (hours). That mismatch caps income, rewards inefficiency, and turns every invoice into an argument. The escape sequence is always the same: **narrow the positioning → diagnose before prescribing → run a value conversation → present three options priced against the client's value, not your cost**. Each step earns the pricing power the next step spends.
+
+Market data says the shift is underway, not hypothetical. In accounting, hourly billing has collapsed to 10% or fewer firms for each benchmarked service — and to under 4% of firms as a primary model, down from ~8% in 2024 — while fixed-fee is now the dominant model at 54% of firms (Ignition 2025 US benchmark, n=219). Agency benchmarks show hourly billing still offered by ~42% of agencies but earning the worst margins of any model: ~13% net for hourly vs ~18% for value-based, ~16% for retainers (Agiled 2026 aggregation). Treat these as directional benchmarks, not laws.
+
+---
+
+## Why Hourly Billing Fails (the four structural defects)
+
+| Defect | Mechanism | Symptom you'll observe |
+|--------|-----------|------------------------|
+| **Income ceiling** | Revenue = rate × hours; hours are capped at ~2,000/yr and rate is capped by market comparison | Growth requires headcount, margins never improve |
+| **Efficiency penalty** | Getting faster at the work cuts your own revenue; expertise makes you cheaper | Your best, fastest people are your least profitable to bill |
+| **Misaligned incentives** | You earn more when the work takes longer; the client wants it done sooner | Scope disputes, invoice audits, trust erosion |
+| **Commodity framing** | An hourly rate invites rate-card comparison against every other vendor | "Your rate is higher than X" objections; procurement wins |
+
+Jonathan Stark's summary: "If you sell somebody an hour, you cannot make it more efficient... it artificially limits your income" (*Hourly Billing Is Nuts*). Alan Weiss made the same case for consultants in *Value-Based Fees* (2002): a fee based on time punishes the expert and confuses cost with value.
+
+**Decision rule:** hourly is acceptable only for (a) genuinely unbounded exploratory work you cannot scope, and (b) staff-augmentation arrangements where the client manages the work. Everything else moves up the ladder below.
+
+### The pricing model ladder
+
+```
+Hourly → Day/week rate → Fixed-price project → Productized service → Retainer → Value-priced engagement
+(input)   (input, bulk)    (output)              (output, repeatable)  (access/output)  (outcome)
+```
+
+Each rung transfers risk from client to provider and pays the provider for taking it. Move one rung at a time; new clients first, legacy clients on renewal.
+
+---
+
+## Value-Based Pricing Mechanics
+
+### Rule 1: Price the client, not the service
+
+The same deliverable is worth different amounts to different buyers. A landing page that lifts conversion 1% is worth ~$500/yr to a $50k/yr shop and ~$100k/yr to a $10M/yr business. Blair Enns (*Pricing Creativity*, 2018): price the client and the situation; a rate card that prices the service guarantees you capture none of the difference.
+
+### Rule 2: Run the value conversation before any proposal
+
+Framework source: Mahan Khalsa (*Let's Get Real or Let's Not Play*) — which David C. Baker calls the definitive treatment — plus Enns's four-question version. Sequence:
+
+1. **Desired future state.** "What does success look like 12 months after this engagement?" Get specifics, not adjectives.
+2. **Metrics.** "How will you measure that?" Force a number: revenue, cost saved, calls booked, churn cut, deals closed.
+3. **Value.** "What is that worth?" Do the arithmetic with the client, out loud, using their numbers. Write it down — it becomes the anchor in the proposal.
+4. **Willingness.** "Would solving this be worth an investment in the range of X–Y?" Test the ceiling before writing anything.
+
+**Gate:** if the client cannot or will not quantify value, either the problem isn't worth solving (walk) or the engagement is a commodity task (productize it — see below). Never write a value-priced proposal without a client-stated value number. Never invent one for them.
+
+### Rule 3: Set the fee against value, not cost
+
+Common practitioner heuristic (Stark, Weiss): price so the client's conservative expected return is roughly 5–10× the fee. This is a negotiating norm, not a research finding — the real constraints are the client-stated value ceiling from the conversation and your cost floor (delivery cost × target margin). Fee lands between them, closer to value than to cost as your proof and positioning strengthen.
+
+### Rule 4: Three options, anchored high
+
+Never send a single take-it-or-leave-it number. Enns's proposal rules:
+
+- **Always three options** in one proposal, on one page, prices visible. Enns claims this alone raises positive outcomes by roughly half (practitioner claim from *Pricing Creativity*, not a controlled study — flag it as such if a client asks).
+- **Present the most expensive option first.** Anchoring high makes the middle feel reasonable and pushes clients to think bigger.
+- **Expect the middle to win.** Extremeness aversion / the compromise effect (Simonson & Tversky 1992) is well documented in choice research, though later replications show the effect size varies by context: buyers tend to avoid the edges because the middle is easiest to justify. Design your intended sale as Option 2. (Product-tier version of the same psychology: `knowledge/playbooks/pricing-strategy.md`, Decoy Effect.)
+- **Options differ in value and risk, not effort.** Option 1 = core outcome. Option 2 = outcome + speed/breadth/support. Option 3 = outcome + guarantees, exclusivity, senior access, or performance component. Never build options by subtracting hours.
+- **Price spread wide.** If the options are $20k / $24k / $28k there is no anchor. A workable spread is roughly 1× / 2× / 4–6×; the top option should mildly shock.
+
+**Worked example (agency, lead-gen engagement, client-stated value ≈ $400k/yr in new revenue):**
+
+```
+OPTION 3 — "Market Ownership"   $120k   Everything in 2, plus category exclusivity,
+                                        weekly exec access, performance bonus tied to SQLs
+OPTION 2 — "Pipeline Engine"    $60k    Full funnel build + 6 months optimization + reporting  ← target
+OPTION 1 — "Foundation"         $28k    Funnel build, handoff playbook, 30-day support
+```
+
+Even at Option 3, the client's stated value is >3× the fee. At Option 2 it's >6×.
+
+### Guardrails (non-negotiable)
+
+Per `knowledge/playbooks/sales-pricing-and-packaging.md`: do not invent value numbers, win rates, or ROI claims; do not call any price "optimal" without evidence; live pricing-page changes, offer sends, and CRM updates require human approval. Any published claim about pricing results needs a collector source under the Kai Data Provenance Rule.
+
+---
+
+## Productized Services
+
+A productized service is a fixed-scope, fixed-price, standardized-workflow offer sold repeatedly: "X deliverable, $Y, in Z days" (Brian Casel, who popularized the model). Examples: technical SEO audit at $4,500/10 days; conversion teardown at $1,500/5 days; "unlimited design requests" subscriptions; a garage-door tune-up at $189.
+
+### When productized beats custom
+
+| Choose productized when... | Stay custom/value-priced when... |
+|---------------------------|----------------------------------|
+| You've delivered the same engagement 3+ times with a stable process | Every engagement genuinely differs in scope and stakes |
+| Buyers know what they need and want a price on the page | Buyers need diagnosis before they know what to buy |
+| Deal size is too small to justify a value conversation (< ~$10k) | Client-specific value is large and quantifiable |
+| You want sales without founders on every call | Senior judgment IS the deliverable |
+| You need a low-friction entry offer that feeds bigger work | You're capacity-constrained and selling out anyway |
+
+### Build sequence
+
+1. Pick the engagement you've repeated most with the best outcomes.
+2. Freeze scope: exact deliverables, exact exclusions, exact timeline. Write the exclusions list first — it's the anti-scope-creep contract.
+3. Document the delivery checklist so a non-founder can run 80% of it.
+4. Price it: cost floor = (delivery hours × loaded cost) ÷ (1 − target margin); then test upward against outcome value. Productized prices are published, so revisit quarterly.
+5. Sell it as the diagnostic entry point (next section) — the productized audit's natural upsell is the custom engagement that fixes what it found.
+
+**Failure mode:** productizing a service that still requires custom diagnosis per client. You'll either eat scope creep or ship templated junk. If >20% of deliveries need scope exceptions, the offer isn't ready to be a product.
+
+---
+
+## Expertise Positioning: Narrow Focus → Pricing Power
+
+Value pricing is downstream of positioning. A generalist cannot anchor on value because the client can always compare them to another generalist's rate card. This is the **generalist trap**: broad positioning feels safer ("we don't turn anything down") but forces competition on price, the only dimension left when expertise claims are unverifiable.
+
+Evidence: Hinge Research Institute's High Growth Study series consistently correlates specialization with growth and profitability — high-growth professional-services firms are 75% more likely to have a highly focused niche, and the 2025 edition found them 22% more likely to be highly specialized in at least one of five axes (service, client problem, buyer role, industry, geography). David C. Baker (*The Business of Expertise*) gives the causal story: narrow focus → pattern recognition across similar clients → real insight generalists can't fake → fewer substitutes → pricing power.
+
+### Positioning decision rules
+
+- **Pick one axis first**: vertical (industry: "marketing for med spas") or horizontal (problem: "churn reduction for subscription businesses"). Vertical is easier to market to (lists, associations, trade press exist); horizontal travels better across a downturn in one industry.
+- **Minimum viable market test (Baker's heuristics):** enough prospects that losing any one client doesn't matter (think hundreds to low thousands of qualified targets, not ten), few enough that you can plausibly become a known name in it.
+- **The claim must be falsifiable.** "Full-service digital agency" excludes no one and proves nothing. "We do CRO for DTC supplement brands doing $2–20M" excludes almost everyone — which is what makes the remaining prospects pay attention and pay more.
+- **Narrowing is a marketing decision, not a delivery decision.** You may still accept off-target work quietly; you market only the focus.
+
+**Local/home services variant:** positioning power comes from perceived legitimacy, not niche selection — branding, wraps, uniforms, reviews, and answered phones set the price ceiling before anyone quotes. A1 Garage Door doubled prices after a professional rebrand and the market accepted it. Full mechanics, option ladders, and monthly-payment framing: `knowledge/people/tommy-mello-knowledge.md` (Pricing & Average-Ticket Mechanics).
+
+---
+
+## Diagnostic Before Prescription
+
+"Prescription before diagnosis is malpractice" — the medical norm, imported into consultative selling via Khalsa and standard in expert-firm practice (Baker's "roadmapping," agencies' paid discovery). Free proposals are unpaid diagnosis: they train clients that your thinking is free and force you to prescribe from ignorance.
+
+**The paid diagnostic offer:**
+
+1. **Scope:** a fixed-price, fixed-timeline engagement (often productized) that produces a findings report + prioritized roadmap. Common sizing heuristic: 5–15% of the likely full engagement price — small enough to be a low-friction yes, large enough to signal the thinking has value. (Heuristic, not research.)
+2. **Position it as valuable standalone.** The client can take the roadmap to anyone, including in-house. Paradoxically this raises conversion to your own follow-on work — you've demonstrated the expertise rather than claimed it.
+3. **It powers the value conversation.** The diagnostic surfaces the numbers (missed calls, leaking funnel steps, churn cost) that Rule 2 above needs. Under Kai's provenance rules, those numbers must come from collectors or client-connected data — see `harness/references/audit-data-provenance.md`.
+4. **It filters.** A prospect who won't pay for diagnosis was never going to pay for the cure.
+
+**Decision rule:** any engagement above ~$15–25k, or any prospect who asks "what would you do for us?" before sharing data, gets routed to the diagnostic. Skip it only when you've already served near-identical clients and can prescribe from pattern (that's the specialization dividend paying out).
+
+---
+
+## Retainer Design: Access vs Deliverable
+
+Retainers are the highest-margin recurring model in agency benchmarks (~16% net vs 13% hourly — Agiled 2026) but only when designed as commitments to value, not prepaid hour banks.
+
+| | **Access retainer** | **Deliverable retainer** |
+|---|---|---|
+| What's sold | Availability of your judgment: advice, review, priority response | A recurring output bundle: N posts, campaigns managed, reports shipped |
+| Priced on | Seniority + exclusivity + response time | Outcome value of the bundle (not summed task hours) |
+| Best for | Consultants, fractional execs, strategic advisors | Agencies, productized ops (content, ads management, bookkeeping) |
+| Classic design | Weiss's model: fee for access to your smarts, scoped by who/how/when — never by hours | Fixed monthly scope with a named swap mechanism for flexibility |
+| Failure mode | Client "banks" unused time and demands rollover → you've rebuilt hourly billing | Scope creep via "small additions" → margin decays invisibly |
+
+**Design rules:**
+
+1. **No hour banks, no rollover.** The retainer buys availability or a defined bundle in that month; unused capacity expires. If a client insists on hour accounting, they're buying hourly work — price it as such or decline.
+2. **Minimum term 3 months, billed monthly in advance.** Value from advisory work lags; shorter terms invite churn before results land.
+3. **Cap concurrent retainers** at real capacity (access retainers fail publicly when two clients call at once).
+4. **Quarterly value review:** restate what the retainer produced against the client's metrics (from the value conversation) — this is what defends renewal price increases. 80% of accounting firms plan fee raises for 2026 (Ignition); retainers without documented value are the ones that can't follow.
+5. **Escalation path:** productized offer → project → deliverable retainer → access retainer is the natural client lifetime arc. Design each offer to make the next one the obvious yes.
+
+---
+
+## Anti-Patterns
+
+1. **Publishing an hourly rate "for reference."** It becomes the denominator for every fee you ever quote.
+2. **Value conversation after the proposal.** The anchor is set; you're negotiating against yourself.
+3. **Three options built by subtracting effort.** Clients see a discount menu, not a value ladder.
+4. **Discounting instead of descoping.** Price defends value; if the client can't afford Option 1, remove outcomes, don't cut the price of the same outcomes. (Same rule as Mello's "never discount the trip charge — widen the option ladder.")
+5. **Niching in the marketing, generalizing in the case studies.** The proof must match the claim or the premium evaporates.
+6. **Guaranteeing outcomes you don't control** (rankings, revenue) to justify value prices — compliance risk and margin roulette. Performance components belong in Option 3, capped and defined.
+7. **Fabricating ROI math in proposals.** Every number in a client-facing pricing document needs a source the client gave you or a collector produced.
+
+---
+
+## How This Maps Into Kai
+
+- **`kai-audit` / CRO audits / marketing audits** — the paid-diagnostic section is the commercial frame for audit offers; provenance rules (`harness/references/audit-data-provenance.md`) govern every number that feeds a value conversation. KaiCalls Fit Rule applies when the diagnostic finds phone-led lead-capture pain.
+- **`sales-pricing-and-packaging.md` workflows** — when the client is a service business, load this doc for offer-shape options (productized / retainer / value-priced) and the dry-run memo's Conservative/Focused/Expansion options map onto the three-option proposal rules here.
+- **Proposal and offer drafting** (`/kai-write`, landing pages for service businesses) — three-option structure, anchor-high ordering, and access-vs-deliverable retainer language come from this doc; `pricing-strategy.md` supplies tier-page psychology when the service is productized enough to have a pricing page.
+- **Positioning engagements** (`kai-brand`, competitor teardowns) — the narrow-focus decision rules and generalist-trap diagnosis frame repositioning recommendations for agency/consultancy clients.
+- **Home-services clients** — route pricing-mechanics questions (option ladders, ticket size, financing framing) to `knowledge/people/tommy-mello-knowledge.md`; this doc supplies the retainer/membership and diagnostic layers above it.
+- **Approval doctrine:** everything here is recommendation-layer. Changing live prices, sending proposals, or editing pricing pages requires explicit human approval per the sales-pricing guardrails.
+
+---
+
+## Sources
+
+- Ignition, 2025/2026 U.S. Accounting and Tax Pricing Benchmark (n=219 firms) — https://www.ignitionapp.com/news/the-end-of-hourly-billing-ignitions-2025-benchmark-signals-pricing-shift-for-firms
+- Agiled, Agency Pricing Statistics 2026 (model mix and margin benchmarks) — https://agiled.app/statistics/agency-pricing-statistics
+- 4A's 2025 Billing Rate Benchmark Survey — https://www.aaaa.org/resource/4as-2025-billing-rate-benchmark-survey-agency-hourly-billing-rates/
+- Blair Enns, *Pricing Creativity* — rules summarized in The Drum interview: https://www.thedrum.com/news/2023/05/12/putting-the-procurement-debate-bed-blair-enns-s-3-rules-pricing-creativity and Peter Kang's notes: https://www.peterkang.com/lessons-from-pricing-creativity-by-blair-enns/
+- Simonson, I. & Tversky, A. (1992), "Choice in Context: Tradeoff Contrast and Extremeness Aversion," *Journal of Marketing Research* — https://journals.sagepub.com/doi/abs/10.1177/002224379202900301
+- Hinge Research Institute, High Growth Study 2025 — https://hingemarketing.com/blog/story/high-growth-study-2025-insights-into-todays-best-performing-firms and specialization analysis: https://hingemarketing.com/blog/story/to-specialize-or-not-to-specialize
+- Alan Weiss, *Value-Based Fees: How to Charge — and Get — What You're Worth* — https://www.goodreads.com/book/show/1145457.Value_Based_Fees
+- Jonathan Stark, *Hourly Billing Is Nuts* — Soul of Enterprise interview: https://www.thesoulofenterprise.com/tsoe/jonathan-stark-hourly-billing-is-nuts
+- Brian Casel on productized services — https://doubleyourfreelancing.com/productizedservices/
+- Mahan Khalsa, *Let's Get Real or Let's Not Play*; David C. Baker, *The Business of Expertise* — Soul of Enterprise interview: https://www.thesoulofenterprise.com/tsoe/david-c-baker-business-expertise-interview
+- Tommy Mello pricing mechanics (internal): `knowledge/people/tommy-mello-knowledge.md`

--- a/scripts/knowledge_freshness.py
+++ b/scripts/knowledge_freshness.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Knowledge freshness sweep.
+
+Scans knowledge/ markdown docs for date metadata (``**Created:**`` or
+``**Last verified:**`` lines) and flags docs past their shelf life so
+volatile claims (roles, prices, benchmarks, platform behavior) get
+re-verified instead of silently decaying. Advisory by default — exits 0
+unless --strict is passed with stale docs present.
+
+Usage:
+    python scripts/knowledge_freshness.py                 # report
+    python scripts/knowledge_freshness.py --months 6      # tighter window
+    python scripts/knowledge_freshness.py --strict        # exit 1 on stale
+    python scripts/knowledge_freshness.py --dir knowledge/people
+
+A doc's freshness date is its ``**Last verified:**`` line when present,
+else its ``**Created:**`` line. Docs with neither are reported as
+"undated" (index files starting with ``_`` are skipped — they change with
+the tree, not with the calendar).
+"""
+
+import argparse
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+DATE_LINE = re.compile(
+    r"\*\*(Last verified|Created):\*\*\s*(?:(\w+)\s+)?(\d{4})", re.IGNORECASE
+)
+MONTHS = {
+    m.lower(): i
+    for i, m in enumerate(
+        [
+            "January", "February", "March", "April", "May", "June",
+            "July", "August", "September", "October", "November", "December",
+        ],
+        start=1,
+    )
+}
+
+
+def doc_date(path: Path):
+    """Return (date, kind) from metadata, preferring Last verified."""
+    found = {}
+    try:
+        head = path.read_text(encoding="utf-8", errors="replace")[:2000]
+    except OSError:
+        return None, None
+    for match in DATE_LINE.finditer(head):
+        kind = match.group(1).lower()
+        month = MONTHS.get((match.group(2) or "").lower(), 6)
+        found[kind] = date(int(match.group(3)), month, 1)
+    if "last verified" in found:
+        return found["last verified"], "last verified"
+    if "created" in found:
+        return found["created"], "created"
+    return None, None
+
+
+def months_between(old: date, new: date) -> int:
+    return (new.year - old.year) * 12 + new.month - old.month
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Flag stale knowledge docs")
+    parser.add_argument("--dir", default="knowledge", help="directory to scan")
+    parser.add_argument("--months", type=int, default=12, help="staleness window")
+    parser.add_argument("--strict", action="store_true", help="exit 1 if stale docs found")
+    parser.add_argument("--show-all-undated", action="store_true", help="list every undated doc")
+    args = parser.parse_args()
+
+    root = Path(args.dir)
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 2
+
+    today = date.today()
+    stale, undated, fresh = [], [], 0
+    for path in sorted(root.rglob("*.md")):
+        if path.name.startswith("_"):
+            continue
+        stamp, kind = doc_date(path)
+        if stamp is None:
+            undated.append(path)
+        elif months_between(stamp, today) >= args.months:
+            stale.append((path, stamp, kind))
+        else:
+            fresh += 1
+
+    print(f"Knowledge freshness sweep — {root}/ (window: {args.months} months)")
+    print(f"  fresh: {fresh}   stale: {len(stale)}   undated: {len(undated)}\n")
+    if stale:
+        print("Stale (re-verify volatile claims — roles, prices, benchmarks):")
+        for path, stamp, kind in stale:
+            print(f"  {path}  ({kind} {stamp.strftime('%B %Y')})")
+        print()
+    if undated:
+        print("Undated (add a '**Created:**' or '**Last verified:**' line):")
+        shown = undated if args.show_all_undated else undated[:15]
+        for path in shown:
+            print(f"  {path}")
+        hidden = len(undated) - len(shown)
+        if hidden:
+            print(f"  ... and {hidden} more (--show-all-undated to list)")
+        print()
+    if not stale and not undated:
+        print("All dated docs inside the freshness window.")
+
+    return 1 if (args.strict and stale) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Follow-up to #49, per direction: no more people-mining — this wave is **person-agnostic frameworks and enforceable rules**. All landed.

### `knowledge/frameworks/marketing-science/` (new directory)

| Doc | Governs |
|---|---|
| `brand-growth-laws.md` | Availability doctrine, distinctive assets, category entry points, light-buyer math — with a 9-signal DR-vs-availability decision table |
| `brand-activation-budget.md` | Long/short evidence, ESOV, allocation worksheet by stage/category — 60/40 framed as a contested databank average, criticisms section included |
| `diagnosis-first-operating-order.md` | Diagnosis → strategy → tactics with evidence bars, failure-mode taxonomy, and a gate rule: no PRODUCE skill before diagnosis inputs exist |
| `experiment-rigor.md` | Sample floors, peeking, Twyman's law, Simpson's paradox, low-traffic alternatives, ICE/RICE failure modes |
| `attribution-and-incrementality.md` | Platform ROAS bias mechanics, MMM vs MTA vs incrementality decision rules, holdout design; reports must state measurement method + bias |
| `growth-metrics-and-pmf.md` | AARRR instrumentation, North Star selection, PMF survey (with its critics), cohort reading |

### `knowledge/playbooks/` (8 new)

demand-side-research (switch interviews / four forces), messaging-architecture (category → narrative → positioning → homepage, with agreement audit), referral-and-word-of-mouth, retention-habit-loops (with ethics guardrails), community-as-channel, services-value-pricing (agency/local-services ICP), product-led-seo, newsletter-growth-economics.

### Rules layer

- **`knowledge/_arbitration.md`** — the keystone: doctrine-conflict routing (brand vs DR, WTP vs value-equation pricing, PLG vs sales-led) resolved by stage/vertical/evidence-state, with vertical routing tables and an escalation rule when doctrines tie. Loaded by planning skills.
- **`scripts/knowledge_freshness.py`** — sweeps knowledge/ for Created/Last-verified metadata, flags stale + undated docs (advisory; `--strict` for CI).

## How it was built

15-lane build → adversarial-verify workflow (30 agents, ~2.2M tokens), plus the freshness script built inline. Verifiers web-checked citations on every doc; representative catches: a misattributed double-jeopardy replication paper, Profit Ability 2 dataset scope stated wrong (141 brands, not "3.5k campaigns"), B2B ESOV coefficient off by 0.1pp, a phantom `kai-positioning` skill reference, and the famous-figure trap (60/40, 76% category-king) now framed as contested with sources.

## Integration

- `knowledge/_index.md`: new Marketing Science section + 8 playbook rows
- `AGENTS.md`: framework-map rows (doctrine conflicts, measurement honesty) + inventory counts
- `/kai-newsletter` loads the growth-economics playbook

## Verification

- `python scripts/doctor.py` — harness intact
- `python scripts/quality_gates/golden_check.py` — all cases pass
- `banned_word_check.py --file` — Tier 1 clear on all 15 new docs
- 15/15 docs through adversarial verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWoxXPsvet5d7u3pKEVv8T