### PR TITLE
feat: framework attribution loop + expert-drift monitor

### DIFF
--- a/.claude/rules/architecture-and-memory.md
+++ b/.claude/rules/architecture-and-memory.md
@@ -85,9 +85,14 @@ Prefer the executable form: if a lesson can be a regex, threshold, or checklist 
 Run `/kai-retro` monthly or after any sprint with 5+ gated pieces:
 
 ```bash
-python scripts/self_improvement/lesson_capture.py mine     # recurring gate failures --> candidate lessons
-python scripts/self_improvement/lesson_capture.py losers   # undiagnosed 30-day losers
+python scripts/self_improvement/lesson_capture.py mine            # recurring gate failures --> candidate lessons
+python scripts/self_improvement/lesson_capture.py losers          # undiagnosed 30-day losers
+python scripts/self_improvement/framework_attribution.py          # per-framework 30-day grade report + review candidates
+python scripts/knowledge_freshness.py                             # stale/undated knowledge docs
+python scripts/intel/expert_drift.py --check                      # new material from cloned experts' sources
 ```
+
+Content-log entries record which frameworks informed each draft (`frameworks` field, written by the engine), so the attribution report grades the frameworks themselves from measured outcomes. Frameworks flagged as review candidates get diagnosed via `/kai-retro` — never auto-edited.
 
 Then triage every lesson — promote / keep / merge / retire (never delete; git keeps history).
 

--- a/.claude/rules/scripts-and-tools.md
+++ b/.claude/rules/scripts-and-tools.md
@@ -53,6 +53,7 @@ python scripts/harness_cli.py run --task blog --site mysite --keyword "..." --pu
 | `python scripts/intel/content_gap.py --site X` | Keywords competitors rank for that you don't |
 | `python scripts/intel/market_brief.py` | AI-synthesized weekly competitive brief |
 | `python scripts/intel/brand_pulse.py <brand> --domain <domain>` | Brand-pulse snapshot (reviews, mentions, share of voice) |
+| `python scripts/intel/expert_drift.py --init/--discover/--check` | Expert-drift monitor — watches cloned experts' cited sources (`knowledge/people/_expert-sources.json`) for new material; report lands in `data/intel/expert-drift-report.md` |
 
 Reddit listening: `scripts/reddit_monitor/reddit_listener.py` + `scripts/reddit_monitor/reddit_digest.py` (profiles in `scripts/reddit_monitor/profiles`).
 

--- a/knowledge/people/_expert-sources.json
+++ b/knowledge/people/_expert-sources.json
@@ -2,7 +2,8 @@
   "alex-hormozi": {
     "doc": "knowledge/people/alex-hormozi-knowledge.md",
     "domains": [],
-    "feeds": []
+    "feeds": [],
+    "last_discovered": "2026-07-19T20:09:10.862398+00:00"
   },
   "april-dunford": {
     "doc": "knowledge/people/april-dunford-knowledge.md",
@@ -11,7 +12,10 @@
       "aprildunford.substack.com",
       "businessofsoftware.org"
     ],
-    "feeds": []
+    "feeds": [
+      "https://aprildunford.substack.com/feed"
+    ],
+    "last_discovered": "2026-07-19T20:09:21.318940+00:00"
   },
   "barry-hott": {
     "doc": "knowledge/people/barry-hott-knowledge.md",
@@ -20,7 +24,10 @@
       "adworldprime.com",
       "canvasrebel.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://canvasrebel.com/feed"
+    ],
+    "last_discovered": "2026-07-19T20:09:34.306234+00:00"
   },
   "bill-gurley": {
     "doc": "knowledge/people/bill-gurley-knowledge.md",
@@ -29,7 +36,12 @@
       "jamesclear.com",
       "podcastnotes.org"
     ],
-    "feeds": []
+    "feeds": [
+      "https://abovethecrowd.com/feed",
+      "https://jamesclear.com/feed",
+      "https://podcastnotes.org/feed"
+    ],
+    "last_discovered": "2026-07-19T20:09:37.117333+00:00"
   },
   "brian-balfour": {
     "doc": "knowledge/people/brian-balfour-knowledge.md",
@@ -38,7 +50,10 @@
       "blog.brianbalfour.com",
       "miro.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://blog.brianbalfour.com/feed"
+    ],
+    "last_discovered": "2026-07-19T20:09:47.415652+00:00"
   },
   "chris-walker": {
     "doc": "knowledge/people/chris-walker-knowledge.md",
@@ -47,7 +62,10 @@
       "databox.com",
       "dreamdata.io"
     ],
-    "feeds": []
+    "feeds": [
+      "https://databox.com/feed"
+    ],
+    "last_discovered": "2026-07-19T20:09:56.105348+00:00"
   },
   "cole-gordon": {
     "doc": "knowledge/people/cole-gordon-knowledge.md",
@@ -56,7 +74,11 @@
       "beyondamillion.com",
       "getlatka.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://beyondamillion.com/feed",
+      "https://closers.io/feed"
+    ],
+    "last_discovered": "2026-07-19T20:10:04.968615+00:00"
   },
   "dan-kennedy": {
     "doc": "knowledge/people/dan-kennedy-knowledge.md",
@@ -65,7 +87,10 @@
       "www.breakthroughmarketingsecrets.com",
       "www.elaunchers.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://www.breakthroughmarketingsecrets.com/feed"
+    ],
+    "last_discovered": "2026-07-19T20:10:19.803081+00:00"
   },
   "dara-denney": {
     "doc": "knowledge/people/dara-denney-knowledge.md",
@@ -74,7 +99,10 @@
       "www.youtube.com",
       "fortpointcapital.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://fortpointcapital.com/rss.xml"
+    ],
+    "last_discovered": "2026-07-19T20:10:31.058027+00:00"
   },
   "darren-shaw": {
     "doc": "knowledge/people/darren-shaw-knowledge.md",
@@ -83,7 +111,12 @@
       "searchlabdigital.com",
       "www.nearmedia.co"
     ],
-    "feeds": []
+    "feeds": [
+      "https://searchlabdigital.com/feed",
+      "https://whitespark.ca/feed",
+      "https://www.nearmedia.co/feed"
+    ],
+    "last_discovered": "2026-07-19T20:10:33.265902+00:00"
   },
   "dave-ramsey": {
     "doc": "knowledge/people/dave-ramsey-knowledge.md",
@@ -92,7 +125,11 @@
       "barrettmedia.com",
       "eathealthy365.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://barrettmedia.com/feed",
+      "https://www.ramseysolutions.com/rss"
+    ],
+    "last_discovered": "2026-07-19T20:10:40.486749+00:00"
   },
   "elena-verna": {
     "doc": "knowledge/people/elena-verna-knowledge.md",
@@ -101,7 +138,12 @@
       "www.lennysnewsletter.com",
       "amplitude.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://amplitude.com/feed",
+      "https://www.elenaverna.com/feed",
+      "https://www.lennysnewsletter.com/feed"
+    ],
+    "last_discovered": "2026-07-19T20:10:42.689757+00:00"
   },
   "eugene-schwartz": {
     "doc": "knowledge/people/eugene-schwartz-knowledge.md",
@@ -110,7 +152,12 @@
       "auresnotes.com",
       "betweenthelinescopy.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://auresnotes.com/feed",
+      "https://betweenthelinescopy.com/feed",
+      "https://www.scientificadvertising.com/feed"
+    ],
+    "last_discovered": "2026-07-19T20:10:49.893748+00:00"
   },
   "jason-wardrop": {
     "doc": "knowledge/people/jason-wardrop-knowledge.md",
@@ -119,7 +166,8 @@
       "www.youtube.com",
       "blog.gohighlevel.com"
     ],
-    "feeds": []
+    "feeds": [],
+    "last_discovered": "2026-07-19T20:11:05.730648+00:00"
   },
   "jay-abraham": {
     "doc": "knowledge/people/jay-abraham-knowledge.md",
@@ -128,7 +176,11 @@
       "www.asbn.com",
       "boutiquegrowth.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://boutiquegrowth.com/feed",
+      "https://www.asbn.com/feed"
+    ],
+    "last_discovered": "2026-07-19T20:11:15.155723+00:00"
   },
   "jimmy-farley": {
     "doc": "knowledge/people/jimmy-farley-knowledge.md",
@@ -137,7 +189,8 @@
       "ippei.com",
       "jimmyfarley.gumroad.com"
     ],
-    "feeds": []
+    "feeds": [],
+    "last_discovered": "2026-07-19T20:11:27.416274+00:00"
   },
   "joy-hawkins": {
     "doc": "knowledge/people/joy-hawkins-knowledge.md",
@@ -146,7 +199,11 @@
       "whitespark.ca",
       "localu.org"
     ],
-    "feeds": []
+    "feeds": [
+      "https://whitespark.ca/feed",
+      "https://www.sterlingsky.ca/feed"
+    ],
+    "last_discovered": "2026-07-19T20:11:36.286311+00:00"
   },
   "madhavan-ramanujam": {
     "doc": "knowledge/people/madhavan-ramanujam-knowledge.md",
@@ -155,12 +212,18 @@
       "www.simon-kucher.com",
       "blas.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://blas.com/feed",
+      "https://www.lennysnewsletter.com/feed",
+      "https://www.simon-kucher.com/rss.xml"
+    ],
+    "last_discovered": "2026-07-19T20:11:39.713791+00:00"
   },
   "nick-cosman": {
     "doc": "knowledge/people/nick-cosman-knowledge.md",
     "domains": [],
-    "feeds": []
+    "feeds": [],
+    "last_discovered": "2026-07-19T20:11:39.713816+00:00"
   },
   "patrick-campbell": {
     "doc": "knowledge/people/patrick-campbell-knowledge.md",
@@ -169,12 +232,16 @@
       "www.paddle.com",
       "blog.profitwell.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://saasclub.io/feed"
+    ],
+    "last_discovered": "2026-07-19T20:11:49.852363+00:00"
   },
   "sam-ovens": {
     "doc": "knowledge/people/sam-ovens-knowledge.md",
     "domains": [],
-    "feeds": []
+    "feeds": [],
+    "last_discovered": "2026-07-19T20:11:49.852388+00:00"
   },
   "tommy-mello": {
     "doc": "knowledge/people/tommy-mello-knowledge.md",
@@ -183,6 +250,9 @@
       "fieldedge.com",
       "joinhampton.com"
     ],
-    "feeds": []
+    "feeds": [
+      "https://fieldedge.com/feed"
+    ],
+    "last_discovered": "2026-07-19T20:11:58.004801+00:00"
   }
 }

--- a/knowledge/people/_expert-sources.json
+++ b/knowledge/people/_expert-sources.json
@@ -1,0 +1,188 @@
+{
+  "alex-hormozi": {
+    "doc": "knowledge/people/alex-hormozi-knowledge.md",
+    "domains": [],
+    "feeds": []
+  },
+  "april-dunford": {
+    "doc": "knowledge/people/april-dunford-knowledge.md",
+    "domains": [
+      "www.aprildunford.com",
+      "aprildunford.substack.com",
+      "businessofsoftware.org"
+    ],
+    "feeds": []
+  },
+  "barry-hott": {
+    "doc": "knowledge/people/barry-hott-knowledge.md",
+    "domains": [
+      "www.hottgrowth.com",
+      "adworldprime.com",
+      "canvasrebel.com"
+    ],
+    "feeds": []
+  },
+  "bill-gurley": {
+    "doc": "knowledge/people/bill-gurley-knowledge.md",
+    "domains": [
+      "abovethecrowd.com",
+      "jamesclear.com",
+      "podcastnotes.org"
+    ],
+    "feeds": []
+  },
+  "brian-balfour": {
+    "doc": "knowledge/people/brian-balfour-knowledge.md",
+    "domains": [
+      "brianbalfour.com",
+      "blog.brianbalfour.com",
+      "miro.com"
+    ],
+    "feeds": []
+  },
+  "chris-walker": {
+    "doc": "knowledge/people/chris-walker-knowledge.md",
+    "domains": [
+      "www.refinelabs.com",
+      "databox.com",
+      "dreamdata.io"
+    ],
+    "feeds": []
+  },
+  "cole-gordon": {
+    "doc": "knowledge/people/cole-gordon-knowledge.md",
+    "domains": [
+      "closers.io",
+      "beyondamillion.com",
+      "getlatka.com"
+    ],
+    "feeds": []
+  },
+  "dan-kennedy": {
+    "doc": "knowledge/people/dan-kennedy-knowledge.md",
+    "domains": [
+      "magneticmarketing.com",
+      "www.breakthroughmarketingsecrets.com",
+      "www.elaunchers.com"
+    ],
+    "feeds": []
+  },
+  "dara-denney": {
+    "doc": "knowledge/people/dara-denney-knowledge.md",
+    "domains": [
+      "motionapp.com",
+      "www.youtube.com",
+      "fortpointcapital.com"
+    ],
+    "feeds": []
+  },
+  "darren-shaw": {
+    "doc": "knowledge/people/darren-shaw-knowledge.md",
+    "domains": [
+      "whitespark.ca",
+      "searchlabdigital.com",
+      "www.nearmedia.co"
+    ],
+    "feeds": []
+  },
+  "dave-ramsey": {
+    "doc": "knowledge/people/dave-ramsey-knowledge.md",
+    "domains": [
+      "www.ramseysolutions.com",
+      "barrettmedia.com",
+      "eathealthy365.com"
+    ],
+    "feeds": []
+  },
+  "elena-verna": {
+    "doc": "knowledge/people/elena-verna-knowledge.md",
+    "domains": [
+      "www.elenaverna.com",
+      "www.lennysnewsletter.com",
+      "amplitude.com"
+    ],
+    "feeds": []
+  },
+  "eugene-schwartz": {
+    "doc": "knowledge/people/eugene-schwartz-knowledge.md",
+    "domains": [
+      "www.scientificadvertising.com",
+      "auresnotes.com",
+      "betweenthelinescopy.com"
+    ],
+    "feeds": []
+  },
+  "jason-wardrop": {
+    "doc": "knowledge/people/jason-wardrop-knowledge.md",
+    "domains": [
+      "www.gohighlevel.com",
+      "www.youtube.com",
+      "blog.gohighlevel.com"
+    ],
+    "feeds": []
+  },
+  "jay-abraham": {
+    "doc": "knowledge/people/jay-abraham-knowledge.md",
+    "domains": [
+      "www.abraham.com",
+      "www.asbn.com",
+      "boutiquegrowth.com"
+    ],
+    "feeds": []
+  },
+  "jimmy-farley": {
+    "doc": "knowledge/people/jimmy-farley-knowledge.md",
+    "domains": [
+      "www.aol.com",
+      "ippei.com",
+      "jimmyfarley.gumroad.com"
+    ],
+    "feeds": []
+  },
+  "joy-hawkins": {
+    "doc": "knowledge/people/joy-hawkins-knowledge.md",
+    "domains": [
+      "www.sterlingsky.ca",
+      "whitespark.ca",
+      "localu.org"
+    ],
+    "feeds": []
+  },
+  "madhavan-ramanujam": {
+    "doc": "knowledge/people/madhavan-ramanujam-knowledge.md",
+    "domains": [
+      "www.lennysnewsletter.com",
+      "www.simon-kucher.com",
+      "blas.com"
+    ],
+    "feeds": []
+  },
+  "nick-cosman": {
+    "doc": "knowledge/people/nick-cosman-knowledge.md",
+    "domains": [],
+    "feeds": []
+  },
+  "patrick-campbell": {
+    "doc": "knowledge/people/patrick-campbell-knowledge.md",
+    "domains": [
+      "saasclub.io",
+      "www.paddle.com",
+      "blog.profitwell.com"
+    ],
+    "feeds": []
+  },
+  "sam-ovens": {
+    "doc": "knowledge/people/sam-ovens-knowledge.md",
+    "domains": [],
+    "feeds": []
+  },
+  "tommy-mello": {
+    "doc": "knowledge/people/tommy-mello-knowledge.md",
+    "domains": [
+      "cortecgroup.com",
+      "fieldedge.com",
+      "joinhampton.com"
+    ],
+    "feeds": []
+  }
+}

--- a/knowledge/people/_people-index.md
+++ b/knowledge/people/_people-index.md
@@ -70,4 +70,5 @@ Raw research outlines from the space transcript. Each stub's top **Status** line
 ## Maintenance
 
 - New clones follow `knowledge-cloning-workflow.md` and this doc's format; add a row here on creation.
-- These docs decay: roles change, benchmarks stale. Re-verify volatile claims older than ~12 months before citing them in publishable work (Kai Data Provenance Rule applies).
+- These docs decay: roles change, benchmarks stale. Re-verify volatile claims older than ~12 months before citing them in publishable work (Kai Data Provenance Rule applies). `python scripts/knowledge_freshness.py --dir knowledge/people` flags overdue docs.
+- Experts keep publishing: `python scripts/intel/expert_drift.py --check` diffs their cited sources (`_expert-sources.json`) against last check and reports new material to triage into the docs.

--- a/scripts/content/content_log.py
+++ b/scripts/content/content_log.py
@@ -141,6 +141,7 @@ def log_entry(
     content_hash: str | None = None,
     status: str | None = None,
     campaign_id: str | None = None,
+    frameworks: list[str] | None = None,
     log_file: str | None = None,
 ) -> dict:
     """Programmatic API to log a content entry.
@@ -155,6 +156,11 @@ def log_entry(
     campaign_id is the shared join key minted by campaign_planner
     (``cmp-YYYYMMDD-<slug>``); it is carried onto the entry and into the
     30-day pending-check file so performance rolls up per campaign.
+
+    frameworks is the list of repo-relative knowledge/reference paths that
+    actually informed the draft (from the engine's framework loader). It is
+    stored on the entry so 30-day grades can be aggregated per framework
+    (scripts/self_improvement/framework_attribution.py).
 
     Returns the created (or updated) entry dict.
     """
@@ -187,6 +193,7 @@ def log_entry(
                 ("module_set", module_set),
                 ("artifact_refs", artifact_refs),
                 ("campaign_id", campaign_id),
+                ("frameworks", frameworks),
             ):
                 if value:
                     entry[key] = value
@@ -229,6 +236,7 @@ def log_entry(
         "content_hash": content_hash,
         "status": status,
         "campaign_id": campaign_id,
+        "frameworks": frameworks or [],
     }
 
     if url:

--- a/scripts/content/engine.py
+++ b/scripts/content/engine.py
@@ -156,18 +156,25 @@ def _make_gemini_fn():
     return call
 
 
-def _load_framework_texts(fmt: str, repo_root: Path, workspace: Path) -> str:
-    """Load and concatenate framework files for a format."""
+def _load_framework_texts(fmt: str, repo_root: Path, workspace: Path) -> tuple[str, list[str]]:
+    """Load and concatenate framework files for a format.
+
+    Returns (concatenated_text, loaded_rel_paths). The loaded paths are the
+    frameworks that actually informed the draft — they flow onto the content
+    log entry so 30-day grades can be aggregated per framework.
+    """
     rel_paths = get_framework_paths(fmt)
     texts = []
+    loaded: list[str] = []
     for rel in rel_paths:
         # Try workspace first (deployed), then repo root (dev)
         for base in [workspace, repo_root]:
             candidate = base / rel
             if candidate.exists():
                 texts.append(candidate.read_text()[:1500])
+                loaded.append(rel)
                 break
-    return "\n\n---\n\n".join(texts)
+    return "\n\n---\n\n".join(texts), loaded
 
 
 def _load_patterns(repo_root: Path, workspace: Path) -> str:
@@ -417,7 +424,7 @@ async def generate(
         # 3. Load all context
         repo_root = cfg.repo_root
         workspace = cfg.workspace_dir
-        framework_texts = _load_framework_texts(format, repo_root, workspace)
+        framework_texts, framework_paths = _load_framework_texts(format, repo_root, workspace)
         patterns = _load_patterns(repo_root, workspace)
         contract = _load_skill_contract(format, workspace)
         site_facts = _load_site_facts(site, repo_root)
@@ -691,6 +698,7 @@ async def generate(
                     content_hash=content_hash,
                     status="published" if (published and publish_url) else "approved_unpublished",
                     campaign_id=campaign_id,
+                    frameworks=framework_paths,
                 )
                 if published and not url_missing:
                     published_artifact = runtime_store.record_artifact(

--- a/scripts/intel/expert_drift.py
+++ b/scripts/intel/expert_drift.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Expert-drift monitor — cloned experts keep publishing; their docs must not rot.
+
+Every knowledge clone in ``knowledge/people/*-knowledge.md`` cites its sources.
+This monitor derives a source registry from those citations, discovers RSS/Atom
+feeds on the cited domains, and on each check reports items published since the
+last run — candidate updates for the expert's doc. It NEVER edits knowledge
+docs; it queues evidence for a human/agent to triage (same doctrine as
+``competitor_monitor.py`` and the retro loop).
+
+Workflow:
+    python scripts/intel/expert_drift.py --init      # build/refresh registry from doc Sources sections
+    python scripts/intel/expert_drift.py --discover  # probe cited domains for real feeds (network)
+    python scripts/intel/expert_drift.py --check     # diff feeds vs state, write drift report (network)
+
+Files:
+    knowledge/people/_expert-sources.json   registry (committed; feeds only added when verified)
+    data/intel/expert_drift_state.json      last-seen item ids per feed (runtime state)
+    data/intel/expert-drift-report.md       latest check report
+
+Run --check on whatever cadence fits (weekly cron is plenty). New items mean:
+re-read, decide if the framework changed, update the doc's **Last verified:**
+line either way.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY_FILE = REPO_ROOT / "knowledge" / "people" / "_expert-sources.json"
+STATE_FILE = REPO_ROOT / "data" / "intel" / "expert_drift_state.json"
+REPORT_FILE = REPO_ROOT / "data" / "intel" / "expert-drift-report.md"
+
+URL_RE = re.compile(r"https?://[^\s)\]>\"']+")
+# Domains that are citation infrastructure, not the expert's own publishing surface.
+SKIP_DOMAINS = {
+    "google.com", "www.google.com", "web.archive.org", "en.wikipedia.org",
+    "www.amazon.com", "amazon.com", "hbr.org", "www.linkedin.com", "linkedin.com",
+    "twitter.com", "x.com", "www.facebook.com", "podcasts.apple.com",
+    "open.spotify.com", "www.nytimes.com", "nytimes.com",
+}
+FEED_CANDIDATES = ("/feed", "/rss", "/rss.xml", "/feed.xml", "/atom.xml", "/index.xml")
+MAX_DOMAINS_PER_EXPERT = 3
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _load_json(path: Path, default):
+    if path.exists():
+        try:
+            return json.loads(path.read_text())
+        except (json.JSONDecodeError, OSError):
+            return default
+    return default
+
+
+def _save_json(path: Path, data) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
+
+
+# ---------------------------------------------------------------- registry
+
+def extract_source_domains(doc_text: str) -> list[str]:
+    """Rank cited domains from a doc's ## Sources section, most-cited first."""
+    match = re.search(r"^## Sources\b(.*)\Z", doc_text, re.MULTILINE | re.DOTALL)
+    section = match.group(1) if match else ""
+    counts: dict[str, int] = {}
+    for url in URL_RE.findall(section):
+        domain = urlparse(url).netloc.lower()
+        if not domain or domain in SKIP_DOMAINS:
+            continue
+        counts[domain] = counts.get(domain, 0) + 1
+    ranked = sorted(counts, key=lambda d: (-counts[d], d))
+    return ranked[:MAX_DOMAINS_PER_EXPERT]
+
+
+def build_registry(people_dir: Path, existing: dict | None = None) -> dict:
+    """Build the registry from *-knowledge.md docs, preserving verified feeds."""
+    existing = existing or {}
+    registry: dict[str, dict] = {}
+    for doc in sorted(people_dir.glob("*-knowledge.md")):
+        slug = doc.name.removesuffix("-knowledge.md")
+        domains = extract_source_domains(doc.read_text(errors="replace"))
+        prior = existing.get(slug, {})
+        registry[slug] = {
+            "doc": f"knowledge/people/{doc.name}",
+            "domains": domains,
+            # feeds are only ever written by --discover after verification
+            "feeds": prior.get("feeds", []),
+        }
+    return registry
+
+
+# ---------------------------------------------------------------- feeds
+
+def parse_feed(xml_text: str) -> list[dict]:
+    """Parse RSS 2.0 or Atom into [{id, title, link, published}]. Empty on junk."""
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return []
+    ns = {"atom": "http://www.w3.org/2005/Atom"}
+    items = []
+    for node in root.iter("item"):  # RSS
+        link = (node.findtext("link") or "").strip()
+        guid = (node.findtext("guid") or link).strip()
+        if not guid:
+            continue
+        items.append({
+            "id": guid,
+            "title": (node.findtext("title") or "").strip(),
+            "link": link,
+            "published": (node.findtext("pubDate") or "").strip(),
+        })
+    for node in root.iter("{http://www.w3.org/2005/Atom}entry"):  # Atom
+        link_el = node.find("atom:link", ns)
+        link = (link_el.get("href") if link_el is not None else "") or ""
+        guid = (node.findtext("atom:id", default="", namespaces=ns) or link).strip()
+        if not guid:
+            continue
+        items.append({
+            "id": guid,
+            "title": (node.findtext("atom:title", default="", namespaces=ns) or "").strip(),
+            "link": link.strip(),
+            "published": (node.findtext("atom:updated", default="", namespaces=ns) or "").strip(),
+        })
+    return items
+
+
+def _http_get(url: str, timeout: int = 15) -> str | None:
+    try:
+        import requests
+
+        resp = requests.get(url, timeout=timeout, headers={"User-Agent": "kai-expert-drift/1.0"})
+        if resp.status_code == 200 and resp.text:
+            return resp.text
+    except Exception:
+        return None
+    return None
+
+
+def discover_feeds(registry: dict, fetch=_http_get) -> dict:
+    """Probe each expert's domains for working feeds; keep only verified ones."""
+    for slug, info in registry.items():
+        verified: list[str] = []
+        for domain in info.get("domains", []):
+            for suffix in FEED_CANDIDATES:
+                url = f"https://{domain}{suffix}"
+                body = fetch(url)
+                if body and parse_feed(body):
+                    verified.append(url)
+                    break  # one feed per domain is enough
+        if verified:
+            info["feeds"] = sorted(set(info.get("feeds", [])) | set(verified))
+        info["last_discovered"] = _now()
+    return registry
+
+
+def check_drift(registry: dict, state: dict, fetch=_http_get) -> tuple[dict, dict]:
+    """Fetch feeds, diff against state. Returns (new_items_by_slug, new_state).
+
+    First sighting of a feed seeds state without reporting (everything is
+    "new" on day one — that is backfill, not drift).
+    """
+    new_by_slug: dict[str, list[dict]] = {}
+    for slug, info in registry.items():
+        for feed_url in info.get("feeds", []):
+            body = fetch(feed_url)
+            if not body:
+                continue
+            items = parse_feed(body)
+            if not items:
+                continue
+            seen = set(state.get(feed_url, {}).get("seen_ids", []))
+            first_sighting = feed_url not in state
+            fresh = [it for it in items if it["id"] not in seen]
+            if fresh and not first_sighting:
+                new_by_slug.setdefault(slug, []).extend(
+                    {**it, "feed": feed_url} for it in fresh
+                )
+            state[feed_url] = {
+                "seen_ids": sorted(seen | {it["id"] for it in items})[-500:],
+                "last_checked": _now(),
+            }
+    return new_by_slug, state
+
+
+def write_report(new_by_slug: dict, registry: dict, report_file: Path) -> str:
+    lines = [
+        "# Expert Drift Report",
+        "",
+        f"Generated: {_now()}",
+        "",
+    ]
+    if not new_by_slug:
+        lines.append("No new items since the last check. All monitored experts quiet.")
+    for slug in sorted(new_by_slug):
+        doc = registry.get(slug, {}).get("doc", "")
+        lines.append(f"## {slug}")
+        lines.append("")
+        lines.append(f"Doc to re-verify: `{doc}`")
+        lines.append("")
+        for item in new_by_slug[slug]:
+            title = item["title"] or item["link"] or item["id"]
+            lines.append(f"- {title} — {item['link'] or item['id']} ({item['published'] or 'no date'})")
+        lines.append("")
+    lines.append(
+        "Triage: re-read new items; if a framework changed, update the doc and "
+        "its `**Last verified:**` line, then log a lesson if the old doctrine "
+        "was wrong. Never bulk-rewrite from headlines alone."
+    )
+    report = "\n".join(lines) + "\n"
+    report_file.parent.mkdir(parents=True, exist_ok=True)
+    report_file.write_text(report)
+    return report
+
+
+# ---------------------------------------------------------------- CLI
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Monitor cloned experts' sources for new material")
+    parser.add_argument("--init", action="store_true", help="build/refresh the source registry from knowledge docs")
+    parser.add_argument("--discover", action="store_true", help="probe cited domains for working feeds (network)")
+    parser.add_argument("--check", action="store_true", help="diff feeds against state and write the drift report (network)")
+    args = parser.parse_args()
+    if not (args.init or args.discover or args.check):
+        parser.print_help()
+        return 2
+
+    registry = _load_json(REGISTRY_FILE, {})
+
+    if args.init:
+        registry = build_registry(REPO_ROOT / "knowledge" / "people", registry)
+        _save_json(REGISTRY_FILE, registry)
+        with_feeds = sum(1 for i in registry.values() if i.get("feeds"))
+        print(f"Registry: {len(registry)} experts, {with_feeds} with verified feeds -> {REGISTRY_FILE}")
+
+    if args.discover:
+        if not registry:
+            print("Registry empty — run --init first.", file=sys.stderr)
+            return 1
+        registry = discover_feeds(registry)
+        _save_json(REGISTRY_FILE, registry)
+        total = sum(len(i.get("feeds", [])) for i in registry.values())
+        print(f"Discovery done: {total} verified feeds across {len(registry)} experts.")
+
+    if args.check:
+        if not registry:
+            print("Registry empty — run --init (and --discover) first.", file=sys.stderr)
+            return 1
+        state = _load_json(STATE_FILE, {})
+        new_by_slug, state = check_drift(registry, state)
+        _save_json(STATE_FILE, state)
+        write_report(new_by_slug, registry, REPORT_FILE)
+        count = sum(len(v) for v in new_by_slug.values())
+        print(f"Drift check: {count} new items across {len(new_by_slug)} experts -> {REPORT_FILE}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/self_improvement/framework_attribution.py
+++ b/scripts/self_improvement/framework_attribution.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Framework attribution report — grade the frameworks, not just the pieces.
+
+Content-log entries record which knowledge/reference frameworks informed each
+draft (``frameworks`` field, written by the engine). The 30-day performance
+loop grades entries winner/average/underperformer. This report joins the two:
+per-framework grade counts and winner rates, so the knowledge base learns
+which frameworks actually work from measured outcomes instead of doctrine.
+
+Entries written before the ``frameworks`` field existed are attributed via
+the format -> framework registry (``GENERATION_FRAMEWORK_MAP``) and counted
+as "inferred" so exact and inferred attribution stay distinguishable.
+
+Usage:
+    python scripts/self_improvement/framework_attribution.py            # table
+    python scripts/self_improvement/framework_attribution.py --json     # machine-readable
+    python scripts/self_improvement/framework_attribution.py --min-graded 5
+
+Review flag: a framework with >= --min-graded graded pieces and a winner
+rate below --flag-below (default 0.34) is listed as a review candidate —
+a prompt to re-read the framework doc and diagnose via /kai-retro, never
+an automatic edit to the knowledge base.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.content.content_log import load_log  # noqa: E402
+from scripts.self_improvement.grades import (  # noqa: E402
+    GRADE_AVERAGE,
+    GRADE_UNDERPERFORMER,
+    GRADE_WINNER,
+    get_grade,
+)
+
+GRADES = (GRADE_WINNER, GRADE_AVERAGE, GRADE_UNDERPERFORMER)
+
+
+def _infer_frameworks(entry: dict) -> list[str]:
+    """Legacy fallback: map an entry's format to its framework registry paths."""
+    fmt = entry.get("format") or entry.get("platform")
+    if not fmt:
+        return []
+    try:
+        from kai.runtime.workflows import get_framework_paths
+    except Exception:
+        return []
+    try:
+        return list(get_framework_paths(str(fmt)))
+    except Exception:
+        return []
+
+
+def aggregate(entries: list) -> dict[str, dict]:
+    """Aggregate grade counts per framework path.
+
+    Returns {framework_path: {winner, average, underperformer, ungraded,
+    graded, inferred, winner_rate}}. Entries without any attributable
+    framework are skipped (they can't inform a framework verdict).
+    """
+    stats: dict[str, dict] = {}
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        frameworks = entry.get("frameworks")
+        inferred = False
+        if not frameworks:
+            frameworks = _infer_frameworks(entry)
+            inferred = True
+        if not frameworks:
+            continue
+        grade = get_grade(entry)
+        for fw in frameworks:
+            row = stats.setdefault(
+                fw,
+                {g: 0 for g in GRADES} | {"ungraded": 0, "graded": 0, "inferred": 0},
+            )
+            if inferred:
+                row["inferred"] += 1
+            if grade in GRADES:
+                row[grade] += 1
+                row["graded"] += 1
+            else:
+                row["ungraded"] += 1
+    for row in stats.values():
+        row["winner_rate"] = (
+            round(row[GRADE_WINNER] / row["graded"], 3) if row["graded"] else None
+        )
+    return stats
+
+
+def review_candidates(stats: dict[str, dict], min_graded: int, flag_below: float) -> list[str]:
+    return sorted(
+        fw
+        for fw, row in stats.items()
+        if row["graded"] >= min_graded
+        and row["winner_rate"] is not None
+        and row["winner_rate"] < flag_below
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Per-framework 30-day grade report")
+    parser.add_argument("--log-file", default=None, help="content log path override")
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    parser.add_argument("--min-graded", type=int, default=3, help="graded pieces before a framework can be flagged")
+    parser.add_argument("--flag-below", type=float, default=0.34, help="winner-rate threshold for the review flag")
+    args = parser.parse_args()
+
+    entries = load_log(args.log_file)
+    stats = aggregate(entries)
+    flagged = review_candidates(stats, args.min_graded, args.flag_below)
+
+    if args.json:
+        print(json.dumps({"frameworks": stats, "review_candidates": flagged}, indent=2))
+        return 0
+
+    if not stats:
+        print("No content-log entries with attributable frameworks yet.")
+        print("Entries gain a 'frameworks' field as the engine generates content.")
+        return 0
+
+    print("Framework attribution — 30-day grades per framework\n")
+    header = f"{'framework':60}  {'win':>4} {'avg':>4} {'under':>5} {'ungr':>4}  {'win rate':>8}"
+    print(header)
+    print("-" * len(header))
+    for fw in sorted(stats, key=lambda f: (-(stats[f]['winner_rate'] or 0), f)):
+        row = stats[fw]
+        rate = f"{row['winner_rate']:.0%}" if row["winner_rate"] is not None else "—"
+        inferred = f" ({row['inferred']} inferred)" if row["inferred"] else ""
+        print(
+            f"{fw[:60]:60}  {row[GRADE_WINNER]:>4} {row[GRADE_AVERAGE]:>4} "
+            f"{row[GRADE_UNDERPERFORMER]:>5} {row['ungraded']:>4}  {rate:>8}{inferred}"
+        )
+    if flagged:
+        print(f"\nReview candidates (>= {args.min_graded} graded, winner rate < {args.flag_below:.0%}):")
+        for fw in flagged:
+            print(f"  {fw}")
+        print("Diagnose via /kai-retro before changing any framework doc.")
+    else:
+        print("\nNo review candidates at current thresholds.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_expert_drift.py
+++ b/tests/test_expert_drift.py
@@ -1,0 +1,129 @@
+"""Expert-drift monitor: registry from doc sources, feed parse, drift diff."""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.intel.expert_drift import (  # noqa: E402
+    build_registry,
+    check_drift,
+    discover_feeds,
+    extract_source_domains,
+    parse_feed,
+    write_report,
+)
+
+DOC = """# Test Expert: Knowledge Distillation
+
+**Created:** July 2026
+
+Body text with a stray link https://en.wikipedia.org/wiki/Ignored that is NOT in Sources.
+
+## Sources
+
+- https://example.com/post/one — first
+- https://example.com/post/two — second
+- https://blog.other.io/essay — third
+- https://en.wikipedia.org/wiki/Something — infrastructure, skipped
+- https://www.google.com/search?q=x — skipped
+"""
+
+RSS = """<?xml version="1.0"?>
+<rss version="2.0"><channel><title>t</title>
+<item><title>Post A</title><link>https://example.com/a</link><guid>id-a</guid><pubDate>Wed, 01 Jul 2026 00:00:00 GMT</pubDate></item>
+<item><title>Post B</title><link>https://example.com/b</link><guid>id-b</guid></item>
+</channel></rss>"""
+
+ATOM = """<?xml version="1.0"?>
+<feed xmlns="http://www.w3.org/2005/Atom"><title>t</title>
+<entry><title>Atom A</title><id>atom-a</id><link href="https://x.io/a"/><updated>2026-07-01</updated></entry>
+</feed>"""
+
+
+def test_extract_source_domains_ranks_and_skips():
+    domains = extract_source_domains(DOC)
+    assert domains[0] == "example.com"  # cited twice, ranked first
+    assert "blog.other.io" in domains
+    assert "en.wikipedia.org" not in domains
+    assert all("google" not in d for d in domains)
+
+
+def test_extract_ignores_links_outside_sources_section():
+    assert extract_source_domains("no sources section https://example.com/x") == []
+
+
+def test_build_registry_preserves_verified_feeds(tmp_path):
+    (tmp_path / "test-expert-knowledge.md").write_text(DOC)
+    existing = {"test-expert": {"feeds": ["https://example.com/feed"]}}
+    registry = build_registry(tmp_path, existing)
+    assert registry["test-expert"]["doc"] == "knowledge/people/test-expert-knowledge.md"
+    assert registry["test-expert"]["feeds"] == ["https://example.com/feed"]
+    assert registry["test-expert"]["domains"][0] == "example.com"
+
+
+def test_parse_feed_rss_and_atom_and_junk():
+    rss_items = parse_feed(RSS)
+    assert [i["id"] for i in rss_items] == ["id-a", "id-b"]
+    assert rss_items[0]["title"] == "Post A"
+    atom_items = parse_feed(ATOM)
+    assert atom_items[0]["id"] == "atom-a"
+    assert atom_items[0]["link"] == "https://x.io/a"
+    assert parse_feed("<html>not a feed</html>") == []
+    assert parse_feed("total junk {") == []
+
+
+def test_discover_keeps_only_verified_feeds():
+    registry = {"e": {"doc": "d", "domains": ["good.com", "dead.com"], "feeds": []}}
+
+    def fetch(url, timeout=15):
+        return RSS if url == "https://good.com/feed" else None
+
+    out = discover_feeds(registry, fetch=fetch)
+    assert out["e"]["feeds"] == ["https://good.com/feed"]
+
+
+def test_check_drift_seeds_silently_then_reports_new_items():
+    registry = {"e": {"doc": "knowledge/people/e-knowledge.md", "domains": [], "feeds": ["https://f/feed"]}}
+    feed_v1 = RSS
+    feed_v2 = RSS.replace(
+        "</channel></rss>",
+        '<item><title>Post C</title><link>https://example.com/c</link><guid>id-c</guid></item></channel></rss>',
+    )
+
+    # First sighting: state seeded, nothing reported (backfill is not drift).
+    new1, state = check_drift(registry, {}, fetch=lambda u, timeout=15: feed_v1)
+    assert new1 == {}
+    assert set(state["https://f/feed"]["seen_ids"]) == {"id-a", "id-b"}
+
+    # Unchanged feed: still quiet.
+    new2, state = check_drift(registry, state, fetch=lambda u, timeout=15: feed_v1)
+    assert new2 == {}
+
+    # New item appears: reported once, then absorbed into state.
+    new3, state = check_drift(registry, state, fetch=lambda u, timeout=15: feed_v2)
+    assert [i["id"] for i in new3["e"]] == ["id-c"]
+    assert "id-c" in state["https://f/feed"]["seen_ids"]
+    new4, _ = check_drift(registry, state, fetch=lambda u, timeout=15: feed_v2)
+    assert new4 == {}
+
+
+def test_check_drift_survives_dead_feed():
+    registry = {"e": {"doc": "d", "domains": [], "feeds": ["https://dead/feed"]}}
+    new, state = check_drift(registry, {}, fetch=lambda u, timeout=15: None)
+    assert new == {}
+    assert state == {}  # dead feed leaves no state
+
+
+def test_write_report(tmp_path):
+    report_file = tmp_path / "report.md"
+    registry = {"e": {"doc": "knowledge/people/e-knowledge.md"}}
+    new = {"e": [{"id": "id-c", "title": "Post C", "link": "https://example.com/c", "published": "", "feed": "f"}]}
+    text = write_report(new, registry, report_file)
+    assert "Post C" in text
+    assert "knowledge/people/e-knowledge.md" in text
+    assert report_file.exists()
+    empty = write_report({}, registry, report_file)
+    assert "quiet" in empty

--- a/tests/test_framework_attribution.py
+++ b/tests/test_framework_attribution.py
@@ -1,0 +1,125 @@
+"""Framework attribution: content-log field, engine loader paths, aggregator."""
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.content.content_log import log_entry  # noqa: E402
+from scripts.self_improvement.framework_attribution import (  # noqa: E402
+    aggregate,
+    review_candidates,
+)
+
+FW_A = "knowledge/frameworks/content-copywriting/algorithmic-authorship.md"
+FW_B = "knowledge/channels/email-lifecycle.md"
+
+
+def _entry(frameworks=None, grade=None, fmt="blog"):
+    entry = {"site": "s", "format": fmt}
+    if frameworks is not None:
+        entry["frameworks"] = frameworks
+    if grade is not None:
+        entry["performance_30d"] = {"grade": grade}
+    return entry
+
+
+def test_log_entry_stores_frameworks(tmp_path):
+    log_file = str(tmp_path / "log.json")
+    entry = log_entry(
+        url=None,
+        keyword="k",
+        site="site-a",
+        format="blog",
+        content_hash="hash-1",
+        frameworks=[FW_A],
+        log_file=log_file,
+    )
+    assert entry["frameworks"] == [FW_A]
+    saved = json.loads(Path(log_file).read_text())
+    assert saved[0]["frameworks"] == [FW_A]
+
+
+def test_log_entry_dedupe_updates_frameworks(tmp_path):
+    log_file = str(tmp_path / "log.json")
+    log_entry(
+        url=None, keyword="k", site="site-a", format="blog",
+        content_hash="hash-1", frameworks=[], log_file=log_file,
+    )
+    entry = log_entry(
+        url=None, keyword="k", site="site-a", format="blog",
+        content_hash="hash-1", frameworks=[FW_A, FW_B], log_file=log_file,
+    )
+    assert entry["frameworks"] == [FW_A, FW_B]
+    saved = json.loads(Path(log_file).read_text())
+    assert len(saved) == 1  # deduped, not appended
+
+
+def test_log_entry_defaults_frameworks_to_empty_list(tmp_path):
+    log_file = str(tmp_path / "log.json")
+    entry = log_entry(
+        url=None, keyword="k", site="site-a", format="blog",
+        content_hash="hash-2", log_file=log_file,
+    )
+    assert entry["frameworks"] == []
+
+
+def test_engine_loader_returns_loaded_paths(tmp_path):
+    from scripts.content.engine import _load_framework_texts
+
+    repo = tmp_path / "repo"
+    target = repo / FW_A
+    target.parent.mkdir(parents=True)
+    target.write_text("# Algorithmic Authorship\nrules")
+    text, paths = _load_framework_texts("blog", repo, tmp_path / "nowhere")
+    assert paths == [FW_A]
+    assert "Algorithmic Authorship" in text
+    # Missing files load nothing and attribute nothing.
+    text_none, paths_none = _load_framework_texts("blog", tmp_path / "empty", tmp_path / "empty2")
+    assert paths_none == []
+    assert text_none == ""
+
+
+def test_aggregate_counts_and_winner_rate():
+    entries = [
+        _entry([FW_A], "winner"),
+        _entry([FW_A], "underperformer"),
+        _entry([FW_A], None),
+        _entry([FW_A, FW_B], "winner"),
+        _entry([FW_B], "loser"),  # legacy alias -> underperformer
+    ]
+    stats = aggregate(entries)
+    assert stats[FW_A]["winner"] == 2
+    assert stats[FW_A]["underperformer"] == 1
+    assert stats[FW_A]["ungraded"] == 1
+    assert stats[FW_A]["graded"] == 3
+    assert stats[FW_A]["winner_rate"] == round(2 / 3, 3)
+    assert stats[FW_B]["underperformer"] == 1
+    assert stats[FW_B]["winner"] == 1
+    assert stats[FW_B]["inferred"] == 0
+
+
+def test_aggregate_infers_frameworks_for_legacy_entries():
+    # No frameworks field: attributed via GENERATION_FRAMEWORK_MAP by format.
+    stats = aggregate([_entry(None, "winner", fmt="blog")])
+    assert stats[FW_A]["winner"] == 1
+    assert stats[FW_A]["inferred"] == 1
+
+
+def test_aggregate_skips_unattributable_entries():
+    stats = aggregate([{"site": "s"}, "junk", None])
+    assert stats == {}
+
+
+def test_review_candidates_threshold():
+    entries = (
+        [_entry([FW_A], "underperformer")] * 3
+        + [_entry([FW_B], "underperformer")]  # only 1 graded — below min
+        + [_entry([FW_B], None)]
+    )
+    stats = aggregate(entries)
+    flagged = review_candidates(stats, min_graded=3, flag_below=0.34)
+    assert flagged == [FW_A]


### PR DESCRIPTION
## What

The two self-updating machinery pieces queued after #49/#50 — the knowledge base now learns from its own measured outcomes and watches its sources for drift.

### Framework attribution — grade the frameworks, not just the pieces

- `engine._load_framework_texts` now returns which framework files actually loaded into the prompt; `generate()` records them on the content-log entry (`frameworks` field via `log_entry`, stored on create and dedupe-update).
- `scripts/self_improvement/framework_attribution.py` joins that field with the 30-day grades: per-framework winner/average/underperformer counts and winner rates. Legacy entries without the field are attributed via `GENERATION_FRAMEWORK_MAP` and counted as *inferred* so exact and inferred attribution stay distinguishable. Frameworks with ≥3 graded pieces below a 34% winner rate are flagged as **review candidates** — a `/kai-retro` prompt, never an automatic edit to a knowledge doc.

### Expert-drift monitor — cloned experts keep publishing

- `scripts/intel/expert_drift.py`: `--init` derives a source registry from each `knowledge/people/*-knowledge.md` doc's Sources section (infrastructure domains like Wikipedia/archive.org excluded); `--discover` probes cited domains for working RSS/Atom feeds and stores only verified ones; `--check` diffs feeds against `data/intel/expert_drift_state.json` and writes new material to `data/intel/expert-drift-report.md`. First sighting of a feed seeds state silently — backfill is not drift.
- `knowledge/people/_expert-sources.json` seeded for all 22 experts.

## Tests

16 new tests across `tests/test_framework_attribution.py` and `tests/test_expert_drift.py` (log field round-trip + dedupe, loader path attribution, aggregation + legacy `loser` normalization + inference, review-candidate thresholds, Sources-section domain extraction, RSS/Atom/junk parsing, feed verification, seed-silently/report-once drift semantics, dead-feed survival). Adjacent suites (`test_publish_truthfulness`, `test_campaign_identity`, `test_learning_loop_repair`) pass — 118 total. `doctor.py` and `golden_check.py` pass.

## Integration

- `.claude/rules/architecture-and-memory.md`: retro-cycle commands now include the attribution report, freshness sweep, and drift check
- `.claude/rules/scripts-and-tools.md`: intel table row for the drift monitor
- `knowledge/people/_people-index.md`: maintenance section points at both tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XWoxXPsvet5d7u3pKEVv8T

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWoxXPsvet5d7u3pKEVv8T)_