### PR TITLE
feat: add proof-bound Company Autopilot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ Kai is a **marketing-native agent runtime**. This repo holds the knowledge base 
 - `scripts/quality/` is the quality/policy layer
 - `gateway/` is the remote runner and connector surface
 
-Inventory reachable from here: 54 skill directories, 52 canonical `kai-*` skill docs, 47 public `/kai` router commands, 67 playbook docs, 36 checklists, 33 framework docs, 26 channel guides, 8 audience persona profiles, and a quality gate pipeline that enforces standards before anything ships.
+<!-- capability-counts:start -->
+Inventory reachable from here: 54 skill directories, 52 canonical `kai-*` skills, 47 public `/kai` router commands, 67 playbook docs, 37 checklists, 38 framework docs, 31 channel guides, 8 audience persona profiles, 36 harness references, and 33 skill contracts.
+<!-- capability-counts:end -->
 
 ## Instruction Contract (critical)
 

--- a/app-meetkai/app/(dashboard)/dashboard/page.tsx
+++ b/app-meetkai/app/(dashboard)/dashboard/page.tsx
@@ -7,6 +7,7 @@ import { AttentionItems } from "@/components/dashboard/attention-items";
 import { AIActivity } from "@/components/dashboard/ai-activity";
 import { QuickActions } from "@/components/dashboard/quick-actions";
 import { PendingActions } from "@/components/dashboard/pending-actions";
+import { AutopilotCommandCenter } from "@/components/dashboard/autopilot-command-center";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { cn, scoreColor } from "@/lib/utils";
@@ -104,6 +105,8 @@ export default function DashboardPage() {
 
   return (
     <div className="space-y-6">
+      <AutopilotCommandCenter />
+
       {/* Hero: Score + Brand + Actions */}
       <div className="card flex flex-col sm:flex-row items-start sm:items-center gap-4">
         <div className="flex items-center gap-4 flex-1">

--- a/app-meetkai/app/api/autopilot/command-center/route.ts
+++ b/app-meetkai/app/api/autopilot/command-center/route.ts
@@ -1,0 +1,130 @@
+import { NextResponse } from "next/server";
+
+import { gateway, GatewayError } from "@/lib/gateway/client";
+import type {
+  AutopilotCommandCenterResponse,
+  Bottleneck,
+  PortfolioBrand,
+} from "@/lib/gateway/types";
+import { createClient } from "@/lib/supabase/server";
+
+export const dynamic = "force-dynamic";
+
+interface GatewayBottleneck {
+  brand_id: string;
+  blocked_gate: string;
+  owner: string;
+  next_action: string;
+  close_condition: string;
+  evidence_refs?: string[];
+  type?: string;
+}
+
+interface GatewayCommandCenter {
+  generated_at: string;
+  primary_bottleneck: GatewayBottleneck | null;
+  coach: {
+    status: string;
+    message: string;
+    next_action: string;
+    close_condition: string;
+    evidence_refs?: string[];
+  };
+}
+
+interface GatewayPortfolioRow {
+  brand_id: string;
+  brand_name: string;
+  lifecycle: string;
+  health: string;
+  blocked_gate: string | null;
+  owner: string;
+  next_action: string;
+  close_condition: string;
+  evidence_refs?: string[];
+}
+
+interface GatewayPortfolio {
+  generated_at: string;
+  rows: GatewayPortfolioRow[];
+}
+
+export async function GET() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    const [commandCenter, portfolioResult] = await Promise.all([
+      gateway<GatewayCommandCenter>("/ops/command-center", { timeout: 15000 }),
+      gateway<GatewayPortfolio>("/ops/portfolio", { timeout: 15000 }),
+    ]);
+
+    const portfolio: PortfolioBrand[] = portfolioResult.rows.map((row) => ({
+      brand_id: row.brand_id,
+      brand_name: row.brand_name,
+      lifecycle: row.lifecycle,
+      health: row.health,
+      blocked_gate: row.blocked_gate || "none",
+      owner: row.owner,
+      next_action: row.next_action,
+      close_condition: row.close_condition,
+      evidence_refs: row.evidence_refs || [],
+    }));
+
+    const rawBottleneck = commandCenter.primary_bottleneck;
+    const bottleneckBrand = rawBottleneck
+      ? portfolio.find((row) => row.brand_id === rawBottleneck.brand_id)
+      : undefined;
+    const primaryBottleneck: Bottleneck | null = rawBottleneck
+      ? {
+          brand_id: rawBottleneck.brand_id,
+          brand_name: bottleneckBrand?.brand_name || rawBottleneck.brand_id,
+          lifecycle: bottleneckBrand?.lifecycle || "unknown",
+          health: bottleneckBrand?.health || "blocked",
+          blocked_gate: rawBottleneck.blocked_gate,
+          owner: rawBottleneck.owner,
+          next_action: rawBottleneck.next_action,
+          close_condition: rawBottleneck.close_condition,
+          evidence_refs: rawBottleneck.evidence_refs || [],
+          summary: rawBottleneck.type
+            ? `The ${rawBottleneck.type.replace(/[_-]+/g, " ")} gate is the highest-priority constraint in the verified portfolio state.`
+            : undefined,
+          proof_state: "evidence_required",
+        }
+      : null;
+
+    const response: AutopilotCommandCenterResponse = {
+      primary_bottleneck: primaryBottleneck,
+      coach: {
+        state: commandCenter.coach.status,
+        message: commandCenter.coach.message,
+        next_action: commandCenter.coach.next_action,
+        close_condition: commandCenter.coach.close_condition,
+        evidence_refs: commandCenter.coach.evidence_refs || [],
+      },
+      portfolio,
+      timestamp: commandCenter.generated_at || portfolioResult.generated_at,
+    };
+
+    return NextResponse.json(response, {
+      headers: { "Cache-Control": "no-store" },
+    });
+  } catch (error: unknown) {
+    const status = error instanceof GatewayError && error.status < 500 ? error.status : 502;
+    const detail = error instanceof Error ? error.message : "Autopilot gateway unavailable";
+
+    return NextResponse.json(
+      {
+        error: "Command Center unavailable",
+        detail,
+      },
+      { status },
+    );
+  }
+}

--- a/app-meetkai/components/dashboard/autopilot-command-center.tsx
+++ b/app-meetkai/components/dashboard/autopilot-command-center.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  CircleDot,
+  Crosshair,
+  FileCheck2,
+  RefreshCw,
+  ShieldCheck,
+} from "lucide-react";
+
+import type {
+  AutopilotCommandCenterResponse,
+  PortfolioBrand,
+} from "@/lib/gateway/types";
+import { cn, timeAgo } from "@/lib/utils";
+
+type LoadState = "loading" | "ready" | "unavailable";
+
+function humanize(value: string) {
+  return value.replace(/[_-]+/g, " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
+}
+
+function healthTone(health: string) {
+  const normalized = health.toLowerCase();
+  if (["healthy", "good", "excellent", "verified", "ready"].includes(normalized)) {
+    return "border-success/25 bg-success-dim text-success";
+  }
+  if (["blocked", "critical", "failed", "unhealthy"].includes(normalized)) {
+    return "border-error/25 bg-error-dim text-error";
+  }
+  return "border-amber/25 bg-amber-dim text-amber-light";
+}
+
+function EvidenceRefs({ refs, compact = false }: { refs: string[]; compact?: boolean }) {
+  if (refs.length === 0) {
+    return <span className="text-text-tertiary">No proof attached</span>;
+  }
+
+  const visible = compact ? refs.slice(0, 2) : refs;
+  return (
+    <span className="inline-flex flex-wrap gap-x-2 gap-y-1">
+      {visible.map((ref) => (
+        <code key={ref} className="font-mono text-[10px] text-info break-all">
+          {ref}
+        </code>
+      ))}
+      {compact && refs.length > visible.length && (
+        <span className="text-[10px] text-text-tertiary">+{refs.length - visible.length} more</span>
+      )}
+    </span>
+  );
+}
+
+function PortfolioCard({ brand }: { brand: PortfolioBrand }) {
+  return (
+    <article className="rounded-lg border border-border bg-background/55 p-4" aria-label={`${brand.brand_name} status`}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-display text-lg font-semibold">{brand.brand_name}</h3>
+          <p className="mt-1 font-mono text-[10px] uppercase tracking-[0.18em] text-text-tertiary">
+            {humanize(brand.lifecycle)}
+          </p>
+        </div>
+        <span className={cn("rounded-full border px-2 py-1 font-mono text-[10px] uppercase", healthTone(brand.health))}>
+          {humanize(brand.health)}
+        </span>
+      </div>
+      <dl className="mt-4 grid gap-3 text-sm">
+        <div>
+          <dt className="text-[10px] font-bold uppercase tracking-[0.16em] text-text-tertiary">Blocked gate</dt>
+          <dd className="mt-1 text-foreground">{humanize(brand.blocked_gate)}</dd>
+        </div>
+        <div>
+          <dt className="text-[10px] font-bold uppercase tracking-[0.16em] text-text-tertiary">Owner</dt>
+          <dd className="mt-1 text-foreground">{brand.owner}</dd>
+        </div>
+        <div>
+          <dt className="text-[10px] font-bold uppercase tracking-[0.16em] text-text-tertiary">Next action</dt>
+          <dd className="mt-1 text-text-secondary">{brand.next_action}</dd>
+        </div>
+        <div>
+          <dt className="text-[10px] font-bold uppercase tracking-[0.16em] text-text-tertiary">Proof-bound close</dt>
+          <dd className="mt-1 text-text-secondary">{brand.close_condition}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}
+
+export function AutopilotCommandCenter() {
+  const [data, setData] = useState<AutopilotCommandCenterResponse | null>(null);
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+
+  const load = useCallback(async () => {
+    setLoadState("loading");
+    try {
+      const response = await fetch("/api/autopilot/command-center", { cache: "no-store" });
+      if (!response.ok) throw new Error(`Command Center returned ${response.status}`);
+      setData((await response.json()) as AutopilotCommandCenterResponse);
+      setLoadState("ready");
+    } catch {
+      setData(null);
+      setLoadState("unavailable");
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const portfolio = data?.portfolio ?? [];
+  const blockedCount = portfolio.filter(
+    (brand) => brand.blocked_gate.toLowerCase() !== "none",
+  ).length;
+
+  if (loadState === "loading") {
+    return (
+      <section className="overflow-hidden rounded-xl border border-border bg-card" aria-busy="true" aria-label="Loading Autopilot Command Center">
+        <div className="h-1 bg-amber/70" />
+        <div className="grid gap-6 p-5 sm:p-7 lg:grid-cols-[1.45fr_0.55fr]">
+          <div className="space-y-4">
+            <div className="h-3 w-40 animate-pulse rounded bg-border" />
+            <div className="h-12 max-w-xl animate-pulse rounded bg-bg-elevated" />
+            <div className="h-24 animate-pulse rounded bg-bg-elevated" />
+          </div>
+          <div className="h-48 animate-pulse rounded-lg bg-bg-elevated" />
+        </div>
+      </section>
+    );
+  }
+
+  if (loadState === "unavailable" || !data) {
+    return (
+      <section className="relative overflow-hidden rounded-xl border border-coral/25 bg-card p-5 sm:p-7" role="status">
+        <div className="absolute inset-y-0 left-0 w-1 bg-coral" />
+        <div className="flex flex-col justify-between gap-5 sm:flex-row sm:items-center">
+          <div className="flex gap-4">
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-coral" />
+            <div>
+              <p className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-coral">Live state unavailable</p>
+              <h2 className="mt-2 font-display text-2xl font-semibold">Autopilot is not guessing.</h2>
+              <p className="mt-1 max-w-2xl text-sm text-text-secondary">
+                The verified operating ledger could not be read. Existing dashboard signals remain below, but no bottleneck is declared without evidence.
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="inline-flex min-h-10 items-center justify-center gap-2 rounded-lg border border-border bg-bg-elevated px-4 text-sm font-semibold text-foreground transition-colors hover:border-border-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber"
+          >
+            <RefreshCw className="h-4 w-4" /> Retry read-back
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const bottleneck = data.primary_bottleneck;
+  const coach = data.coach;
+
+  return (
+    <section className="space-y-4" aria-labelledby="autopilot-title">
+      <div className="overflow-hidden rounded-xl border border-border bg-card shadow-[0_20px_70px_rgba(0,0,0,0.24)]">
+        <div className="h-1 bg-gradient-to-r from-amber via-info to-coral" />
+        <div className="grid lg:grid-cols-[minmax(0,1.55fr)_minmax(280px,0.65fr)]">
+          <div className="relative overflow-hidden p-5 sm:p-7 lg:p-9">
+            <div className="pointer-events-none absolute -right-20 -top-24 h-64 w-64 rounded-full border border-amber/10 bg-amber/5" />
+            <div className="relative">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <p className="inline-flex items-center gap-2 font-mono text-[10px] font-bold uppercase tracking-[0.24em] text-amber-light">
+                  <Crosshair className="h-3.5 w-3.5" /> Company Autopilot / primary constraint
+                </p>
+                <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-text-tertiary">
+                  Read back {timeAgo(data.timestamp)}
+                </span>
+              </div>
+
+              {bottleneck ? (
+                <>
+                  <div className="mt-7 flex items-start gap-4">
+                    <span className="mt-1 flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-coral/30 bg-coral-dim text-coral">
+                      <CircleDot className="h-5 w-5" />
+                    </span>
+                    <div>
+                      <p className="font-mono text-xs uppercase tracking-[0.16em] text-text-tertiary">
+                        {bottleneck.brand_name} · {humanize(bottleneck.lifecycle)}
+                      </p>
+                      <h1 id="autopilot-title" className="mt-2 max-w-4xl font-display text-3xl font-bold leading-[1.06] sm:text-5xl">
+                        {humanize(bottleneck.blocked_gate)}
+                      </h1>
+                      {bottleneck.summary && (
+                        <p className="mt-3 max-w-3xl text-base leading-relaxed text-text-secondary">{bottleneck.summary}</p>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="mt-8 grid gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid-cols-3">
+                    <div className="bg-background/90 p-4">
+                      <p className="font-mono text-[10px] uppercase tracking-[0.17em] text-text-tertiary">Owner</p>
+                      <p className="mt-2 text-sm font-semibold">{bottleneck.owner}</p>
+                    </div>
+                    <div className="bg-background/90 p-4 sm:col-span-2">
+                      <p className="font-mono text-[10px] uppercase tracking-[0.17em] text-text-tertiary">Do this next</p>
+                      <p className="mt-2 flex gap-2 text-sm font-semibold text-amber-light">
+                        <ArrowRight className="mt-0.5 h-4 w-4 shrink-0" /> {bottleneck.next_action}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="mt-4 flex items-start gap-3 rounded-lg border border-success/20 bg-success-dim px-4 py-3">
+                    <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-success" />
+                    <div>
+                      <p className="font-mono text-[10px] uppercase tracking-[0.17em] text-success">Close only when</p>
+                      <p className="mt-1 text-sm text-foreground">{bottleneck.close_condition}</p>
+                      <div className="mt-2 text-xs"><EvidenceRefs refs={bottleneck.evidence_refs} /></div>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="mt-8 flex items-start gap-4">
+                  <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-success/30 bg-success-dim text-success">
+                    <CheckCircle2 className="h-5 w-5" />
+                  </span>
+                  <div>
+                    <h1 id="autopilot-title" className="font-display text-3xl font-bold sm:text-5xl">No proof-bound constraint.</h1>
+                    <p className="mt-3 max-w-2xl text-text-secondary">Every currently observed gate has acceptable evidence. Autopilot will surface one constraint when verified state changes.</p>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <aside className="border-t border-border bg-bg-elevated/70 p-5 sm:p-7 lg:border-l lg:border-t-0" aria-label="Implementation coach">
+            <div className="flex items-center justify-between gap-3">
+              <p className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-info">Implementation coach</p>
+              <span className={cn("rounded-full border px-2 py-1 font-mono text-[9px] uppercase", healthTone(coach.state))}>
+                {humanize(coach.state)}
+              </span>
+            </div>
+            <p className="mt-5 font-display text-xl font-semibold leading-snug">{coach.message}</p>
+            <div className="mt-6 space-y-5 border-l border-border pl-4">
+              <div>
+                <p className="font-mono text-[9px] uppercase tracking-[0.18em] text-text-tertiary">Verified next action</p>
+                <p className="mt-1 text-sm text-text-secondary">{coach.next_action}</p>
+              </div>
+              <div>
+                <p className="font-mono text-[9px] uppercase tracking-[0.18em] text-text-tertiary">Acceptance evidence</p>
+                <p className="mt-1 text-sm text-text-secondary">{coach.close_condition}</p>
+              </div>
+              <div>
+                <p className="font-mono text-[9px] uppercase tracking-[0.18em] text-text-tertiary">Evidence ledger</p>
+                <div className="mt-2 text-xs"><EvidenceRefs refs={coach.evidence_refs} /></div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-4 sm:p-6">
+        <div className="mb-5 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="font-mono text-[10px] font-bold uppercase tracking-[0.22em] text-text-tertiary">Agency portfolio / live gate ledger</p>
+            <h2 className="mt-1 font-display text-2xl font-semibold">{portfolio.length} companies. {blockedCount} blocked.</h2>
+          </div>
+          <p className="max-w-md text-right text-xs text-text-tertiary">Lifecycle labels describe observed state. Close conditions require evidence, not a checked box.</p>
+        </div>
+
+        {portfolio.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-border px-6 py-10 text-center">
+            <FileCheck2 className="mx-auto h-6 w-6 text-text-tertiary" />
+            <p className="mt-3 text-sm text-text-secondary">No companies have durable operating context yet.</p>
+          </div>
+        ) : (
+          <>
+            <div className="grid gap-3 md:hidden">
+              {portfolio.map((brand) => <PortfolioCard key={brand.brand_id} brand={brand} />)}
+            </div>
+            <div className="hidden overflow-x-auto md:block">
+              <table className="w-full min-w-[1080px] border-collapse text-left text-sm">
+                <thead>
+                  <tr className="border-y border-border font-mono text-[9px] uppercase tracking-[0.16em] text-text-tertiary">
+                    <th scope="col" className="px-3 py-3 font-medium">Company / lifecycle</th>
+                    <th scope="col" className="px-3 py-3 font-medium">Health</th>
+                    <th scope="col" className="px-3 py-3 font-medium">Blocked gate</th>
+                    <th scope="col" className="px-3 py-3 font-medium">Owner</th>
+                    <th scope="col" className="px-3 py-3 font-medium">Next action</th>
+                    <th scope="col" className="px-3 py-3 font-medium">Proof-bound close</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {portfolio.map((brand) => (
+                    <tr key={brand.brand_id} className="border-b border-border/70 align-top transition-colors hover:bg-bg-elevated/60">
+                      <th scope="row" className="px-3 py-4 font-normal">
+                        <span className="block font-display text-base font-semibold text-foreground">{brand.brand_name}</span>
+                        <span className="mt-1 block font-mono text-[9px] uppercase tracking-[0.14em] text-text-tertiary">{humanize(brand.lifecycle)}</span>
+                      </th>
+                      <td className="px-3 py-4">
+                        <span className={cn("inline-flex rounded-full border px-2 py-1 font-mono text-[9px] uppercase", healthTone(brand.health))}>{humanize(brand.health)}</span>
+                      </td>
+                      <td className="max-w-[150px] px-3 py-4 font-medium text-foreground">{humanize(brand.blocked_gate)}</td>
+                      <td className="max-w-[120px] px-3 py-4 text-text-secondary">{brand.owner}</td>
+                      <td className="max-w-[220px] px-3 py-4 text-text-secondary">{brand.next_action}</td>
+                      <td className="max-w-[280px] px-3 py-4">
+                        <p className="text-text-secondary">{brand.close_condition}</p>
+                        <div className="mt-2"><EvidenceRefs refs={brand.evidence_refs} compact /></div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app-meetkai/components/layout/sidebar.tsx
+++ b/app-meetkai/components/layout/sidebar.tsx
@@ -19,7 +19,7 @@ import {
 import { useState } from "react";
 
 const navItems = [
-  { href: "/dashboard", label: "Command Center", icon: LayoutDashboard },
+  { href: "/dashboard", label: "Autopilot Command", icon: LayoutDashboard },
   { href: "/connect", label: "Connections", icon: Link2 },
   { href: "/content", label: "Library", icon: FileText },
   { href: "/actions", label: "Approvals", icon: Zap },

--- a/app-meetkai/lib/gateway/types.ts
+++ b/app-meetkai/lib/gateway/types.ts
@@ -71,6 +71,47 @@ export interface DashboardResponse {
   channel_summary: Record<string, unknown>;
 }
 
+export interface Bottleneck {
+  brand_id: string;
+  brand_name: string;
+  lifecycle: string;
+  health: string;
+  blocked_gate: string;
+  owner: string;
+  next_action: string;
+  close_condition: string;
+  evidence_refs: string[];
+  summary?: string;
+  proof_state?: string;
+}
+
+export interface ImplementationCoach {
+  state: string;
+  message: string;
+  next_action: string;
+  close_condition: string;
+  evidence_refs: string[];
+}
+
+export interface PortfolioBrand {
+  brand_id: string;
+  brand_name: string;
+  lifecycle: string;
+  health: string;
+  blocked_gate: string;
+  owner: string;
+  next_action: string;
+  close_condition: string;
+  evidence_refs: string[];
+}
+
+export interface AutopilotCommandCenterResponse {
+  primary_bottleneck: Bottleneck | null;
+  coach: ImplementationCoach;
+  portfolio: PortfolioBrand[];
+  timestamp: string;
+}
+
 export interface AgentStatus {
   running: boolean;
   paused: boolean;

--- a/docs/system/capability-manifest.json
+++ b/docs/system/capability-manifest.json
@@ -1,0 +1,701 @@
+{
+  "schema_version": 1,
+  "sources": {
+    "skills": "harness/skills/*/SKILL.md",
+    "public_router_commands": "harness/skills/kai/SKILL.md",
+    "public_manifest_pages": "docs/skill-manifest/kai-*.md",
+    "knowledge": "repository filesystem counts using counting_rules"
+  },
+  "counting_rules": {
+    "skill_directories": "Immediate directories under harness/skills.",
+    "canonical_kai_skills": "Immediate kai-* directories under harness/skills with their SKILL.md as source.",
+    "public_router_commands": "Unique /kai-* rows in the PRODUCE, AUDIT, PLAN, ANALYZE, and LEARN tables.",
+    "public_manifest_pages": "kai-*.md files under docs/skill-manifest.",
+    "knowledge_markdown": "Markdown files under the named surface; recursive only for frameworks; AGENTS.md and CLAUDE.md excluded.",
+    "audience_persona_profiles": "Non-underscore Markdown files under knowledge/personas; AGENTS.md and CLAUDE.md excluded.",
+    "harness_references": "Immediate files under harness/references.",
+    "skill_contracts": "Immediate *.yaml files under harness/skill-contracts."
+  },
+  "counts": {
+    "skill_directories": 54,
+    "canonical_kai_skills": 52,
+    "public_router_commands": 47,
+    "public_manifest_pages": 45,
+    "undocumented_canonical_skills": 7,
+    "playbook_docs": 67,
+    "checklists": 37,
+    "framework_docs": 38,
+    "channel_guides": 31,
+    "audience_persona_profiles": 8,
+    "harness_references": 36,
+    "skill_contracts": 33
+  },
+  "coverage": {
+    "undocumented_canonical_skills": [
+      "kai-brand-pulse",
+      "kai-content-batching",
+      "kai-funnel-audit",
+      "kai-hook-bench",
+      "kai-offer-builder",
+      "kai-proof-builder",
+      "kai-retro"
+    ],
+    "orphan_manifest_pages": [],
+    "unresolved_router_commands": []
+  },
+  "router_commands": [
+    {
+      "name": "kai-write",
+      "category": "produce",
+      "description": "Write one piece of content (any format)"
+    },
+    {
+      "name": "kai-landing-page",
+      "category": "produce",
+      "description": "Complete landing page with perception engineering"
+    },
+    {
+      "name": "kai-email-system",
+      "category": "produce",
+      "description": "All lifecycle + transactional emails (Loops-ready)"
+    },
+    {
+      "name": "kai-ad-campaign",
+      "category": "produce",
+      "description": "Full paid campaign across platforms + funnel stages"
+    },
+    {
+      "name": "kai-content-calendar",
+      "category": "produce",
+      "description": "Month/quarter of blog + SEO content"
+    },
+    {
+      "name": "kai-social",
+      "category": "produce",
+      "description": "Batch social posts across IG, X, TikTok, LinkedIn, YouTube"
+    },
+    {
+      "name": "kai-video",
+      "category": "produce",
+      "description": "Video scripts + clipping plans for short/long-form"
+    },
+    {
+      "name": "kai-cold-outreach",
+      "category": "produce",
+      "description": "Cold email outreach sequences"
+    },
+    {
+      "name": "kai-sdr-operator",
+      "category": "produce",
+      "description": "SDR operator package for lead sources, scoring, outreach handoff, and reply triage"
+    },
+    {
+      "name": "kai-sdr-reply-triage",
+      "category": "produce",
+      "description": "Reply classification, suppression handling, CRM handoff, and next actions"
+    },
+    {
+      "name": "kai-sales-meeting-prep",
+      "category": "produce",
+      "description": "Meeting briefs, discovery plans, follow-up drafts, and sales handoff notes"
+    },
+    {
+      "name": "kai-reddit-listen",
+      "category": "produce",
+      "description": "Monitor subreddits + draft replies to Discord (profile-driven)"
+    },
+    {
+      "name": "kai-newsletter",
+      "category": "produce",
+      "description": "Newsletter editions — content, subject lines, scheduling"
+    },
+    {
+      "name": "kai-case-study",
+      "category": "produce",
+      "description": "Customer case studies from interview/data"
+    },
+    {
+      "name": "kai-product-maker",
+      "category": "produce",
+      "description": "Ship a Gumroad-ready digital product — ebook, card deck, flipbook"
+    },
+    {
+      "name": "kai-repurpose",
+      "category": "produce",
+      "description": "1 pillar → 15-25 assets across all channels"
+    },
+    {
+      "name": "kai-content-batching",
+      "category": "produce",
+      "description": "Pillars → gated 30-day multi-platform content batch"
+    },
+    {
+      "name": "kai-offer-builder",
+      "category": "produce",
+      "description": "Grand Slam Offer construction scored on the Value Equation"
+    },
+    {
+      "name": "kai-hook-bench",
+      "category": "produce",
+      "description": "Ranked, provenance-tagged hook bank per persona and channel"
+    },
+    {
+      "name": "kai-proof-builder",
+      "category": "produce",
+      "description": "Provenance-clean proof library — testimonials, stats, case proof"
+    },
+    {
+      "name": "kai-launch",
+      "category": "produce",
+      "description": "Full product launch (orchestrates everything above)"
+    },
+    {
+      "name": "kai-retarget",
+      "category": "produce",
+      "description": "Retargeting/remarketing campaigns"
+    },
+    {
+      "name": "kai-influencer",
+      "category": "produce",
+      "description": "Influencer/creator marketing campaigns"
+    },
+    {
+      "name": "kai-webinar",
+      "category": "produce",
+      "description": "Webinar/event marketing + follow-up"
+    },
+    {
+      "name": "kai-podcast",
+      "category": "produce",
+      "description": "Podcast launch or guest strategy"
+    },
+    {
+      "name": "kai-abm",
+      "category": "produce",
+      "description": "Account-based marketing for enterprise"
+    },
+    {
+      "name": "kai-partnership",
+      "category": "produce",
+      "description": "Co-marketing / partnership campaigns"
+    },
+    {
+      "name": "kai-gate",
+      "category": "audit",
+      "description": "Quality gate — Four U's, banned words, SEO lint"
+    },
+    {
+      "name": "kai-audit",
+      "category": "audit",
+      "description": "Full marketing audit — all checklists at once"
+    },
+    {
+      "name": "kai-weekly-audit",
+      "category": "audit",
+      "description": "Weekly marketing audit - 7-day scorecard, urgent flags, and actions"
+    },
+    {
+      "name": "kai-monthly-audit",
+      "category": "audit",
+      "description": "Monthly marketing audit - 30-day executive review and next-month plan"
+    },
+    {
+      "name": "kai-seo-audit",
+      "category": "audit",
+      "description": "Technical SEO audit with prioritized fixes"
+    },
+    {
+      "name": "kai-cro",
+      "category": "audit",
+      "description": "Conversion rate audit — 5-layer optimization stack"
+    },
+    {
+      "name": "kai-funnel-audit",
+      "category": "audit",
+      "description": "Full-funnel awareness + lead-capture audit on collected data"
+    },
+    {
+      "name": "kai-html-presentation",
+      "category": "audit",
+      "description": "HTML presentation builder for audit and report delivery"
+    },
+    {
+      "name": "kai-data-dashboard",
+      "category": "audit",
+      "description": "Dashboard-ready specs or static dashboards from sourced Kai data"
+    },
+    {
+      "name": "kai-brief",
+      "category": "plan",
+      "description": "Create a content brief before writing"
+    },
+    {
+      "name": "kai-growth-plan",
+      "category": "plan",
+      "description": "Stage-appropriate marketing plan ($0 → $100K+ MRR)"
+    },
+    {
+      "name": "kai-growth-hacker",
+      "category": "plan",
+      "description": "First-growth-hire distribution OS across B2B and B2C channels"
+    },
+    {
+      "name": "kai-brand",
+      "category": "plan",
+      "description": "Brand positioning + messaging framework"
+    },
+    {
+      "name": "kai-budget",
+      "category": "plan",
+      "description": "Marketing budget planning + forecasting"
+    },
+    {
+      "name": "kai-retention",
+      "category": "plan",
+      "description": "Customer retention system design"
+    },
+    {
+      "name": "kai-competitors",
+      "category": "analyze",
+      "description": "Competitive teardown + sales battlecards"
+    },
+    {
+      "name": "kai-brand-pulse",
+      "category": "analyze",
+      "description": "Cited public brand intelligence across web, news, social, Reddit, and review sites"
+    },
+    {
+      "name": "kai-surround-sound",
+      "category": "analyze",
+      "description": "AI-search visibility, source-quality, and agent-readiness strategy"
+    },
+    {
+      "name": "kai-analytics",
+      "category": "analyze",
+      "description": "Analytics + attribution setup"
+    },
+    {
+      "name": "kai-retro",
+      "category": "learn",
+      "description": "Learning retrospective — mine gate failures, diagnose losers, promote lessons into enforced checks"
+    }
+  ],
+  "skills": [
+    {
+      "name": "kai-abm",
+      "description": "Plan and execute account-based marketing campaigns for enterprise targets — account selection, personalized outreach, multi-channel touch sequences, and deal acceleration. Use when \"ABM\", \"account-based marketing\", \"enterprise marketing\", \"target accounts\", \"named accounts\", \"enterprise outreach\", \"key accounts\", or any request to build personalized campaigns for specific companies.",
+      "source": "harness/skills/kai-abm/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-abm.md"
+    },
+    {
+      "name": "kai-ad-campaign",
+      "description": "Plan, evaluate, and produce paid ad campaigns across platforms (Meta, Google, LinkedIn, TikTok, Microsoft, Pinterest, Snapchat, Amazon, X). Evaluate existing ads, map funnel stages (TOF/MOF/BOF), produce ad variants per platform with policy compliance, output ready-to-upload copy. Use when \"ad campaign\", \"create ads\", \"run ads for\", \"paid campaign\", \"media plan\", \"launch ads\", \"Meta campaign\", \"Google Ads campaign\", \"multi-platform ads\", \"evaluate my ads\", \"how are my ads doing\", \"audit my ads\", \"ad performance\", \"analyze ads\", or any request to evaluate existing or create new advertising.",
+      "source": "harness/skills/kai-ad-campaign/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-ad-campaign.md"
+    },
+    {
+      "name": "kai-analytics",
+      "description": "Analytics and attribution setup — tracking plan, UTM conventions, dashboard design, and attribution model selection. Use when \"analytics setup\", \"attribution\", \"tracking plan\", \"UTM\", \"marketing analytics\", \"dashboard setup\", \"measurement strategy\", \"how do I track\", \"which metrics\", or any request to set up or improve marketing measurement and attribution.",
+      "source": "harness/skills/kai-analytics/SKILL.md",
+      "public_router_command": true,
+      "router_category": "analyze",
+      "manifest_doc": "docs/skill-manifest/kai-analytics.md"
+    },
+    {
+      "name": "kai-audit",
+      "description": "Full marketing audit — runs all relevant checklists against your product, site, and marketing in one go. Covers SEO, content, email, ads, social media, CRO, landing pages, technical SEO, and creative production. Produces a \"state of your marketing\" report with health scores per area and a prioritized fix list. Use when \"marketing audit\", \"full audit\", \"audit everything\", \"marketing health check\", \"what's broken\", \"state of marketing\", or any request to comprehensively assess marketing across all channels.",
+      "source": "harness/skills/kai-audit/SKILL.md",
+      "public_router_command": true,
+      "router_category": "audit",
+      "manifest_doc": "docs/skill-manifest/kai-audit.md"
+    },
+    {
+      "name": "kai-brand",
+      "description": "Brand positioning workshop — define messaging framework, voice/tone, differentiation strategy, and taglines. Use when \"brand positioning\", \"messaging framework\", \"brand voice\", \"how should we position ourselves\", \"differentiation\", \"tagline\", or any request to define or refine brand identity and messaging.",
+      "source": "harness/skills/kai-brand/SKILL.md",
+      "public_router_command": true,
+      "router_category": "plan",
+      "manifest_doc": "docs/skill-manifest/kai-brand.md"
+    },
+    {
+      "name": "kai-brand-pulse",
+      "description": "Multi-platform brand intelligence pulse - collect cited public reputation evidence across web, news, YouTube, X, LinkedIn, Reddit, and review sites, then turn it into objection mining, content angles, competitor positioning, and surround-sound actions. Use when \"brand monitor\", \"brand pulse\", \"what are people saying about us\", \"multi-platform reputation\", \"brand intelligence\", \"weekly brand monitoring\", \"objection mining\", or \"public reputation scan\".",
+      "source": "harness/skills/kai-brand-pulse/SKILL.md",
+      "public_router_command": true,
+      "router_category": "analyze",
+      "manifest_doc": null
+    },
+    {
+      "name": "kai-brief",
+      "description": "Create a structured content brief using the Kai CMO Harness brief schema. Selects persona, defines angle, sets quality targets. Use when \"create a brief\", \"content brief\", \"plan this content\", \"brief for [topic]\", \"what persona should I use\", or before any content creation to define the strategy. Outputs a brief that /kai-write and /kai-email-system consume.",
+      "source": "harness/skills/kai-brief/SKILL.md",
+      "public_router_command": true,
+      "router_category": "plan",
+      "manifest_doc": "docs/skill-manifest/kai-brief.md"
+    },
+    {
+      "name": "kai-budget",
+      "description": "Marketing budget planning and forecasting — channel allocation, CAC targets, ROI projections, and spend optimization. Use when \"marketing budget\", \"budget planning\", \"channel allocation\", \"marketing spend\", \"CAC forecast\", \"budget forecast\", \"how much should I spend\", \"allocate budget\", or any request to plan, forecast, or optimize marketing spend.",
+      "source": "harness/skills/kai-budget/SKILL.md",
+      "public_router_command": true,
+      "router_category": "plan",
+      "manifest_doc": "docs/skill-manifest/kai-budget.md"
+    },
+    {
+      "name": "kai-case-study",
+      "description": "Produce customer case studies from interviews or data — Problem, Solution, Results structure with perception engineering and quality gates. Use when \"case study\", \"customer story\", \"testimonial\", \"success story\", \"client results\", or any request to document a customer win.",
+      "source": "harness/skills/kai-case-study/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-case-study.md"
+    },
+    {
+      "name": "kai-cold-outreach",
+      "description": "Build a complete cold email outreach system — ICP definition, sequence architecture, personalization strategy, and batch-produced email sequences with CAN-SPAM/deliverability compliance. Use when \"cold outreach\", \"cold email sequence\", \"outbound campaign\", \"prospecting emails\", \"sales outreach\", \"build outreach sequence\", or any request to create systematic cold email campaigns for lead generation.",
+      "source": "harness/skills/kai-cold-outreach/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-cold-outreach.md"
+    },
+    {
+      "name": "kai-competitors",
+      "description": "Competitive intelligence teardown — 5-layer analysis (signals, product, marketing, positioning, strategy) plus sales battlecard. Use when \"competitor analysis\", \"competitive teardown\", \"who are our competitors\", \"battlecard\", \"competitive intel\", \"compare us to X\", \"what is X doing\", or any request to research, analyze, or position against competitors.",
+      "source": "harness/skills/kai-competitors/SKILL.md",
+      "public_router_command": true,
+      "router_category": "analyze",
+      "manifest_doc": "docs/skill-manifest/kai-competitors.md"
+    },
+    {
+      "name": "kai-content-batching",
+      "description": "Turn a brand's positioning into a 30-day, multi-platform content batch — 3-7 pillars, subtopic matrix mapped to funnel stage and persona, pillar pieces plus derivative fan-out, proof elements in at least half the slots, all registered in the editorial calendar store and quality-gated. Use when \"content batch\", \"batch my content\", \"30 days of content\", \"month of content\", \"content batching machine\", \"content pillars\", \"fill the content calendar\", \"plan a month of posts\", or any request to produce a full month of multi-platform content in one run.",
+      "source": "harness/skills/kai-content-batching/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": null
+    },
+    {
+      "name": "kai-content-calendar",
+      "description": "Plan and produce a content calendar — a month (or quarter) of blog posts, LinkedIn articles, and SEO content mapped to business goals, personas, and keywords. Generates briefs for each piece, optionally batch-produces all content with quality gates. Use when \"content calendar\", \"plan blog content\", \"monthly content\", \"quarterly content plan\", \"what should we publish\", \"content strategy\", \"editorial calendar\", or any request to plan multiple pieces of content over time.",
+      "source": "harness/skills/kai-content-calendar/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-content-calendar.md"
+    },
+    {
+      "name": "kai-cro",
+      "description": "Conversion rate optimization audit — analyze a landing page, signup flow, or checkout funnel using the 5-layer CRO stack (technical performance, traffic quality, offer/pricing, design/layout, copy/messaging). Produces prioritized fix list with expected impact. Use when \"CRO audit\", \"conversion audit\", \"why isn't this converting\", \"improve conversion rate\", \"landing page not converting\", \"optimize funnel\", \"signup flow audit\", or any request to diagnose and fix conversion problems.",
+      "source": "harness/skills/kai-cro/SKILL.md",
+      "public_router_command": true,
+      "router_category": "audit",
+      "manifest_doc": "docs/skill-manifest/kai-cro.md"
+    },
+    {
+      "name": "kai-daily-ad-review",
+      "description": "Daily ad performance check-in across platforms. Pulls live metrics from Meta, Google, and LinkedIn via deterministic scripts, compares against benchmarks and previous period, flags overspend/underperformers/policy issues, and outputs a quick daily summary with action items. Use when \"daily ad review\", \"how are my ads doing today\", \"ad check-in\", \"morning ad report\", \"daily ad summary\", \"check ad performance\", \"ad dashboard\", \"daily ads\", or any request for a recurring or quick-glance ad performance review.",
+      "source": "harness/skills/kai-daily-ad-review/SKILL.md",
+      "public_router_command": false,
+      "router_category": null,
+      "manifest_doc": "docs/skill-manifest/kai-daily-ad-review.md"
+    },
+    {
+      "name": "kai-data-dashboard",
+      "description": "Convert Kai workflow data, CSV exports, audit folders, SDR package outputs, and marketing reports into dashboard-ready specs or lightweight static dashboards. Use when \"data dashboard\", \"operator dashboard\", \"operator room\", \"HTML operators room\", \"sales dashboard\", \"SDR dashboard\", \"turn this data into a dashboard\", \"dashboard handoff\", \"visualize Kai data\", or any request to package sourced marketing, sales, audit, or SDR data for a dashboard or presentation surface.",
+      "source": "harness/skills/kai-data-dashboard/SKILL.md",
+      "public_router_command": true,
+      "router_category": "audit",
+      "manifest_doc": "docs/skill-manifest/kai-data-dashboard.md"
+    },
+    {
+      "name": "kai-email-system",
+      "description": "Plan and batch-produce an entire email system for a product. Maps every lifecycle touchpoint (onboarding, activation, conversion, retention, transactional, win-back), generates all emails with quality gates, outputs Loops-ready copy. Use when \"create all emails\", \"email system\", \"build email sequences\", \"lifecycle emails\", \"onboarding sequence\", \"set up transactional emails\", \"plan all the emails for [product]\", or any request to systematically produce a complete set of emails for a platform.",
+      "source": "harness/skills/kai-email-system/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-email-system.md"
+    },
+    {
+      "name": "kai-funnel-audit",
+      "description": "Two-layer funnel audit on collected data only — stress-test the awareness layer (hooks, messaging, proof placement, attention leaks on live pages and ads) and the lead-capture layer (opt-ins and lead magnets scored on the four Value Equation variables, friction findings, weakest-magnet rewrite), plus a phone-path check under the KaiCalls Fit Rule. Use when \"funnel audit\", \"audit my funnel\", \"why is my funnel leaking\", \"top of funnel isn't converting\", \"audit our lead magnets\", \"opt-in audit\", \"awareness to lead audit\", \"where are we losing people\", \"lead capture audit\", or any request to diagnose the full awareness-to-lead flow rather than one page.",
+      "source": "harness/skills/kai-funnel-audit/SKILL.md",
+      "public_router_command": true,
+      "router_category": "audit",
+      "manifest_doc": null
+    },
+    {
+      "name": "kai-gate",
+      "description": "Run Kai CMO Harness quality gates on content. Scores Four U's (Unique/Useful/Ultra-specific/Urgent), checks for banned words and AI slop, runs SEO lint for search content. Use when \"score this\", \"quality check\", \"run quality gates\", \"check this content\", \"four u's score\", \"banned word check\", \"SEO lint\", or any request to validate content quality before publishing.",
+      "source": "harness/skills/kai-gate/SKILL.md",
+      "public_router_command": true,
+      "router_category": "audit",
+      "manifest_doc": "docs/skill-manifest/kai-gate.md"
+    },
+    {
+      "name": "kai-growth-hacker",
+      "description": "Build an exhaustive first-growth-hire distribution operating system across B2B and B2C channels: LinkedIn, events, AI outbound, AEO, blogs, long-form writing, YouTube, webinars, X, influencers, AI UGC, organic TikTok, paid social, sponsorships, partnerships, lifecycle, referral, and community. Use when \"growth hacker\", \"first growth hire\", \"distribution hire\", \"cover every channel\", \"channel hacking\", \"0 to ARR growth system\", \"growth operator\", \"growth hacker OS\", or any request to fan out channel operators and plug the result into Kai workflows.",
+      "source": "harness/skills/kai-growth-hacker/SKILL.md",
+      "public_router_command": true,
+      "router_category": "plan",
+      "manifest_doc": "docs/skill-manifest/kai-growth-hacker.md"
+    },
+    {
+      "name": "kai-growth-plan",
+      "description": "Generate a stage-appropriate marketing plan based on your company's MRR/stage. Uses the marketing-by-stage playbook to tell you exactly what to do (and what NOT to do) at pre-launch, early ($0-10K MRR), growth ($10-100K MRR), or scale ($100K+ MRR). Use when \"what should I do for marketing\", \"growth plan\", \"marketing plan\", \"I just raised a round\", \"marketing strategy\", \"what's the right marketing for my stage\", \"GTM strategy\", or any request for a stage-appropriate marketing roadmap.",
+      "source": "harness/skills/kai-growth-plan/SKILL.md",
+      "public_router_command": true,
+      "router_category": "plan",
+      "manifest_doc": "docs/skill-manifest/kai-growth-plan.md"
+    },
+    {
+      "name": "kai-hook-bench",
+      "description": "Generate, rank, and gate a reusable hook bank — sourced pains × named hook formula families, scored on clarity/specificity/curiosity/proof-backing, gated at the 10/16 ad threshold, delivered in 3 lengths with per-hook provenance and downstream routing. Use when \"hook bank\", \"generate hooks\", \"hook generator\", \"write hooks for\", \"ad hooks\", \"scroll stoppers\", \"opening lines\", \"hook ideas\", \"first 3 seconds\", \"hook matrix\", \"I need 50 hooks\", or any request to batch-produce attention-openers for ads, social, or video.",
+      "source": "harness/skills/kai-hook-bench/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": null
+    },
+    {
+      "name": "kai-html-presentation",
+      "description": "Client-ready HTML presentation builder for Kai audit and report folders. Converts weekly audits, monthly audits, marketing reports, scorecards, findings, data-source notes, and action plans into a polished single-file HTML deck with sourced metrics, executive slides, speaker notes, and delivery-ready styling. Use when \"HTML presentation\", \"HTML deck\", \"client-ready audit deck\", \"turn this audit into slides\", \"present the weekly audit\", \"present the monthly audit\", or any request to deliver Kai reports as HTML slides.",
+      "source": "harness/skills/kai-html-presentation/SKILL.md",
+      "public_router_command": true,
+      "router_category": "audit",
+      "manifest_doc": "docs/skill-manifest/kai-html-presentation.md"
+    },
+    {
+      "name": "kai-influencer",
+      "description": "Plan influencer marketing campaigns — find creators, write briefs, manage partnerships, and measure ROI. Use when \"influencer\", \"influencer marketing\", \"creator campaign\", \"UGC campaign\", \"brand ambassador\", \"creator partnership\", or any request to work with influencers or content creators.",
+      "source": "harness/skills/kai-influencer/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-influencer.md"
+    },
+    {
+      "name": "kai-landing-page",
+      "description": "Produce complete landing page copy using perception engineering and conversion frameworks. Generates hero section, value props, social proof blocks, objection handlers, and CTA — all scored against quality gates. Use when \"landing page\", \"sales page\", \"LP copy\", \"write a landing page\", \"hero section\", \"conversion page\", \"signup page\", or any request to produce persuasive page copy that converts visitors.",
+      "source": "harness/skills/kai-landing-page/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-landing-page.md"
+    },
+    {
+      "name": "kai-launch",
+      "description": "Plan and produce a complete product launch marketing package — landing page copy, email sequences, ad campaigns, press release, social posts, and launch timeline. Orchestrates all other kai skills into a coordinated launch. Use when \"product launch\", \"launch campaign\", \"go-to-market\", \"GTM plan\", \"launch marketing\", \"we're launching\", \"prepare launch materials\", or any request to coordinate marketing for a new product, feature, or major update.",
+      "source": "harness/skills/kai-launch/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-launch.md"
+    },
+    {
+      "name": "kai-monthly-audit",
+      "description": "Monthly marketing audit and executive review. Pulls the last 30 days of source-backed marketing, analytics, SEO, CRO, content, paid media, lifecycle, reputation, and pipeline data; compares it to the previous period; summarizes strategic learning; and produces an executive report plus next-month plan. Use when \"monthly audit\", \"monthly marketing review\", \"monthly report\", \"executive marketing review\", \"board-ready marketing report\", \"month-end audit\", or any request for a 30-day marketing audit.",
+      "source": "harness/skills/kai-monthly-audit/SKILL.md",
+      "public_router_command": true,
+      "router_category": "audit",
+      "manifest_doc": "docs/skill-manifest/kai-monthly-audit.md"
+    },
+    {
+      "name": "kai-newsletter",
+      "description": "Plan and produce newsletter editions — content selection, subject lines, scheduling, and production with quality gates. Use when \"newsletter\", \"plan newsletter\", \"newsletter content\", \"email newsletter\", \"weekly digest\", or any request to create or manage a newsletter.",
+      "source": "harness/skills/kai-newsletter/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-newsletter.md"
+    },
+    {
+      "name": "kai-offer-builder",
+      "description": "Construct and score Grand Slam Offers using the Value Equation — sourced pain mining, dream outcome articulation, problems→solutions→trim-and-stack offer construction, guarantee/scarcity/bonus design, 1-10 scoring on the four Value Equation variables, pricing sanity pass, and compliance check. Use when \"build an offer\", \"grand slam offer\", \"value equation\", \"offer stack\", \"make this offer irresistible\", \"design a guarantee\", \"hormozi offer\", \"why isn't my offer selling\", \"pricing and packaging for my offer\", or any request to design, score, or rework a commercial offer.",
+      "source": "harness/skills/kai-offer-builder/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": null
+    },
+    {
+      "name": "kai-partnership",
+      "description": "Partnership and co-marketing campaign planner — partner selection criteria, joint content strategy, cross-promotion plans, and co-branded assets. Use when \"partnership\", \"co-marketing\", \"partner program\", \"cross-promotion\", \"joint venture\", \"co-branded\", \"partner campaign\", or any request to plan or execute a marketing partnership.",
+      "source": "harness/skills/kai-partnership/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-partnership.md"
+    },
+    {
+      "name": "kai-podcast",
+      "description": "Launch a podcast or plan podcast guest strategy — format, content planning, episode production, guest outreach, and distribution. Use when \"podcast\", \"start a podcast\", \"podcast marketing\", \"podcast guest\", \"podcast strategy\", \"be a podcast guest\", \"launch a show\", or any request related to podcast creation or guest appearances.",
+      "source": "harness/skills/kai-podcast/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-podcast.md"
+    },
+    {
+      "name": "kai-product-maker",
+      "description": "Build a Gumroad-ready digital product from scratch — ebook, card deck, playbook, Notion template, or flipbook. Walks from concept → content outline → design brief → per-item markdown → images → multi-format build (PDF, HTML flipbook, Notion, card deck) → Gumroad sales page + email blast + launch assets. Use when \"make a digital product\", \"build an ebook\", \"create a playbook\", \"card deck\", \"notion template product\", \"gumroad product\", \"make a pdf to sell\", or any request to ship a sellable information product.",
+      "source": "harness/skills/kai-product-maker/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-product-maker.md"
+    },
+    {
+      "name": "kai-proof-builder",
+      "description": "Build and maintain a provenance-clean proof library — inventory every real proof asset (analytics, reviews, permitted testimonials, case studies, press, certifications), categorize it, rewrite each cleared item in 3 lengths, fuse top assets with narrative, and gate everything through FTC testimonial rules before it can ship. Use when \"proof library\", \"gather our proof\", \"authority builder\", \"collect testimonials\", \"social proof assets\", \"proof points for the sales page\", \"what results can we claim\", or any request to assemble evidence for marketing claims. NEVER invents proof — missing proof is reported as a gap.",
+      "source": "harness/skills/kai-proof-builder/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": null
+    },
+    {
+      "name": "kai-reddit-listen",
+      "description": "Monitor Reddit for conversation-fit opportunities — watches a list of subreddits, keyword-filters new posts, runs an LLM eval in your voice (with identity guardrails), and drops drafted replies into Discord. Use when \"reddit monitor\", \"reddit listener\", \"reddit outreach\", \"watch subreddits\", \"find reddit opportunities\", \"listen on reddit\", \"community listening\", or any request to automate finding posts you should reply to on Reddit.",
+      "source": "harness/skills/kai-reddit-listen/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-reddit-listen.md"
+    },
+    {
+      "name": "kai-repurpose",
+      "description": "Take one pillar content piece and produce 15-25 derivative assets across platforms — social posts, email, LinkedIn article, video scripts, newsletter section, infographic brief, and more. The ultimate content multiplier. Use when \"repurpose this\", \"turn this into\", \"make social posts from this blog\", \"content repurposing\", \"1 to many\", \"atomize this content\", \"extract posts from\", or any request to derive multiple pieces from one source.",
+      "source": "harness/skills/kai-repurpose/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-repurpose.md"
+    },
+    {
+      "name": "kai-retarget",
+      "description": "Design retargeting and remarketing campaign architecture across platforms — audience segmentation, creative strategy, frequency caps, and platform-specific setup with ad policy compliance. Use when \"retargeting\", \"remarketing\", \"retarget\", \"re-engage visitors\", \"abandoned cart\", \"pixel setup\", or any request to bring back visitors who didn't convert.",
+      "source": "harness/skills/kai-retarget/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-retarget.md"
+    },
+    {
+      "name": "kai-retention",
+      "description": "Customer retention system — churn analysis, retention tactics, loyalty programs, and engagement scoring. Use when \"retention\", \"reduce churn\", \"keep customers\", \"loyalty program\", \"customer retention\", \"churn prevention\", \"churn analysis\", \"engagement scoring\", \"win-back\", \"customer lifetime value\", or any request to analyze, prevent, or reduce customer churn.",
+      "source": "harness/skills/kai-retention/SKILL.md",
+      "public_router_command": true,
+      "router_category": "plan",
+      "manifest_doc": "docs/skill-manifest/kai-retention.md"
+    },
+    {
+      "name": "kai-retro",
+      "description": "Run a learning retrospective on the Kai harness. Mines gate-failure logs and 30-day performance results into lessons, triages candidate lessons (promote/keep/retire), and graduates repeated lessons into enforced gate checks with golden corpus cases. Use when \"retro\", \"what have we learned\", \"triage lessons\", \"promote lessons\", \"why does this keep failing\", \"harness retrospective\", or monthly / after any heavy content sprint.",
+      "source": "harness/skills/kai-retro/SKILL.md",
+      "public_router_command": true,
+      "router_category": "learn",
+      "manifest_doc": null
+    },
+    {
+      "name": "kai-sales-meeting-prep",
+      "description": ">",
+      "source": "harness/skills/kai-sales-meeting-prep/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-sales-meeting-prep.md"
+    },
+    {
+      "name": "kai-sdr-operator",
+      "description": ">",
+      "source": "harness/skills/kai-sdr-operator/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-sdr-operator.md"
+    },
+    {
+      "name": "kai-sdr-reply-triage",
+      "description": ">",
+      "source": "harness/skills/kai-sdr-reply-triage/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-sdr-reply-triage.md"
+    },
+    {
+      "name": "kai-seo-audit",
+      "description": "One-click technical SEO audit of a website. Runs the full technical SEO audit SOP — crawlability, indexation, Core Web Vitals, schema markup, internal linking, mobile UX, and content quality. Outputs a prioritized fix list. Use when \"SEO audit\", \"technical SEO\", \"site audit\", \"crawl issues\", \"indexation problems\", \"why aren't we ranking\", \"SEO health check\", or any request to diagnose SEO issues on a website.",
+      "source": "harness/skills/kai-seo-audit/SKILL.md",
+      "public_router_command": true,
+      "router_category": "audit",
+      "manifest_doc": "docs/skill-manifest/kai-seo-audit.md"
+    },
+    {
+      "name": "kai-social",
+      "description": "Plan and batch-produce social media content across platforms (Instagram, X/Twitter, TikTok, LinkedIn, YouTube). Generates a week or month of posts with platform-specific formatting, hashtags, hooks, and posting schedule. Use when \"social media posts\", \"social calendar\", \"plan social content\", \"Instagram posts\", \"tweets\", \"LinkedIn posts\", \"TikTok ideas\", \"social media strategy\", \"batch social\", or any request to systematically produce social media content.",
+      "source": "harness/skills/kai-social/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-social.md"
+    },
+    {
+      "name": "kai-start",
+      "description": "First-run onboarding for Kai CMO Harness. Walks new users through product discovery, generates MARKETING.md, and recommends the first command to run. Use when a user has just installed Kai and types /kai-start, \"get started with Kai\", \"set up Kai\", \"first time using Kai\", or when MARKETING.md doesn't exist yet.",
+      "source": "harness/skills/kai-start/SKILL.md",
+      "public_router_command": false,
+      "router_category": null,
+      "manifest_doc": "docs/skill-manifest/kai-start.md"
+    },
+    {
+      "name": "kai-surround-sound",
+      "description": "LLM brand manipulation — build a consensus web so ChatGPT, Claude, Perplexity, and Google AI Overviews mention your brand when people ask about your category. Uses surround sound methodology, entity SEO, and LLM citation science. Use when \"get mentioned in AI\", \"LLM brand presence\", \"surround sound\", \"AI search visibility\", \"Perplexity ranking\", \"ChatGPT mentions\", \"AI Overview inclusion\", \"entity authority\", \"brand mentions in AI\", or any request to influence how AI systems perceive and recommend your brand.",
+      "source": "harness/skills/kai-surround-sound/SKILL.md",
+      "public_router_command": true,
+      "router_category": "analyze",
+      "manifest_doc": "docs/skill-manifest/kai-surround-sound.md"
+    },
+    {
+      "name": "kai-taste",
+      "description": "Audit or design generative AI interfaces against three diagnostic pillars (deterministic-stochastic balance, interaction density, visual cohesion). Treats taste as a measurable control system, not subjective preference. Use when: 'taste audit', 'score this UI', 'design quality', 'interaction density', 'visual cohesion', 'refiner layer', 'correction cost', 'why does this feel off', 'polish this', 'design review', or building any user-facing AI product.",
+      "source": "harness/skills/kai-taste/SKILL.md",
+      "public_router_command": false,
+      "router_category": null,
+      "manifest_doc": "docs/skill-manifest/kai-taste.md"
+    },
+    {
+      "name": "kai-topical-map",
+      "description": "Build an AEO-first topical map optimized for AI search citation — entity clusters, query fan-out coverage, information gain scoring, and multi-platform distribution. Produces entity map, content node architecture, schema blueprint, and 90-day publishing calendar. Use when \"topical map\", \"content architecture\", \"site structure\", \"topic clusters\", \"pillar content plan\", \"AEO map\", \"AI search architecture\", \"entity map\", \"what content should we build\", or any request to plan a site's topical structure for AI search visibility.",
+      "source": "harness/skills/kai-topical-map/SKILL.md",
+      "public_router_command": false,
+      "router_category": null,
+      "manifest_doc": "docs/skill-manifest/kai-topical-map.md"
+    },
+    {
+      "name": "kai-video",
+      "description": "Produce video scripts and clipping plans for TikTok, YouTube Shorts, Instagram Reels, and long-form YouTube. Generates hook-first scripts optimized for each platform's algorithm, plus a clipping plan to extract short-form from long-form content. Use when \"video script\", \"TikTok script\", \"YouTube script\", \"Reels script\", \"Shorts script\", \"video content\", \"clipping plan\", \"video ideas\", or any request to create video content for social platforms.",
+      "source": "harness/skills/kai-video/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-video.md"
+    },
+    {
+      "name": "kai-video-production",
+      "description": "Full-stack video production from script to rendered video. Combines script generation (optimized for TikTok/YouTube/Reels) with AI-powered video rendering using Remotion, AI voiceovers (Qwen3-TTS/ElevenLabs), music generation (ACE-Step), and browser-based demo recording. Multi-session project tracking with automatic intent reconciliation. Use when \"create video\", \"produce video\", \"demo video\", \"product video\", or any request to generate AND render video content.",
+      "source": "harness/skills/kai-video-production/SKILL.md",
+      "public_router_command": false,
+      "router_category": null,
+      "manifest_doc": "docs/skill-manifest/kai-video-production.md"
+    },
+    {
+      "name": "kai-webinar",
+      "description": "Plan webinar and event marketing — topic selection, promotion strategy, content production, registration flow, and post-event follow-up sequences. Use when \"webinar\", \"event marketing\", \"virtual event\", \"live event\", \"workshop\", \"online event\", or any request to plan, promote, or produce a webinar or marketing event.",
+      "source": "harness/skills/kai-webinar/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-webinar.md"
+    },
+    {
+      "name": "kai-weekly-audit",
+      "description": "Weekly marketing audit and operating review. Pulls the last 7 days of source-backed marketing, analytics, content, paid media, lead, watcher, and audit data; compares it to the prior 7 days; flags urgent issues; and produces a weekly scorecard plus action list. Use when \"weekly audit\", \"weekly marketing review\", \"weekly check-in\", \"weekly scorecard\", \"what changed this week\", \"Friday marketing review\", or any request for a recurring 7-day marketing audit.",
+      "source": "harness/skills/kai-weekly-audit/SKILL.md",
+      "public_router_command": true,
+      "router_category": "audit",
+      "manifest_doc": "docs/skill-manifest/kai-weekly-audit.md"
+    },
+    {
+      "name": "kai-write",
+      "description": "Write a single piece of marketing content using Kai CMO Harness frameworks and quality gates. Supports blog posts, LinkedIn articles, emails, cold outreach, press releases, ad copy, and TikTok scripts. Automatically loads the right framework, skill contract, and persona. Use when \"write a blog post\", \"draft an email\", \"LinkedIn article\", \"cold outreach\", \"write ad copy\", \"press release\", \"TikTok script\", or any single content creation request. For building a complete email system, use /kai-email-system instead.",
+      "source": "harness/skills/kai-write/SKILL.md",
+      "public_router_command": true,
+      "router_category": "produce",
+      "manifest_doc": "docs/skill-manifest/kai-write.md"
+    }
+  ]
+}

--- a/docs/system/governance-and-quality.md
+++ b/docs/system/governance-and-quality.md
@@ -4,22 +4,26 @@ Kai should be useful without being reckless. Governance is split into instructio
 
 ## Authoritative Inventory
 
-Use these counts when public docs, skill docs, or agent prompts need a system inventory. Update this table before changing counts elsewhere.
+Use these generated counts when public docs, skill docs, or agent prompts need a system inventory.
 
-| Surface | Count | Counting rule |
-|---|---:|---|
-| Skill directories | 48 | Directories under `harness/skills/`. This includes canonical `kai-*` skill directories, the `/kai` router, and `kaicalls-design`. |
-| Canonical `kai-*` skill docs | 45 | Public API-style pages in `docs/skill-manifest/`. |
-| Public `/kai` router commands | 42 | Commands listed by `harness/skills/kai/SKILL.md`. Router-visible commands are a subset of the canonical `kai-*` skill inventory. |
-| Playbook docs | 54 | Markdown playbooks under `knowledge/playbooks/`, excluding local `CLAUDE.md` metadata. |
-| Checklists | 36 | Markdown checklists under `knowledge/checklists/`, excluding local `CLAUDE.md` metadata. |
-| Framework docs | 27 | Markdown framework files under `knowledge/frameworks/`. |
-| Channel guides | 26 | Markdown channel guides under `knowledge/channels/`. |
-| Audience persona profiles | 8 | Named persona files under `knowledge/personas/`, excluding the index and local metadata. |
-| Harness references | 18 | Markdown or YAML/JSON references under `harness/references/`. |
-| Skill contracts | 30 | YAML contracts under `harness/skill-contracts/`. |
+<!-- capability-counts:start -->
+Generated from `docs/system/capability-manifest.json`. Regenerate with `python -m scripts.capability_manifest generate`; verify with `python -m scripts.capability_manifest check`.
 
-Inventory date: 2026-06-17. Regenerate with scoped file counts before publishing a release.
+| Surface | Count |
+|---|---:|
+| Skill directories | 54 |
+| Canonical `kai-*` skills | 52 |
+| Public `/kai` router commands | 47 |
+| Public skill manifest pages | 45 |
+| Canonical skills missing manifest pages | 7 |
+| Playbook docs | 67 |
+| Checklists | 37 |
+| Framework docs | 38 |
+| Channel guides | 31 |
+| Audience persona profiles | 8 |
+| Harness references | 36 |
+| Skill contracts | 33 |
+<!-- capability-counts:end -->
 
 ## Instruction Contract
 

--- a/gateway/routers/actions.py
+++ b/gateway/routers/actions.py
@@ -42,6 +42,14 @@ def _get_integration_registry():
         return None
 
 
+def _get_company_autopilot_service():
+    try:
+        from kai.runtime.company_autopilot import CompanyAutopilotService
+        return CompanyAutopilotService()
+    except (ImportError, Exception):
+        return None
+
+
 def _require_store(name: str, store):
     if store is None:
         raise HTTPException(
@@ -291,6 +299,26 @@ async def toggle_kill_switch(integration_id: str, enabled: bool = True):
 # ============================================================================
 # Operator Dashboard
 # ============================================================================
+
+
+@router.get("/command-center")
+async def company_autopilot_command_center(brand_id: Optional[str] = None):
+    """Return the single highest-priority proof-bound company bottleneck."""
+    service = _require_store(
+        "Company Autopilot service",
+        _get_company_autopilot_service(),
+    )
+    return service.command_center(brand_id=brand_id)
+
+
+@router.get("/portfolio")
+async def company_autopilot_portfolio(brand_id: Optional[str] = None):
+    """Return evidence-derived lifecycle and blocker rows across brands."""
+    service = _require_store(
+        "Company Autopilot service",
+        _get_company_autopilot_service(),
+    )
+    return service.portfolio(brand_id=brand_id)
 
 
 @router.get("/dashboard")

--- a/gateway/routers/runtime.py
+++ b/gateway/routers/runtime.py
@@ -9,6 +9,7 @@ from kai.runtime import (
     load_module_manifests,
     load_workspace_profile,
 )
+from scripts.capability_manifest import discover_inventory
 
 
 router = APIRouter()
@@ -39,6 +40,12 @@ async def list_modules():
         "modules": [manifest.model_dump() for manifest in manifests.values()],
         "count": len(manifests),
     }
+
+
+@router.get("/capabilities")
+async def list_capabilities():
+    """Return the generated capability inventory from canonical repo sources."""
+    return discover_inventory()
 
 
 @router.get("/state")

--- a/kai/packaging/agency_setup.py
+++ b/kai/packaging/agency_setup.py
@@ -1,0 +1,130 @@
+"""One-command durable agency setup for Kai Company Autopilot.
+
+This module wraps :class:`kai.packaging.setup.SetupWizard` instead of creating
+another onboarding schema.  The setup receipt proves that the durable context
+was written and read back; it deliberately does not claim that connectors or
+external effects have been verified.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from .setup import SetupResult, SetupWizard
+
+
+class AgencySetupError(ValueError):
+    """Raised when a one-command setup payload is incomplete or invalid."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(64 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _write_json_atomic(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def _validated_answers(wizard: SetupWizard, answers: Dict[str, Any]) -> Dict[str, Any]:
+    normalized: Dict[str, Any] = dict(answers)
+    errors = []
+    for index, section in enumerate(wizard.get_sections()):
+        processed = wizard.process_section(index, normalized)
+        errors.extend(processed.pop("_errors", []))
+        normalized.update(processed)
+
+    if errors:
+        raise AgencySetupError("; ".join(errors))
+    return normalized
+
+
+def run_agency_setup(
+    workspace_dir: str | Path,
+    answers: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Create durable agency context and return a read-back-bound receipt.
+
+    The command writes the existing canonical setup artifacts, reads them back,
+    binds their SHA-256 hashes into ``setup_receipt.json``, and returns both the
+    canonical :class:`SetupResult` and the receipt.  This is idempotent for the
+    same agency id; a rerun replaces the same generated context files.
+    """
+
+    workspace = Path(workspace_dir).resolve()
+    wizard = SetupWizard(str(workspace))
+    normalized = _validated_answers(wizard, answers)
+    result: SetupResult = wizard.complete_setup(normalized)
+    brand_id = result.business_profile.get("brand_id", "default")
+
+    artifact_paths = {
+        "config": workspace / "config.yaml",
+        "business_profile": workspace / brand_id / "config" / "business_profile.json",
+        "workspace_state": workspace / brand_id / "workspace_state.json",
+    }
+    missing = [name for name, path in artifact_paths.items() if not path.is_file()]
+    if missing:
+        raise RuntimeError(f"Setup did not persist required artifacts: {', '.join(missing)}")
+
+    profile_readback = json.loads(
+        artifact_paths["business_profile"].read_text(encoding="utf-8")
+    )
+    state_readback = json.loads(
+        artifact_paths["workspace_state"].read_text(encoding="utf-8")
+    )
+    if profile_readback.get("brand_id") != brand_id:
+        raise RuntimeError("Business profile read-back did not match the setup brand")
+    if state_readback.get("brand_id") != brand_id:
+        raise RuntimeError("Workspace state read-back did not match the setup brand")
+
+    receipt = {
+        "schema_version": 1,
+        "status": "durable_context_written",
+        "brand_id": brand_id,
+        "workspace": str(workspace),
+        "created_at": _utc_now(),
+        "proof_boundary": (
+            "This receipt proves local durable-context write and read-back only; "
+            "connector, provider, and external-effect verification remain separate gates."
+        ),
+        "artifacts": {
+            name: {
+                "path": str(path),
+                "sha256": _sha256(path),
+                "bytes": path.stat().st_size,
+            }
+            for name, path in artifact_paths.items()
+        },
+    }
+    receipt_path = workspace / brand_id / "setup_receipt.json"
+    _write_json_atomic(receipt_path, receipt)
+
+    receipt_readback = json.loads(receipt_path.read_text(encoding="utf-8"))
+    if receipt_readback.get("brand_id") != brand_id:
+        raise RuntimeError("Setup receipt read-back did not match the setup brand")
+
+    return {
+        "result": result.model_dump(),
+        "receipt": receipt_readback,
+        "receipt_path": str(receipt_path),
+    }
+
+
+__all__ = ["AgencySetupError", "run_agency_setup"]

--- a/kai/runtime/company_autopilot.py
+++ b/kai/runtime/company_autopilot.py
@@ -1,0 +1,397 @@
+"""Proof-bound Company Autopilot command-center aggregation.
+
+This module is deliberately read-only.  It derives an operator view from the
+canonical workspace, runtime, action, connector-health, and goal stores without
+creating a second state model or treating onboarding checklists as evidence.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+from .actions import derive_operating_state
+from .goals import compute_goal_pace
+
+
+PROOF_PASS_VALUES = {
+    "accepted", "matched", "pass", "passed", "reconciled", "success", "succeeded", "verified",
+}
+UNHEALTHY_CONNECTOR_STATES = {
+    "degraded", "error", "failed", "disconnected", "expired", "revoked", "unhealthy",
+}
+EVIDENCE_DECISION_KEYS = {
+    "accepted", "matched", "passed", "reconciled", "success", "verified",
+}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_utc(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _positive_evidence(value: Any) -> bool:
+    """Require positive evidence when a value carries its own verdict."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(_positive_evidence(item) for item in value)
+    if not isinstance(value, dict) or not value:
+        return False
+
+    normalized = {str(key).lower(): item for key, item in value.items()}
+    if "status" in normalized:
+        return str(normalized["status"]).lower() in PROOF_PASS_VALUES
+    decisions = [normalized[key] for key in EVIDENCE_DECISION_KEYS if key in normalized]
+    if decisions:
+        return any(item is True or str(item).lower() in PROOF_PASS_VALUES for item in decisions)
+    return any(_positive_evidence(item) for item in normalized.values())
+
+
+def _truthy_evidence(payload: Any, keys: Iterable[str]) -> bool:
+    """Find explicit, non-empty evidence under one of *keys* recursively."""
+    wanted = {key.lower() for key in keys}
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            if str(key).lower() in wanted:
+                if _positive_evidence(value):
+                    return True
+            if _truthy_evidence(value, wanted):
+                return True
+    elif isinstance(payload, list):
+        return any(_truthy_evidence(item, wanted) for item in payload)
+    return False
+
+
+def has_strict_proof(action: Dict[str, Any]) -> bool:
+    """Return whether an executed action has the full acceptance evidence.
+
+    A successful connector response is not enough.  Strict proof requires an
+    accepted verification decision plus a provider receipt, an independent
+    read-back, and reconciliation evidence.
+    """
+    verification = action.get("verification_result")
+    if not isinstance(verification, dict):
+        return False
+    decision = str(
+        verification.get("status")
+        or verification.get("verdict")
+        or verification.get("decision")
+        or ""
+    ).lower()
+    accepted = (
+        decision in PROOF_PASS_VALUES
+        or verification.get("passed") is True
+        or verification.get("accepted") is True
+    )
+    if not accepted:
+        return False
+    proof_payload = {
+        "verification": verification,
+        "result": action.get("result_summary") or {},
+        "metadata": action.get("metadata") or {},
+    }
+    provider_receipt = _truthy_evidence(
+        proof_payload,
+        {"provider_receipt", "provider_receipt_id", "provider_response_receipt"},
+    )
+    independent_readback = _truthy_evidence(
+        proof_payload,
+        {"independent_readback", "independent_read_back", "readback", "read_back"},
+    )
+    reconciliation = _truthy_evidence(
+        proof_payload,
+        {"reconciliation", "reconciliation_evidence", "reconciled_at", "reconciled"},
+    )
+    return provider_receipt and independent_readback and reconciliation
+
+
+class CompanyAutopilotService:
+    """Build a deterministic command center from injected canonical stores."""
+
+    def __init__(
+        self,
+        *,
+        workspace_loader: Optional[Callable[[], Any]] = None,
+        runtime_store: Any = None,
+        action_store: Any = None,
+        connector_health: Any = None,
+        goal_registry: Any = None,
+        now: Optional[Callable[[], datetime]] = None,
+        stale_after_days: int = 7,
+    ) -> None:
+        if workspace_loader is None:
+            from .loader import load_workspace_profile
+            workspace_loader = load_workspace_profile
+        if runtime_store is None:
+            from .store import get_default_runtime_store
+            runtime_store = get_default_runtime_store()
+        if action_store is None:
+            from .actions import get_default_action_store
+            action_store = get_default_action_store()
+        if connector_health is None:
+            from .connector_health import ConnectorHealthDashboard
+            connector_health = ConnectorHealthDashboard()
+        if goal_registry is None:
+            from .goals import get_default_goal_registry
+            goal_registry = get_default_goal_registry()
+
+        self._workspace_loader = workspace_loader
+        self._runtime_store = runtime_store
+        self._action_store = action_store
+        self._connector_health = connector_health
+        self._goal_registry = goal_registry
+        self._now = now or _utc_now
+        self._stale_after = timedelta(days=stale_after_days)
+
+    def command_center(self, brand_id: Optional[str] = None) -> Dict[str, Any]:
+        """Return exactly one primary proof-bound bottleneck and its coach."""
+        rows = self._build_rows(brand_id=brand_id)
+        blocked = [row for row in rows if row["primary_bottleneck"] is not None]
+        primary = min(blocked, key=lambda row: (row["priority_rank"], row["brand_id"])) if blocked else None
+        bottleneck = primary["primary_bottleneck"] if primary else None
+        coach = self._coach(bottleneck)
+        return {
+            "generated_at": self._now().isoformat(),
+            "brand_scope": brand_id or "portfolio",
+            "primary_bottleneck": bottleneck,
+            "coach": coach,
+            "portfolio_count": len(rows),
+        }
+
+    def portfolio(self, brand_id: Optional[str] = None) -> Dict[str, Any]:
+        """Return one evidence-derived lifecycle row per configured brand."""
+        rows = self._build_rows(brand_id=brand_id)
+        for row in rows:
+            row.pop("priority_rank", None)
+        return {
+            "generated_at": self._now().isoformat(),
+            "rows": rows,
+            "count": len(rows),
+        }
+
+    def _build_rows(self, brand_id: Optional[str]) -> List[Dict[str, Any]]:
+        workspace = self._workspace_loader()
+        brands = list(getattr(workspace, "brands", []) or [])
+        if brand_id:
+            brands = [brand for brand in brands if getattr(brand, "id", None) == brand_id]
+        rows = [self._brand_row(brand) for brand in sorted(brands, key=lambda item: item.id)]
+        return rows
+
+    def _brand_row(self, brand: Any) -> Dict[str, Any]:
+        brand_id = brand.id
+        actions = self._action_store.list_actions(brand_id=brand_id, limit=10_000)
+        runs = self._runtime_store.list_runs(brand_id=brand_id, limit=10_000)
+        goals = [goal for goal in self._goal_registry.list_goals(brand_id=brand_id) if goal.status == "active"]
+        health = self._connector_health.brand_health(brand_id)
+        bottleneck, rank = self._select_bottleneck(brand, actions, runs, goals, health)
+
+        latest_action = self._latest(actions)
+        latest_run = self._latest(runs)
+        lifecycle = derive_operating_state(latest_action) if latest_action else (
+            latest_run.get("status", "not_started") if latest_run else "not_started"
+        )
+        row_health = "blocked" if bottleneck else "healthy"
+        if bottleneck and bottleneck["type"] in {"pending_approval", "behind_pace_goal", "stale_runtime"}:
+            row_health = "needs_attention"
+
+        return {
+            "brand_id": brand_id,
+            "brand_name": getattr(brand, "name", brand_id),
+            "lifecycle": lifecycle,
+            "health": row_health,
+            "blocked_gate": bottleneck["blocked_gate"] if bottleneck else None,
+            "owner": bottleneck["owner"] if bottleneck else self._owner(brand),
+            "next_action": bottleneck["next_action"] if bottleneck else "Monitor verified outcomes and goal pace.",
+            "close_condition": bottleneck["close_condition"] if bottleneck else "No proof-bound blocker is open.",
+            "evidence_refs": bottleneck["evidence_refs"] if bottleneck else self._baseline_refs(latest_run, latest_action),
+            "primary_bottleneck": bottleneck,
+            "priority_rank": rank,
+        }
+
+    def _select_bottleneck(
+        self,
+        brand: Any,
+        actions: List[Dict[str, Any]],
+        runs: List[Dict[str, Any]],
+        goals: List[Any],
+        health: Dict[str, Any],
+    ) -> tuple[Optional[Dict[str, Any]], int]:
+        failed = [a for a in actions if a.get("execution_state") in {"failed", "rolled_back"}]
+        if failed:
+            action = self._latest(failed)
+            return self._action_bottleneck(
+                brand, action, 1, "failed_action", "execution_failed",
+                "Diagnose the failed action and submit a corrected proposal.",
+                "A replacement action is approved, executed, and carries strict verification proof.",
+            ), 1
+
+        unverified = [
+            action for action in actions
+            if action.get("execution_state") == "completed" and not has_strict_proof(action)
+        ]
+        if unverified:
+            action = self._latest(unverified)
+            return self._action_bottleneck(
+                brand, action, 2, "unverified_execution", "strict_proof_missing",
+                "Collect provider receipt, independent read-back, and reconciliation evidence.",
+                "Verification is accepted and all three strict-proof evidence classes are attached.",
+            ), 2
+
+        unhealthy = self._unhealthy_integrations(health)
+        if unhealthy:
+            integration = sorted(unhealthy, key=lambda item: str(item.get("integration_id", "")))[0]
+            refs = [f"integration:{integration.get('integration_id') or integration.get('provider') or 'unknown'}"]
+            return self._bottleneck(
+                brand, 3, "connector_unhealthy", "connector_health",
+                "Restore the connector and verify scopes, freshness, and a successful read.",
+                "Connector is healthy, current, and independently readable with required scopes.", refs,
+                subject=integration.get("provider") or integration.get("channel"),
+            ), 3
+
+        approvals = [a for a in actions if a.get("approval_state") in {"held", "pending"}]
+        if approvals:
+            action = self._latest(approvals)
+            return self._action_bottleneck(
+                brand, action, 4, "pending_approval", "human_approval",
+                "Review the proposal evidence and approve, reject, or request revision.",
+                "A human records a decision and any approved execution remains proof-gated.",
+            ), 4
+
+        behind = []
+        for goal in goals:
+            pace = compute_goal_pace(goal, now=self._now())
+            if pace.get("behind_pace"):
+                behind.append((goal, pace))
+        if behind:
+            goal, pace = sorted(behind, key=lambda item: item[0].goal_id)[0]
+            refs = [f"goal:{goal.goal_id}"]
+            return self._bottleneck(
+                brand, 5, "behind_pace_goal", "goal_pace",
+                f"Replan work for {goal.name} from current measured KPI state.",
+                "Measured KPI pace is on target or the goal is achieved, with source-backed current value.", refs,
+                subject=goal.name,
+                extra={"pace": pace},
+            ), 5
+
+        latest_run = self._latest(runs)
+        latest_at = _as_utc((latest_run or {}).get("updated_at"))
+        if latest_run is None or latest_at is None or self._now() - latest_at > self._stale_after:
+            refs = [f"run:{latest_run['run_id']}"] if latest_run else []
+            return self._bottleneck(
+                brand, 6, "stale_runtime", "current_runtime_state",
+                "Run a current evidence-backed review for this brand.",
+                "A current run snapshot exists within the freshness window and records its sources.", refs,
+                subject=(latest_run or {}).get("run_id"),
+            ), 6
+        return None, 999
+
+    def _action_bottleneck(
+        self, brand: Any, action: Dict[str, Any], rank: int, kind: str, gate: str,
+        next_action: str, close_condition: str,
+    ) -> Dict[str, Any]:
+        refs = [f"action:{action.get('action_id', 'unknown')}"]
+        if action.get("source_run_id"):
+            refs.append(f"run:{action['source_run_id']}")
+        for evidence in action.get("evidence") or []:
+            if isinstance(evidence, str):
+                refs.append(evidence)
+            elif isinstance(evidence, dict):
+                ref = evidence.get("id") or evidence.get("source") or evidence.get("url")
+                if ref:
+                    refs.append(str(ref))
+        return self._bottleneck(
+            brand, rank, kind, gate, next_action, close_condition, refs,
+            subject=action.get("action_id"), owner=self._owner(brand, action),
+        )
+
+    def _bottleneck(
+        self, brand: Any, rank: int, kind: str, gate: str, next_action: str,
+        close_condition: str, evidence_refs: List[str], *, subject: Any = None,
+        owner: Optional[str] = None, extra: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        result = {
+            "priority_rank": rank,
+            "type": kind,
+            "brand_id": brand.id,
+            "subject": subject,
+            "blocked_gate": gate,
+            "owner": owner or self._owner(brand),
+            "next_action": next_action,
+            "close_condition": close_condition,
+            "evidence_refs": list(dict.fromkeys(evidence_refs)),
+        }
+        if extra:
+            result.update(extra)
+        return result
+
+    @staticmethod
+    def _unhealthy_integrations(health: Dict[str, Any]) -> List[Dict[str, Any]]:
+        unhealthy = []
+        for integration in health.get("integrations") or []:
+            state = str(integration.get("status") or "").lower()
+            if (
+                state in UNHEALTHY_CONNECTOR_STATES
+                or integration.get("stale_sync") is True
+                or integration.get("kill_switch") is True
+                or bool(integration.get("last_error"))
+            ):
+                unhealthy.append(integration)
+        return unhealthy
+
+    @staticmethod
+    def _latest(records: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+        if not records:
+            return None
+        return max(records, key=lambda item: item.get("updated_at") or item.get("created_at") or "")
+
+    @staticmethod
+    def _owner(brand: Any, action: Optional[Dict[str, Any]] = None) -> str:
+        metadata = (action or {}).get("metadata") or {}
+        brand_metadata = getattr(brand, "metadata", {}) or {}
+        return str(
+            metadata.get("owner")
+            or metadata.get("assigned_to")
+            or brand_metadata.get("owner")
+            or "unassigned"
+        )
+
+    @staticmethod
+    def _baseline_refs(
+        latest_run: Optional[Dict[str, Any]], latest_action: Optional[Dict[str, Any]],
+    ) -> List[str]:
+        refs = []
+        if latest_run:
+            refs.append(f"run:{latest_run.get('run_id')}")
+        if latest_action:
+            refs.append(f"action:{latest_action.get('action_id')}")
+        return refs
+
+    @staticmethod
+    def _coach(bottleneck: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        if bottleneck is None:
+            return {
+                "status": "monitor",
+                "message": "No proof-bound blocker is open. Monitor verified outcomes and goal pace.",
+                "next_action": "Monitor verified outcomes and goal pace.",
+                "close_condition": "No proof-bound blocker is open.",
+                "evidence_refs": [],
+            }
+        return {
+            "status": "action_required",
+            "message": bottleneck["next_action"],
+            "next_action": bottleneck["next_action"],
+            "close_condition": bottleneck["close_condition"],
+            "evidence_refs": bottleneck["evidence_refs"],
+        }

--- a/scripts/capability_manifest.py
+++ b/scripts/capability_manifest.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Generate and verify Kai's repository capability inventory.
+
+The filesystem and the /kai router tables are the sources of truth.  The
+checked-in JSON manifest and bounded documentation blocks are derived views.
+No wall-clock value is emitted, so identical trees produce identical output.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ARTIFACT_PATH = Path("docs/system/capability-manifest.json")
+ROUTER_PATH = Path("harness/skills/kai/SKILL.md")
+
+BLOCK_START = "<!-- capability-counts:start -->"
+BLOCK_END = "<!-- capability-counts:end -->"
+
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*(?:\n|\Z)", re.DOTALL)
+_ROUTER_ROW_RE = re.compile(
+    r"^\|\s*`/(?P<name>kai-[a-z0-9-]+)`\s*\|\s*(?P<description>.*?)\s*\|\s*$"
+)
+_HEADING_RE = re.compile(r"^##\s+(?P<name>[A-Z][A-Z ]+?)(?:\s+\(.*\))?\s*$")
+
+
+def _relative(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _frontmatter(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    values: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key.strip() in {"name", "description"}:
+            values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def parse_router_commands(router_path: Path) -> list[dict[str, str]]:
+    """Parse public commands only from categorized router table rows."""
+    commands: list[dict[str, str]] = []
+    seen: set[str] = set()
+    category: str | None = None
+    for line in router_path.read_text(encoding="utf-8").splitlines():
+        heading = _HEADING_RE.match(line)
+        if heading:
+            candidate = heading.group("name").strip().lower().replace(" ", "-")
+            category = candidate if candidate in {"produce", "audit", "plan", "analyze", "learn"} else None
+            continue
+        row = _ROUTER_ROW_RE.match(line)
+        if not row or category is None:
+            continue
+        name = row.group("name")
+        if name in seen:
+            continue
+        seen.add(name)
+        commands.append(
+            {
+                "name": name,
+                "category": category,
+                "description": row.group("description").strip(),
+            }
+        )
+    return commands
+
+
+def _markdown_count(path: Path, *, recursive: bool = False) -> int:
+    iterator = path.rglob("*.md") if recursive else path.glob("*.md")
+    return sum(1 for item in iterator if item.is_file() and item.name not in {"AGENTS.md", "CLAUDE.md"})
+
+
+def discover_inventory(root: Path = REPO_ROOT) -> dict[str, Any]:
+    """Return the deterministic capability manifest derived from ``root``."""
+    root = root.resolve()
+    skills_root = root / "harness" / "skills"
+    router_commands = parse_router_commands(root / ROUTER_PATH)
+    router_by_name = {command["name"]: command for command in router_commands}
+
+    skill_dirs = sorted(path for path in skills_root.iterdir() if path.is_dir())
+    canonical_dirs = sorted(
+        path for path in skill_dirs if path.name.startswith("kai-") and (path / "SKILL.md").is_file()
+    )
+    manifest_pages = {
+        path.stem: path
+        for path in (root / "docs" / "skill-manifest").glob("kai-*.md")
+        if path.is_file()
+    }
+
+    skills: list[dict[str, Any]] = []
+    for directory in canonical_dirs:
+        skill_path = directory / "SKILL.md"
+        metadata = _frontmatter(skill_path) if skill_path.exists() else {}
+        command = router_by_name.get(directory.name)
+        doc_path = manifest_pages.get(directory.name)
+        skills.append(
+            {
+                "name": directory.name,
+                "description": metadata.get("description", ""),
+                "source": _relative(skill_path, root),
+                "public_router_command": command is not None,
+                "router_category": command["category"] if command else None,
+                "manifest_doc": _relative(doc_path, root) if doc_path else None,
+            }
+        )
+
+    canonical_names = {skill["name"] for skill in skills}
+    unresolved_commands = sorted(set(router_by_name) - canonical_names)
+    undocumented_skills = sorted(canonical_names - set(manifest_pages))
+    orphan_manifest_pages = sorted(set(manifest_pages) - canonical_names)
+    named_personas = [
+        path
+        for path in (root / "knowledge" / "personas").glob("*.md")
+        if path.is_file() and not path.name.startswith("_") and path.name not in {"AGENTS.md", "CLAUDE.md"}
+    ]
+
+    counts = {
+        "skill_directories": len(skill_dirs),
+        "canonical_kai_skills": len(skills),
+        "public_router_commands": len(router_commands),
+        "public_manifest_pages": len(manifest_pages),
+        "undocumented_canonical_skills": len(undocumented_skills),
+        "playbook_docs": _markdown_count(root / "knowledge" / "playbooks"),
+        "checklists": _markdown_count(root / "knowledge" / "checklists"),
+        "framework_docs": _markdown_count(root / "knowledge" / "frameworks", recursive=True),
+        "channel_guides": _markdown_count(root / "knowledge" / "channels"),
+        "audience_persona_profiles": len(named_personas),
+        "harness_references": sum(1 for path in (root / "harness" / "references").iterdir() if path.is_file()),
+        "skill_contracts": sum(1 for path in (root / "harness" / "skill-contracts").glob("*.yaml") if path.is_file()),
+    }
+
+    return {
+        "schema_version": 1,
+        "sources": {
+            "skills": "harness/skills/*/SKILL.md",
+            "public_router_commands": ROUTER_PATH.as_posix(),
+            "public_manifest_pages": "docs/skill-manifest/kai-*.md",
+            "knowledge": "repository filesystem counts using counting_rules",
+        },
+        "counting_rules": {
+            "skill_directories": "Immediate directories under harness/skills.",
+            "canonical_kai_skills": "Immediate kai-* directories under harness/skills with their SKILL.md as source.",
+            "public_router_commands": "Unique /kai-* rows in the PRODUCE, AUDIT, PLAN, ANALYZE, and LEARN tables.",
+            "public_manifest_pages": "kai-*.md files under docs/skill-manifest.",
+            "knowledge_markdown": "Markdown files under the named surface; recursive only for frameworks; AGENTS.md and CLAUDE.md excluded.",
+            "audience_persona_profiles": "Non-underscore Markdown files under knowledge/personas; AGENTS.md and CLAUDE.md excluded.",
+            "harness_references": "Immediate files under harness/references.",
+            "skill_contracts": "Immediate *.yaml files under harness/skill-contracts.",
+        },
+        "counts": counts,
+        "coverage": {
+            "undocumented_canonical_skills": undocumented_skills,
+            "orphan_manifest_pages": orphan_manifest_pages,
+            "unresolved_router_commands": unresolved_commands,
+        },
+        "router_commands": router_commands,
+        "skills": skills,
+    }
+
+
+def render_json(manifest: dict[str, Any]) -> str:
+    return json.dumps(manifest, indent=2, ensure_ascii=False) + "\n"
+
+
+def render_markdown(manifest: dict[str, Any]) -> str:
+    counts = manifest["counts"]
+    rows = ["| Surface | Count |", "|---|---:|"]
+    labels = {
+        "skill_directories": "Skill directories",
+        "canonical_kai_skills": "Canonical `kai-*` skills",
+        "public_router_commands": "Public `/kai` router commands",
+        "public_manifest_pages": "Public skill manifest pages",
+        "undocumented_canonical_skills": "Canonical skills missing manifest pages",
+        "playbook_docs": "Playbook docs",
+        "checklists": "Checklists",
+        "framework_docs": "Framework docs",
+        "channel_guides": "Channel guides",
+        "audience_persona_profiles": "Audience persona profiles",
+        "harness_references": "Harness references",
+        "skill_contracts": "Skill contracts",
+    }
+    for key, label in labels.items():
+        rows.append(f"| {label} | {counts[key]} |")
+    return "\n".join(rows)
+
+
+def generated_doc_blocks(manifest: dict[str, Any]) -> dict[Path, str]:
+    counts = manifest["counts"]
+    agent_summary = (
+        f"Inventory reachable from here: {counts['skill_directories']} skill directories, "
+        f"{counts['canonical_kai_skills']} canonical `kai-*` skills, "
+        f"{counts['public_router_commands']} public `/kai` router commands, "
+        f"{counts['playbook_docs']} playbook docs, {counts['checklists']} checklists, "
+        f"{counts['framework_docs']} framework docs, {counts['channel_guides']} channel guides, "
+        f"{counts['audience_persona_profiles']} audience persona profiles, "
+        f"{counts['harness_references']} harness references, and {counts['skill_contracts']} skill contracts."
+    )
+    governance = (
+        "Generated from `docs/system/capability-manifest.json`. Regenerate with "
+        "`python -m scripts.capability_manifest generate`; verify with "
+        "`python -m scripts.capability_manifest check`.\n\n"
+        + render_markdown(manifest)
+    )
+    return {
+        Path("AGENTS.md"): f"{BLOCK_START}\n{agent_summary}\n{BLOCK_END}",
+        Path("docs/system/governance-and-quality.md"): f"{BLOCK_START}\n{governance}\n{BLOCK_END}",
+    }
+
+
+def _replace_block(text: str, replacement: str, path: Path) -> str:
+    pattern = re.compile(re.escape(BLOCK_START) + r".*?" + re.escape(BLOCK_END), re.DOTALL)
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        raise ValueError(f"{path.as_posix()}: expected exactly one generated capability-count block, found {len(matches)}")
+    return pattern.sub(replacement, text, count=1)
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(text, encoding="utf-8")
+    temporary.replace(path)
+
+
+def generate(root: Path = REPO_ROOT) -> dict[str, Any]:
+    manifest = discover_inventory(root)
+    _atomic_write(root / ARTIFACT_PATH, render_json(manifest))
+    for relative_path, block in generated_doc_blocks(manifest).items():
+        path = root / relative_path
+        updated = _replace_block(path.read_text(encoding="utf-8"), block, relative_path)
+        _atomic_write(path, updated)
+    return manifest
+
+
+def check_manifest(root: Path = REPO_ROOT) -> list[str]:
+    root = root.resolve()
+    expected = discover_inventory(root)
+    errors: list[str] = []
+    for name in expected["coverage"]["unresolved_router_commands"]:
+        errors.append(f"public router command has no canonical skill implementation: {name}")
+    for name in expected["coverage"]["orphan_manifest_pages"]:
+        errors.append(f"public manifest page has no canonical skill implementation: {name}")
+    artifact = root / ARTIFACT_PATH
+    if not artifact.exists():
+        errors.append(f"missing generated artifact: {ARTIFACT_PATH.as_posix()}")
+    elif artifact.read_text(encoding="utf-8") != render_json(expected):
+        try:
+            actual_manifest = json.loads(artifact.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            actual_manifest = {}
+        actual_counts = actual_manifest.get("counts", {})
+        for key, expected_value in expected["counts"].items():
+            actual_value = actual_counts.get(key)
+            if actual_value != expected_value:
+                errors.append(
+                    f"capability count drift: {key} is {actual_value!r} in the artifact, "
+                    f"but live discovery is {expected_value!r}"
+                )
+        actual_coverage = actual_manifest.get("coverage", {})
+        for key, expected_value in expected["coverage"].items():
+            actual_value = actual_coverage.get(key)
+            if actual_value != expected_value:
+                errors.append(
+                    f"capability coverage drift: {key} is {actual_value!r} in the artifact, "
+                    f"but live discovery is {expected_value!r}"
+                )
+        errors.append(
+            f"{ARTIFACT_PATH.as_posix()} is stale; run `python -m scripts.capability_manifest generate`"
+        )
+
+    for relative_path, block in generated_doc_blocks(expected).items():
+        path = root / relative_path
+        if not path.exists():
+            errors.append(f"missing generated-count document: {relative_path.as_posix()}")
+            continue
+        try:
+            actual = path.read_text(encoding="utf-8")
+            expected_text = _replace_block(actual, block, relative_path)
+        except ValueError as exc:
+            errors.append(str(exc))
+            continue
+        if actual != expected_text:
+            errors.append(
+                f"{relative_path.as_posix()} capability-count block is stale; "
+                "run `python -m scripts.capability_manifest generate`"
+            )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate or verify Kai's capability manifest")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("generate", help="Regenerate the JSON artifact and bounded documentation blocks")
+    subparsers.add_parser("check", help="Fail when the artifact or documentation blocks drift")
+    show = subparsers.add_parser("show", help="Print the live derived inventory without writing files")
+    show.add_argument("--format", choices=("json", "markdown"), default="json")
+    args = parser.parse_args(argv)
+
+    if args.command == "generate":
+        manifest = generate()
+        print(f"Generated {ARTIFACT_PATH.as_posix()} ({manifest['counts']['canonical_kai_skills']} canonical skills)")
+        return 0
+    if args.command == "check":
+        errors = check_manifest()
+        if errors:
+            for error in errors:
+                print(f"FAIL {error}", file=sys.stderr)
+            return 1
+        print("Capability manifest and generated documentation blocks are current.")
+        return 0
+
+    manifest = discover_inventory()
+    print(render_json(manifest) if args.format == "json" else render_markdown(manifest))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/doctor.py
+++ b/scripts/doctor.py
@@ -67,6 +67,7 @@ REQUIRED_PATHS = [
     "scripts/self_improvement/lesson_capture.py",
     "scripts/content/engine.py",
     "scripts/audit/collect.py",
+    "scripts/capability_manifest.py",
     "scripts/intel/brand_pulse.py",
     "memory/MEMORY.md",
     "memory/lessons.md",
@@ -74,6 +75,7 @@ REQUIRED_PATHS = [
     "memory/what-doesnt-work.md",
     "evals/golden/manifest.json",
     "docs/system/governance-and-quality.md",
+    "docs/system/capability-manifest.json",
     "docs/system/learning-loop.md",
     "docs/OPENCLAW_SETUP.md",
 ]
@@ -121,6 +123,7 @@ COMPILE_PATHS = [
     "scripts/quality_gates/golden_check.py",
     "scripts/self_improvement/lesson_capture.py",
     "scripts/intel/brand_pulse.py",
+    "scripts/capability_manifest.py",
     "scripts/doctor.py",
 ]
 
@@ -286,6 +289,26 @@ def check_golden_corpus(report: Report) -> None:
                 report.fail(f"golden case {r['id']}: {r['detail']}")
 
 
+def check_capability_manifest(report: Report) -> None:
+    """Fail when the generated inventory or its bounded doc blocks drift."""
+    try:
+        manifest_path = REPO_ROOT / "scripts" / "capability_manifest.py"
+        spec = importlib.util.spec_from_file_location("_doctor_capability_manifest", manifest_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"cannot load {manifest_path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        errors = module.check_manifest(REPO_ROOT)
+    except Exception as exc:
+        report.fail(f"capability manifest check crashed: {exc}")
+        return
+    if errors:
+        for error in errors:
+            report.fail(f"capability manifest: {error}")
+        return
+    report.ok("capability manifest and generated inventory docs current")
+
+
 def check_learning_layer(report: Report) -> None:
     learn_dir = REPO_ROOT / "data" / "learning"
     try:
@@ -337,6 +360,7 @@ def main() -> int:
     check_required_paths(report)
     check_instruction_chain(report)
     check_compiles(report)
+    check_capability_manifest(report)
     check_golden_corpus(report)
     if not args.ci:
         check_learning_layer(report)

--- a/scripts/harness_cli.py
+++ b/scripts/harness_cli.py
@@ -40,6 +40,7 @@ if str(_BOOTSTRAP_ROOT) not in sys.path:
     sys.path.insert(0, str(_BOOTSTRAP_ROOT))
 
 from scripts.harness_config import get_config
+from kai.packaging.agency_setup import AgencySetupError, run_agency_setup
 from scripts.content._writer import (
     FORMAT_INSTRUCTIONS as _WRITER_FORMAT_INSTRUCTIONS,
     FORMAT_TO_POLICY as _WRITER_FORMAT_TO_POLICY,
@@ -1066,6 +1067,43 @@ def cmd_dashboard(_args):
         print("  Dashboard not found.")
 
 
+def cmd_agency_setup(args):
+    """Create durable Company Autopilot context in one command."""
+
+    answers = {}
+    if args.answers:
+        answers_path = Path(args.answers).resolve()
+        answers = json.loads(answers_path.read_text(encoding="utf-8"))
+        if not isinstance(answers, dict):
+            raise ValueError("--answers must point to a JSON object")
+
+    direct_answers = {
+        "business_name": args.name,
+        "business_description": args.description,
+        "business_type": args.business_type,
+        "primary_service": args.primary_service,
+        "service_list": args.services,
+        "operator_email": args.owner_email,
+    }
+    answers.update({key: value for key, value in direct_answers.items() if value is not None})
+
+    try:
+        response = run_agency_setup(args.workspace, answers)
+    except AgencySetupError as exc:
+        raise SystemExit(f"Agency setup rejected: {exc}") from exc
+
+    if args.json:
+        print(json.dumps(response, indent=2, sort_keys=True))
+        return
+
+    receipt = response["receipt"]
+    header("Company Autopilot — Agency Setup")
+    print(f"  Agency:  {receipt['brand_id']}")
+    print(f"  Status:  {receipt['status']}")
+    print(f"  Receipt: {response['receipt_path']}")
+    print("\n  Durable context is ready. Provider verification remains a separate gate.")
+
+
 # ── CLI ────────────────────────────────────────────────────────────────────
 def main():
     p = argparse.ArgumentParser(prog="kai-harness", description="Kai Harness — Marketing Pipeline")
@@ -1153,6 +1191,30 @@ def main():
     # dashboard
     sub.add_parser("dashboard", help="Open marketing dashboard in browser")
 
+    # agency-setup
+    aset = sub.add_parser(
+        "agency-setup",
+        help="Create durable Company Autopilot agency context in one command",
+    )
+    aset.add_argument("--workspace", default=str(WORKSPACE), help="Target workspace directory")
+    aset.add_argument("--answers", help="JSON object containing all SetupWizard answers")
+    aset.add_argument("--name", help="Agency or business name")
+    aset.add_argument("--description", help="One-sentence agency description")
+    aset.add_argument(
+        "--business-type",
+        choices=[
+            "Local Service Business",
+            "Ecommerce/Online Store",
+            "Professional Services/B2B",
+            "Multi-Location Business",
+        ],
+        help="Business archetype",
+    )
+    aset.add_argument("--primary-service", help="Primary service or offer")
+    aset.add_argument("--services", help="Comma-separated service list")
+    aset.add_argument("--owner-email", help="Approval owner email")
+    aset.add_argument("--json", action="store_true", help="Print the full setup receipt as JSON")
+
     # goals
     gl = sub.add_parser("goals", help="Track brand goals / KPI targets (GoalRegistry)")
     glsub = gl.add_subparsers(dest="goals_command", required=True)
@@ -1195,6 +1257,7 @@ def main():
         "intel":          cmd_intel,
         "weekly-report":  cmd_weekly_report,
         "dashboard":      cmd_dashboard,
+        "agency-setup":   cmd_agency_setup,
         "goals":          cmd_goals,
     }[args.command](args)
 

--- a/tests/test_agency_setup.py
+++ b/tests/test_agency_setup.py
@@ -1,0 +1,54 @@
+"""Tests for the one-command durable agency setup."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from kai.packaging.agency_setup import AgencySetupError, run_agency_setup
+
+
+def _answers():
+    return {
+        "business_name": "Proofbound Agency",
+        "business_description": "An agency that operates client marketing systems.",
+        "business_type": "Professional Services/B2B",
+        "primary_service": "Marketing operations",
+        "service_list": "Marketing operations, Paid media",
+        "social_platforms": ["LinkedIn"],
+        "ad_platforms": ["Google Ads"],
+        "require_content_approval": True,
+        "auto_approve_low_risk": False,
+    }
+
+
+def test_run_agency_setup_writes_and_reads_back_durable_context(tmp_path):
+    response = run_agency_setup(tmp_path, _answers())
+
+    receipt = response["receipt"]
+    assert receipt["status"] == "durable_context_written"
+    assert receipt["brand_id"] == "proofbound-agency"
+    assert "external-effect verification" in receipt["proof_boundary"]
+
+    for artifact in receipt["artifacts"].values():
+        resolved = Path(artifact["path"])
+        assert resolved.is_file()
+        assert hashlib.sha256(resolved.read_bytes()).hexdigest() == artifact["sha256"]
+
+    receipt_path = Path(response["receipt_path"])
+    assert json.loads(receipt_path.read_text(encoding="utf-8"))["brand_id"] == "proofbound-agency"
+
+
+def test_run_agency_setup_rejects_missing_required_context(tmp_path):
+    with pytest.raises(AgencySetupError, match="business name"):
+        run_agency_setup(tmp_path, {"business_type": "Professional Services/B2B"})
+
+
+def test_run_agency_setup_rejects_invalid_select_values(tmp_path):
+    answers = _answers()
+    answers["business_type"] = "Space empire"
+    with pytest.raises(AgencySetupError, match="must be one of"):
+        run_agency_setup(tmp_path, answers)

--- a/tests/test_capability_manifest.py
+++ b/tests/test_capability_manifest.py
@@ -1,0 +1,127 @@
+import asyncio
+import json
+from pathlib import Path
+
+from scripts import capability_manifest as manifest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write(path: Path, text: str = "") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _minimal_tree(root: Path) -> None:
+    for relative in (
+        "harness/skills",
+        "harness/references",
+        "harness/skill-contracts",
+        "docs/skill-manifest",
+        "docs/system",
+        "knowledge/playbooks",
+        "knowledge/checklists",
+        "knowledge/frameworks",
+        "knowledge/channels",
+        "knowledge/personas",
+    ):
+        (root / relative).mkdir(parents=True, exist_ok=True)
+    _write(
+        root / "harness/skills/kai/SKILL.md",
+        "---\nname: kai\ndescription: Router\n---\n\n"
+        "Mention `/kai-not-public` outside a table.\n\n"
+        "## PRODUCE (make assets)\n\n"
+        "| Skill | What It Does |\n|---|---|\n"
+        "| `/kai-alpha` | Alpha workflow |\n"
+        "| `/kai-alpha` | Duplicate row ignored |\n",
+    )
+    _write(
+        root / "harness/skills/kai-alpha/SKILL.md",
+        "---\nname: kai-alpha\ndescription: Alpha skill\n---\n# Alpha\n",
+    )
+    _write(root / "docs/skill-manifest/kai-alpha.md", "# Alpha\n")
+    _write(root / "AGENTS.md", f"# Agents\n\n{manifest.BLOCK_START}\nstale\n{manifest.BLOCK_END}\n")
+    _write(
+        root / "docs/system/governance-and-quality.md",
+        f"# Governance\n\n{manifest.BLOCK_START}\nstale\n{manifest.BLOCK_END}\n",
+    )
+
+
+def test_current_inventory_is_derived_from_live_sources():
+    inventory = manifest.discover_inventory(REPO_ROOT)
+    assert inventory["counts"] == {
+        "skill_directories": 54,
+        "canonical_kai_skills": 52,
+        "public_router_commands": 47,
+        "public_manifest_pages": 45,
+        "undocumented_canonical_skills": 7,
+        "playbook_docs": 67,
+        "checklists": 37,
+        "framework_docs": 38,
+        "channel_guides": 31,
+        "audience_persona_profiles": 8,
+        "harness_references": 36,
+        "skill_contracts": 33,
+    }
+    assert inventory["coverage"]["unresolved_router_commands"] == []
+    assert inventory["coverage"]["orphan_manifest_pages"] == []
+
+
+def test_current_manifest_doc_gaps_are_explicit():
+    inventory = manifest.discover_inventory(REPO_ROOT)
+    assert inventory["coverage"]["undocumented_canonical_skills"] == [
+        "kai-brand-pulse",
+        "kai-content-batching",
+        "kai-funnel-audit",
+        "kai-hook-bench",
+        "kai-offer-builder",
+        "kai-proof-builder",
+        "kai-retro",
+    ]
+
+
+def test_router_parser_only_counts_unique_categorized_table_rows(tmp_path):
+    _minimal_tree(tmp_path)
+    commands = manifest.parse_router_commands(tmp_path / manifest.ROUTER_PATH)
+    assert commands == [
+        {"name": "kai-alpha", "category": "produce", "description": "Alpha workflow"}
+    ]
+
+
+def test_generated_manifest_is_deterministic_and_detects_added_skill(tmp_path):
+    _minimal_tree(tmp_path)
+    first = manifest.discover_inventory(tmp_path)
+    second = manifest.discover_inventory(tmp_path)
+    assert manifest.render_json(first) == manifest.render_json(second)
+
+    manifest.generate(tmp_path)
+    assert manifest.check_manifest(tmp_path) == []
+    artifact = json.loads((tmp_path / manifest.ARTIFACT_PATH).read_text(encoding="utf-8"))
+    assert artifact["counts"]["canonical_kai_skills"] == 1
+
+    _write(
+        tmp_path / "harness/skills/kai-beta/SKILL.md",
+        "---\nname: kai-beta\ndescription: Beta skill\n---\n# Beta\n",
+    )
+    errors = manifest.check_manifest(tmp_path)
+    assert any("capability-manifest.json is stale" in error for error in errors)
+    assert any("AGENTS.md capability-count block is stale" in error for error in errors)
+
+
+def test_checked_in_artifact_and_generated_blocks_are_current():
+    assert manifest.check_manifest(REPO_ROOT) == []
+
+
+def test_checked_in_artifact_matches_live_discovery_byte_for_byte():
+    expected = manifest.render_json(manifest.discover_inventory(REPO_ROOT))
+    actual = (REPO_ROOT / manifest.ARTIFACT_PATH).read_text(encoding="utf-8")
+    assert actual == expected
+
+
+def test_runtime_capability_endpoint_uses_live_generated_inventory():
+    from gateway.routers.runtime import list_capabilities
+
+    response = asyncio.run(list_capabilities())
+    assert response == manifest.discover_inventory(REPO_ROOT)
+    assert response["coverage"]["unresolved_router_commands"] == []

--- a/tests/test_company_autopilot.py
+++ b/tests/test_company_autopilot.py
@@ -1,0 +1,239 @@
+"""Focused tests for the proof-bound Company Autopilot aggregation."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from kai.runtime.company_autopilot import CompanyAutopilotService, has_strict_proof
+from kai.runtime.models import KaiGoal
+
+
+NOW = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
+
+
+class FakeActionStore:
+    def __init__(self, actions=None):
+        self.actions = list(actions or [])
+
+    def list_actions(self, *, brand_id=None, limit=50, **_filters):
+        rows = [row for row in self.actions if brand_id is None or row["brand_id"] == brand_id]
+        return rows[:limit]
+
+
+class FakeRuntimeStore:
+    def __init__(self, runs=None):
+        self.runs = list(runs or [])
+
+    def list_runs(self, *, brand_id=None, limit=50, **_filters):
+        rows = [row for row in self.runs if brand_id is None or row["brand_id"] == brand_id]
+        return rows[:limit]
+
+
+class FakeConnectorHealth:
+    def __init__(self, reports=None):
+        self.reports = reports or {}
+
+    def brand_health(self, brand_id):
+        return self.reports.get(brand_id, {"brand_id": brand_id, "integrations": []})
+
+
+class FakeGoalRegistry:
+    def __init__(self, goals=None):
+        self.goals = list(goals or [])
+
+    def list_goals(self, brand_id=None):
+        return [goal for goal in self.goals if brand_id is None or goal.brand_id == brand_id]
+
+
+def _brand(brand_id="acme", **metadata):
+    return SimpleNamespace(id=brand_id, name=brand_id.title(), metadata=metadata)
+
+
+def _run(brand_id="acme", age_days=0):
+    return {
+        "run_id": f"run-{brand_id}",
+        "brand_id": brand_id,
+        "status": "completed",
+        "updated_at": (NOW - timedelta(days=age_days)).isoformat(),
+    }
+
+
+def _action(
+    action_id,
+    *,
+    brand_id="acme",
+    approval="approved",
+    execution="completed",
+    verification=None,
+    result=None,
+    updated_offset=0,
+):
+    return {
+        "action_id": action_id,
+        "brand_id": brand_id,
+        "approval_state": approval,
+        "execution_state": execution,
+        "verification_result": verification,
+        "result_summary": result,
+        "metadata": {},
+        "evidence": [{"source": f"evidence:{action_id}"}],
+        "updated_at": (NOW + timedelta(minutes=updated_offset)).isoformat(),
+    }
+
+
+def _service(*, brands=None, actions=None, runs=None, health=None, goals=None):
+    workspace = SimpleNamespace(brands=brands or [_brand()])
+    return CompanyAutopilotService(
+        workspace_loader=lambda: workspace,
+        runtime_store=FakeRuntimeStore(runs if runs is not None else [_run()]),
+        action_store=FakeActionStore(actions),
+        connector_health=FakeConnectorHealth(health),
+        goal_registry=FakeGoalRegistry(goals),
+        now=lambda: NOW,
+    )
+
+
+def _strict_verification():
+    return {
+        "status": "accepted",
+        "provider_receipt": {"id": "receipt-1"},
+        "independent_readback": {"matched": True},
+        "reconciliation_evidence": {"status": "matched"},
+    }
+
+
+def test_strict_proof_requires_all_four_acceptance_elements():
+    action = _action("a1", verification={"status": "accepted"})
+    assert has_strict_proof(action) is False
+
+    action["verification_result"].update({
+        "provider_receipt_id": "receipt-1",
+        "independent_read_back": {"matched": True},
+        "reconciled": True,
+    })
+    assert has_strict_proof(action) is True
+
+
+def test_strict_proof_rejects_failed_readback_or_reconciliation_verdicts():
+    action = _action(
+        "a1",
+        verification={
+            "status": "accepted",
+            "provider_receipt": {"id": "receipt-1"},
+            "independent_readback": {"matched": False},
+            "reconciliation_evidence": {"status": "mismatch"},
+        },
+    )
+    assert has_strict_proof(action) is False
+
+
+def test_failed_action_wins_over_unverified_execution_and_approval():
+    actions = [
+        _action("pending", approval="pending", execution="pending"),
+        _action("unverified", updated_offset=1),
+        _action("failed", execution="failed", updated_offset=2),
+    ]
+    result = _service(actions=actions).command_center()
+
+    assert result["primary_bottleneck"]["type"] == "failed_action"
+    assert result["primary_bottleneck"]["subject"] == "failed"
+    assert result["coach"]["status"] == "action_required"
+
+
+def test_completed_connector_response_is_blocked_without_strict_proof():
+    action = _action(
+        "executed",
+        verification={"status": "accepted"},
+        result={"response": {"id": "provider-object"}},
+    )
+    row = _service(actions=[action]).portfolio()["rows"][0]
+
+    assert row["lifecycle"] == "verified"
+    assert row["blocked_gate"] == "strict_proof_missing"
+    assert row["primary_bottleneck"]["type"] == "unverified_execution"
+    assert "provider receipt" in row["next_action"].lower()
+
+
+def test_connector_health_precedes_pending_approval():
+    action = _action("pending", approval="pending", execution="pending")
+    health = {
+        "acme": {
+            "integrations": [{
+                "integration_id": "int-1",
+                "provider": "meta",
+                "status": "connected",
+                "stale_sync": True,
+            }]
+        }
+    }
+    result = _service(actions=[action], health=health).command_center()
+
+    assert result["primary_bottleneck"]["type"] == "connector_unhealthy"
+    assert result["primary_bottleneck"]["evidence_refs"] == ["integration:int-1"]
+
+
+def test_behind_pace_goal_uses_measured_goal_state_after_verified_action():
+    goal = KaiGoal(
+        goal_id="goal-1",
+        brand_id="acme",
+        name="Organic leads",
+        kpi_name="leads",
+        target_value=100,
+        current_value=5,
+        target_direction="increase",
+        status="active",
+        deadline=(NOW + timedelta(days=1)).isoformat(),
+        created_at=(NOW - timedelta(days=9)).isoformat(),
+        metadata={"baseline_value": 0},
+    )
+    action = _action("verified", verification=_strict_verification())
+    result = _service(actions=[action], goals=[goal]).command_center()
+
+    assert result["primary_bottleneck"]["type"] == "behind_pace_goal"
+    assert result["primary_bottleneck"]["evidence_refs"] == ["goal:goal-1"]
+
+
+def test_portfolio_returns_one_row_per_brand_and_one_global_primary():
+    brands = [_brand("beta"), _brand("acme")]
+    actions = [
+        _action("acme-pending", approval="pending", execution="pending"),
+        _action("beta-failed", brand_id="beta", execution="failed"),
+    ]
+    runs = [_run("acme"), _run("beta")]
+    service = _service(brands=brands, actions=actions, runs=runs)
+
+    portfolio = service.portfolio()
+    command_center = service.command_center()
+
+    assert [row["brand_id"] for row in portfolio["rows"]] == ["acme", "beta"]
+    assert all("priority_rank" not in row for row in portfolio["rows"])
+    assert command_center["primary_bottleneck"]["brand_id"] == "beta"
+    assert command_center["primary_bottleneck"]["type"] == "failed_action"
+
+
+def test_no_current_run_is_a_bottleneck_but_current_verified_state_is_clear():
+    verified = _action("verified", verification=_strict_verification())
+    no_run = _service(actions=[verified], runs=[]).command_center()
+    assert no_run["primary_bottleneck"]["type"] == "stale_runtime"
+
+    clear = _service(actions=[verified], runs=[_run()]).command_center()
+    assert clear["primary_bottleneck"] is None
+    assert clear["coach"]["status"] == "monitor"
+
+
+def test_mounted_router_handlers_delegate_without_changing_existing_router(monkeypatch):
+    from gateway.routers import actions as router
+
+    fake = SimpleNamespace(
+        command_center=lambda brand_id=None: {"surface": "command-center", "brand_id": brand_id},
+        portfolio=lambda brand_id=None: {"surface": "portfolio", "brand_id": brand_id},
+    )
+    monkeypatch.setattr(router, "_get_company_autopilot_service", lambda: fake)
+
+    command = asyncio.run(router.company_autopilot_command_center("acme"))
+    portfolio = asyncio.run(router.company_autopilot_portfolio("acme"))
+
+    assert command == {"surface": "command-center", "brand_id": "acme"}
+    assert portfolio == {"surface": "portfolio", "brand_id": "acme"}


### PR DESCRIPTION
## Outcome
Implements the five Company Autopilot ideas extracted from the SFA OS teardown:

- proof-bound Command Center that selects exactly one portfolio bottleneck
- one-command `agency-setup` with durable context and a read-back-bound receipt
- implementation coach derived from runtime/action/connector/goal state
- portfolio ledger with lifecycle, health, blocked gate, owner, next action, and close condition
- deterministic generated capability manifest, docs blocks, doctor/CI drift gate, and `/runtime/capabilities`

Also mounts the Command Center in the existing MeetKai dashboard with authenticated proxying and honest unavailable states.

## Proof
- `PYTHONUTF8=1 python -m pytest tests -q -k "not test_enqueue_raises_on_bad_path and not test_record_run_never_raises"` — 872 passed, 2 deselected
- `python -m pytest tests/test_company_autopilot.py tests/test_capability_manifest.py -q` — 16 passed
- `python -m scripts.capability_manifest check` — current
- `python scripts/doctor.py --ci` — fully configured
- `npm run lint` — clean
- `npm run build` — 56 pages compiled, including `/api/autopilot/command-center` and `/dashboard`
- dev smoke: `/` HTTP 200; protected dashboard/API redirect without auth

The two deselected tests assume `/proc/...` is unwritable and are invalid on Windows. A raw default-locale run also exposes pre-existing CP1252/UTF-8 failures; the UTF-8 run above clears those.