### PR TITLE
Tighten public lead intent filtering

### DIFF
--- a/scripts/reddit_monitor/profiles/kaicalls-digest.json
+++ b/scripts/reddit_monitor/profiles/kaicalls-digest.json
@@ -15,13 +15,13 @@
   "search_max_daily_cost_usd": 1.0,
   "search_cost_guard_per_query_usd": 0.02,
   "search_queries": [
-    "site:facebook.com/groups \"looking for an answering service\"",
-    "site:facebook.com/groups \"need a receptionist\" small business",
-    "site:facebook.com/groups \"missed calls\" (plumber OR HVAC OR electrician OR roofer)",
-    "site:facebook.com/groups \"can't answer the phone\" business",
-    "site:facebook.com/groups \"after hours calls\" small business",
-    "site:facebook.com/groups \"virtual receptionist\" recommendation",
-    "site:facebook.com/groups \"ai receptionist\" recommendation"
+    "site:facebook.com/groups \"I am looking for an answering service\"",
+    "site:facebook.com/groups \"I need a receptionist\" small business",
+    "site:facebook.com/groups \"we keep missing calls\" (plumber OR HVAC OR electrician OR roofer)",
+    "site:facebook.com/groups \"I can't answer the phone\" business",
+    "site:facebook.com/groups \"need help with after hours calls\" small business",
+    "site:facebook.com/groups \"anyone recommend a virtual receptionist\"",
+    "site:facebook.com/groups \"anyone using an AI receptionist\""
   ],
   "search_verticals": [
     "plumbing business owners",
@@ -36,10 +36,10 @@
     "cleaning business owners"
   ],
   "search_query_templates": [
-    "site:facebook.com/groups \"{vertical}\" \"looking for an answering service\"",
-    "site:facebook.com/groups \"{vertical}\" (\"missed calls\" OR \"can't answer the phone\")",
-    "site:facebook.com/groups \"{vertical}\" (\"after hours calls\" OR \"virtual receptionist\")",
-    "\"{vertical}\" (\"answering service recommendation\" OR \"what do you use for missed calls\")"
+    "site:facebook.com/groups \"{vertical}\" (\"I need an answering service\" OR \"I am looking for an answering service\")",
+    "site:facebook.com/groups \"{vertical}\" (\"we keep missing calls\" OR \"I can't answer the phone\")",
+    "site:facebook.com/groups \"{vertical}\" \"anyone recommend\" (\"answering service\" OR \"virtual receptionist\")",
+    "\"{vertical}\" (\"what do you use for missed calls\" OR \"recommend an answering service\")"
   ],
   "subreddits": [
     "AIReceptionists",

--- a/scripts/reddit_monitor/profiles/kaicalls-digest.prompt.md
+++ b/scripts/reddit_monitor/profiles/kaicalls-digest.prompt.md
@@ -31,6 +31,7 @@ Content: {content}
 - If answering well would require faking experience Connor doesn't have (legal advice, plumbing/HVAC/electrical diagnosis, being a realtor) — score **≤ 20**.
 - If it's a generic gear/lifestyle/community post in a vertical sub (e.g. "show me your everyday-carry") — score **≤ 15**.
 - If the post is someone advertising, launching, or showing off their OWN AI receptionist / voice-agent product (a promo or "check out what I built", not a genuine question or pain point) — score **≤ 25**. Commenting on a competitor's launch is not an opportunity.
+- If the post asks a generic market-research question such as "do missed calls cost businesses money?" without a first-person problem or recommendation request — score **≤ 25**. These are usually vendor content, not buyers.
 - If the post is about finding a job, hiring a receptionist, stacking jobs, or offering receptionist/answering-service services — score **≤ 20**. The lane is for buyers asking for a solution.
 - The angle must answer this post. For answering-service recommendations or missed-call pain, use Connor's measured inbound-call experience. Never use his Meta-ad or directory-acquisition story there.
 - Be a harsh grader. Connor wants ~10 genuinely good threads a day, not 100 mediocre ones. When unsure between two tiers, pick the LOWER one.

--- a/scripts/reddit_monitor/reddit_digest.py
+++ b/scripts/reddit_monitor/reddit_digest.py
@@ -113,6 +113,55 @@ def matched_triggers(text: str, keywords: list[str]) -> list[str]:
     return [kw for kw in keywords if kw.lower() in lower]
 
 
+_SEARCH_BUYER_INTENT = (
+    "i need ",
+    "i'm looking",
+    "i am looking",
+    "we need ",
+    "we're looking",
+    "we are looking",
+    "we keep ",
+    "we're missing",
+    "we are missing",
+    "i can't answer",
+    "i cannot answer",
+    "anyone recommend",
+    "can anyone recommend",
+    "does anybody know",
+    "what do you use",
+    "who do you use",
+    "anyone have a virtual",
+    "anyone using",
+    "need help with",
+    "looking for a",
+)
+_SEARCH_PROMO_SIGNALS = (
+    "i built ",
+    "we built ",
+    "i launched ",
+    "we launched ",
+    "we help ",
+    "our ai ",
+    "our service ",
+    "free ai ",
+    "book a demo",
+    "dm me",
+    "message me",
+    "we offer ",
+    "i offer ",
+    "check out ",
+    "try my ",
+)
+
+
+def search_result_has_buyer_intent(post: dict) -> bool:
+    """Keep search results with an explicit buyer ask, not generic SEO/promo."""
+    text = f"{post.get('title', '')} {post.get('content', '')}".lower()
+    if any(signal in text for signal in _SEARCH_PROMO_SIGNALS):
+        return False
+    return any(signal in text for signal in _SEARCH_BUYER_INTENT)
+
+
 def fetch_subreddit(subreddit: str, limit: int) -> list[dict]:
     url = f"https://www.reddit.com/r/{subreddit}/new.rss"
     try:
@@ -290,7 +339,7 @@ def collect_candidates(profile: dict, seen_path: Path) -> list[dict]:
             new_seen.append(post["id"])
             text = f"{post['title']} {post['content']}"
             matches = matched_triggers(text, profile["trigger_keywords"])
-            if matches:
+            if matches and search_result_has_buyer_intent(post):
                 post["matched_keywords"] = matches
                 candidates.append(post)
 

--- a/scripts/reddit_monitor/test_reddit_digest.py
+++ b/scripts/reddit_monitor/test_reddit_digest.py
@@ -183,6 +183,24 @@ def test_expanded_search_queries_dedupes_and_expands_verticals():
     assert queries == ["fixed", "HVAC missed calls"]
 
 
+def test_search_result_has_buyer_intent_requires_explicit_ask():
+    assert digest.search_result_has_buyer_intent({
+        "title": "Anyone recommend a virtual receptionist?",
+        "content": "We keep missing calls while our HVAC techs are out.",
+    })
+    assert not digest.search_result_has_buyer_intent({
+        "title": "Do missed calls cost HVAC businesses money?",
+        "content": "A generic market-research question.",
+    })
+
+
+def test_search_result_has_buyer_intent_rejects_self_promotion():
+    assert not digest.search_result_has_buyer_intent({
+        "title": "I need an answering service",
+        "content": "I built one. DM me to book a demo.",
+    })
+
+
 def test_render_html_supports_legacy_reddit_rows():
     html = digest.render_html(
         {"page_title": "Opportunities"},


### PR DESCRIPTION
## Outcome
- requires explicit first-person buyer intent before a paid-search result reaches the scorer
- rejects deterministic self-promotion signals
- rewrites all 47 searches around direct asks and recommendations rather than generic missed-call topics

## Proof
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest scripts/reddit_monitor/test_reddit_digest.py -q - 9 passed
