### PR TITLE
Reject receptionist offer false positives

### DIFF
--- a/scripts/reddit_monitor/reddit_digest.py
+++ b/scripts/reddit_monitor/reddit_digest.py
@@ -120,7 +120,8 @@ _SEARCH_BUYER_INTENT = (
     "we need ",
     "we're looking",
     "we are looking",
-    "we keep ",
+    "we keep missing",
+    "we keep getting missed",
     "we're missing",
     "we are missing",
     "i can't answer",
@@ -151,6 +152,11 @@ _SEARCH_PROMO_SIGNALS = (
     "i offer ",
     "check out ",
     "try my ",
+    "receptionist available",
+    "services available",
+    "affordable ",
+    "we can help",
+    "helping businesses",
 )
 
 

--- a/scripts/reddit_monitor/test_reddit_digest.py
+++ b/scripts/reddit_monitor/test_reddit_digest.py
@@ -201,6 +201,13 @@ def test_search_result_has_buyer_intent_rejects_self_promotion():
     })
 
 
+def test_search_result_has_buyer_intent_rejects_receptionist_offer():
+    assert not digest.search_result_has_buyer_intent({
+        "title": "Receptionist available for Cheyenne businesses",
+        "content": "We can help if you keep missing calls after hours.",
+    })
+
+
 def test_render_html_supports_legacy_reddit_rows():
     html = digest.render_html(
         {"page_title": "Opportunities"},


### PR DESCRIPTION
The first explicit-intent canary exposed a receptionist-offer result whose snippet reused the query language. This narrows the buyer phrase and rejects receptionist/service availability and related offer signals.

Proof: 10 focused collector tests pass.
