### PR TITLE
Fix stale count in the ECO marketing floors reference

### DIFF
--- a/harness/references/eco-marketing-floors.md
+++ b/harness/references/eco-marketing-floors.md
@@ -45,7 +45,7 @@ Full definitions in `harness/eco-floors.yaml`. Summary:
 | Internal research | E2 / C2 / O0 | File exists and matches structure | none |
 | Harness change | E3 / C3 / O1 | Tests + doctor + golden corpus pass | 30d |
 
-Two floors deserve their reasoning stated:
+Three floors deserve their reasoning stated:
 
 - **Cold email is C4, not C3.** The residue is legal, not editorial. Sender identity, opt-out mechanics, and consent basis are field-standard obligations under CAN-SPAM/GDPR/CASL. A good reviewer who is not checking those is not clearing C4.
 - **Product UI is C4, not C3.** The residue is accessibility and design-system integrity — WCAG AA contrast, focus order, token compliance, and every loading/empty/error state. A reviewer who likes how it looks but has not checked those has not cleared C4.


### PR DESCRIPTION
One-word correctness fix in `harness/references/eco-marketing-floors.md`.

When I added the `product-ui` work type in #61, I inserted a third reasoning bullet under a line that reads "Two floors deserve their reasoning stated" — leaving the count wrong. There are three: cold email (C4), product UI (C4), and audits (E3).

Caught on a post-merge scan of the numeric claims in the docs I wrote in #61. The other count claims in those files check out: "the three failures" has three, and "two standing prohibitions" in the long-horizon contract has two.

`doctor --ci` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqKvc3hkf8ZDt4L58izxkT

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqKvc3hkf8ZDt4L58izxkT)_