### PR TITLE
readme: put the hosted product above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Use it when you want an AI operator to create growth plans, landing pages, email
 
 > Built by [Connor Gallic](https://pr.linkedin.com/in/cgallic) — follow on LinkedIn for more agentic marketing systems.
 
+**Don't want to run it yourself?** [Meet Kai](https://meetkai.xyz) is the hosted version of this system. Same skills, same approval gates, but it starts from your business brief and brings you the next move instead of waiting for a prompt. [Start with an audit](https://meetkai.xyz) if you'd rather see the gaps than go find them.
+
 ## Try Kai In 60 Seconds — No API Key
 
 Inside Claude Code:


### PR DESCRIPTION
The only above-the-fold CTA was a LinkedIn follow. `meetkai.xyz` sat on line **458 of 486** — 94% scroll depth, in a link list.

Measured on this repo over 14 days:

| metric | value |
|---|---|
| stars | 40 |
| forks | 5 |
| unique visitors | 172 |
| top external referrer | t.co (27 uniques) |
| Google | 12 uniques |

This is the highest-traffic surface in the stack, and it was sending that attention to a social profile instead of the hosted product it feeds.

**Change:** two sentences after the byline — what Meet Kai is relative to the harness (hosted, same skills, same approval gates, starts from a business brief rather than a prompt), plus the audit entry point. Existing line 458 reference left alone.

No change to install instructions, licensing, or any code path. Merge or close — it's one paragraph.

---

*Correction to the original version of this description: it cited "531 unique cloners in 14 days." That figure does not represent adoption — the daily clone series jumps from 65 on 07-25 to 564 on 07-27 and holds at 700–820/day against 27–56 unique visitors/day, which is a mirror or scraper, not installs. Removed rather than left standing.*