### PR TITLE
Add BulkPublish social publishing handoff skill

### DIFF
--- a/harness/skills/kai-bulkpublish/SKILL.md
+++ b/harness/skills/kai-bulkpublish/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: kai-bulkpublish
+description: Prepare an approved social content queue for BulkPublish scheduling or publication. Use when "schedule social posts", "publish the calendar", "send posts to BulkPublish", or "hand off approved social content".
+---
+
+# BulkPublish Handoff
+
+Use this skill after `/kai-social`, `/kai-repurpose`, or another content workflow has produced a reviewed calendar. This skill prepares the handoff; it does not bypass approval or silently publish.
+
+## Inputs
+
+- Approved social post calendar with platform, content, media, and links
+- BulkPublish channel IDs or names
+- Desired schedule and IANA timezone
+- Approval status and the person authorized to publish
+
+## Workflow
+
+1. Confirm every post has an explicit approval state and remove anything still in draft or rejected status.
+2. Validate each platform’s character, link, media, and format requirements.
+3. Resolve channel IDs with BulkPublish `list_channels`; never infer IDs from names alone.
+4. Create drafts or approval-gated scheduled posts through the BulkPublish API or MCP server.
+5. Before any external publish action, show the final post count, channels, media, and schedule and obtain immediate authorization.
+6. Record returned post IDs, status, schedule time, and any per-platform failures in the campaign record.
+7. After publication, use BulkPublish analytics to compare outcomes with the campaign objective without promising reach, engagement, or revenue.
+
+## Safety gates
+
+- Treat scheduling and publishing as external side effects.
+- Never expose API keys, cookies, or private analytics in content or logs.
+- Stop if the audience, account, channel, media, or schedule is ambiguous.
+- Do not claim guaranteed engagement, virality, conversions, or revenue.
+
+## References
+
+- BulkPublish API: https://github.com/azeemkafridi/bulkpublish-api
+- MCP documentation: https://app.bulkpublish.com/docs
+- Social-media skills: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills

--- a/harness/skills/kai/SKILL.md
+++ b/harness/skills/kai/SKILL.md
@@ -62,6 +62,7 @@ Doctrine: `docs/system/eco-completion-standard.md` · Marketing floors: `harness
 | `/kai-ad-campaign` | Full paid campaign across platforms + funnel stages |
 | `/kai-content-calendar` | Month/quarter of blog + SEO content |
 | `/kai-social` | Batch social posts across IG, X, TikTok, LinkedIn, YouTube |
+| `/kai-bulkpublish` | Approval-gated handoff of social content to BulkPublish |
 | `/kai-video` | Video scripts + clipping plans for short/long-form |
 | `/kai-cold-outreach` | Cold email outreach sequences |
 | `/kai-sdr-operator` | SDR operator package for lead sources, scoring, outreach handoff, and reply triage |


### PR DESCRIPTION
Adds `/kai-bulkpublish`, an approval-gated handoff skill for sending reviewed social content calendars to BulkPublish for scheduling or publication. It includes channel resolution, validation, external-side-effect safeguards, and links to the BulkPublish API, MCP docs, and social-media skills.\n\nValidation: `python3 scripts/quality_gates/golden_check.py` passed (4/4). The local clone does not have pytest installed; the existing CI workflow will run the full test suite.\n\nDisclosure: I am affiliated with BulkPublish and am submitting this integration for consideration.